### PR TITLE
Manual hide cursor command + subtle cursor hide/show engineering improvements

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -7,6 +7,14 @@ import (
 	te "github.com/muesli/termenv"
 )
 
+func hideCursor(w io.Writer) {
+	fmt.Fprintf(w, te.CSI+te.HideCursorSeq)
+}
+
+func showCursor(w io.Writer) {
+	fmt.Fprintf(w, te.CSI+te.ShowCursorSeq)
+}
+
 func clearLine(w io.Writer) {
 	fmt.Fprintf(w, te.CSI+te.EraseLineSeq, 2)
 }

--- a/tea.go
+++ b/tea.go
@@ -93,6 +93,18 @@ type WindowSizeMsg struct {
 	Height int
 }
 
+// HideCursor is a special command for manually instructing Bubble Tea to hide
+// the cursor. In some rare cases, certain operations will cause the terminal
+// to show the cursor, which is normally hidden for the duration of a Bubble
+// Tea program's lifetime. You most likely will not need to use this command.
+func HideCursor() Msg {
+	return hideCursorMsg{}
+}
+
+// hideCursorMsg is an internal command used to hide the cursor. You can send
+// this message with HideCursor.
+type hideCursorMsg struct{}
+
 // NewProgram creates a new Program.
 func NewProgram(model Model) *Program {
 	return &Program{
@@ -193,11 +205,14 @@ func (p *Program) Start() error {
 			return err
 		case msg := <-msgs:
 
-			// Handle quit message
-			if _, ok := msg.(quitMsg); ok {
+			// Handle special messages
+			switch msg.(type) {
+			case quitMsg:
 				p.renderer.stop()
 				close(done)
 				return nil
+			case hideCursorMsg:
+				hideCursor(p.output)
 			}
 
 			// Process batch commands

--- a/tea.go
+++ b/tea.go
@@ -124,11 +124,11 @@ func (p *Program) Start() error {
 
 	p.renderer = newRenderer(p.output, &p.mtx)
 
-	err := initTerminal()
+	err := initTerminal(p.output)
 	if err != nil {
 		return err
 	}
-	defer restoreTerminal()
+	defer restoreTerminal(p.output)
 
 	// Initialize program
 	model := p.initialModel

--- a/tty.go
+++ b/tty.go
@@ -1,13 +1,14 @@
 package tea
 
 import (
+	"io"
+
 	"github.com/containerd/console"
-	"github.com/muesli/termenv"
 )
 
 var tty console.Console
 
-func initTerminal() error {
+func initTerminal(w io.Writer) error {
 	tty = console.Current()
 	err := tty.SetRaw()
 	if err != nil {
@@ -15,11 +16,11 @@ func initTerminal() error {
 	}
 
 	enableAnsiColors()
-	termenv.HideCursor()
+	hideCursor(w)
 	return nil
 }
 
-func restoreTerminal() error {
-	termenv.ShowCursor()
+func restoreTerminal(w io.Writer) error {
+	showCursor(w)
 	return tty.Reset()
 }


### PR DESCRIPTION
In some rare cases a user may want to hide the cursor. This PR addresses that.

In particular, this is being added to address charmbracelet/glow#214.