### PR TITLE
Add space after prefix if one doesn't exist

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -3,6 +3,7 @@ package tea
 import (
 	"log"
 	"os"
+	"unicode"
 )
 
 // LogToFile sets up default logging to log to a file. This is helpful as we
@@ -23,6 +24,16 @@ func LogToFile(path string, prefix string) (*os.File, error) {
 		return nil, err
 	}
 	log.SetOutput(f)
+
+	// Add a space after the prefix if a prefix is being specified and it
+	// doesn't already have a trailing space.
+	if len(prefix) > 0 {
+		finalChar := prefix[len(prefix)-1]
+		if unicode.IsSpace(rune(finalChar)) {
+			prefix += " "
+		}
+	}
 	log.SetPrefix(prefix)
+
 	return f, nil
 }


### PR DESCRIPTION
Right now the logs read `prefix2021/02/01…`. This PR adds a space if one doesn't exist at the end of the prefix, so logs will now read `prefix 2021/02/01…`.