### PR TITLE
Fixed build tags

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,4 +1,4 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+// +build !windows
 
 package tea
 


### PR DESCRIPTION
Cause, you know, windows is **only one** non-unix operating system, and js literally can't use any ansi colors at all :)