### PR TITLE
Fix incorrect program description comment

### DIFF
--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -1,6 +1,6 @@
 package main
 
-// A simple program that counts down from 5 and then exits.
+// A simple program that makes a GET request and prints the response status.
 
 import (
 	"errors"


### PR DESCRIPTION
Hi. I'd noticed that the `/examples/http/main.go` program has an incorrect program description comment. It's using the same description comment as the `/examples/simple/main.go` program. This PR fixes it.