### PR TITLE
Automatically trim lines wider than the window width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/containerd/console v1.0.1
 	github.com/mattn/go-isatty v0.0.12
+	github.com/muesli/reflow v0.2.1-0.20201126184510-3bcb929042f2
 	github.com/muesli/termenv v0.7.2
 	golang.org/x/crypto v0.0.0-20201012173705-84dcc777aaee
 	golang.org/x/sys v0.0.0-20201009025420-dfb3f7c4e634

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/muesli/reflow v0.2.1-0.20201126184510-3bcb929042f2 h1:+cpkcmASpeBn4qXz2tU+x+njyKe91NoHXqrJdhoDnZo=
+github.com/muesli/reflow v0.2.1-0.20201126184510-3bcb929042f2/go.mod h1:qT22vjVmM9MIUeLgsVYe/Ye7eZlbv9dZjL3dVhUqLX8=
 github.com/muesli/termenv v0.7.2 h1:r1raklL3uKE7rOvWgSenmEm2px+dnc33OTisZ8YR1fw=
 github.com/muesli/termenv v0.7.2/go.mod h1:ct2L5N2lmix82RaY3bMWwVu/jUFc9Ule0KGDCiKYPh8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/renderer.go
+++ b/renderer.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/muesli/reflow/truncate"
 )
 
 const (
@@ -148,7 +150,20 @@ func (r *renderer) flush() {
 		if _, exists := r.ignoreLines[r.linesRendered]; exists {
 			cursorDown(out) // skip rendering for this line.
 		} else {
-			_, _ = io.WriteString(out, lines[i])
+			line := lines[i]
+
+			// Truncate lines wider than the width of the window to avoid
+			// rendering troubles. If we don't have the width of the window
+			// this will be ignored.
+			//
+			// Note that on Windows we can't get the width of the window
+			// (signal SIGWINCH is not supported), so this will be ignored.
+			if r.width > 0 {
+				line = truncate.String(line, uint(r.width))
+			}
+
+			_, _ = io.WriteString(out, line)
+
 			if i != len(lines)-1 {
 				_, _ = io.WriteString(out, "\r\n")
 			}


### PR DESCRIPTION
This will prevent rendering issues that could occur when the terminal automatically wraps long lines.

Do note that for more precise control you can truncate long lines yourself. We recommend the [`truncate`](https://pkg.go.dev/github.com/muesli/reflow/truncate) package in [Reflow](https://github.com/muesli/reflow), which Bubble Tea is using internally.