### PR TITLE
allow custom input/output and handle eof for os.input properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/containerd/console v1.0.1
+	github.com/mattn/go-isatty v0.0.12
 	github.com/muesli/termenv v0.7.2
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634


### PR DESCRIPTION
This PR allows the user to set a custom input and output. In addition it handles the case where the input returns an io.EOF error. There are cases eg. piping where os.Stdin may be empty when bubbletea starts.

An alternative  (or even additional) implementation would be to allow rendering without reading from the input at all. 

Signed-off-by: Christoph Hartmann <chris@lollyrock.com>