### PR TITLE
Avoid race on renderer.buf in flush vs. write

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -88,6 +88,9 @@ func (r *renderer) listen() {
 
 // flush renders the buffer.
 func (r *renderer) flush() {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
 	if r.buf.Len() == 0 || r.buf.String() == r.lastRender {
 		// Nothing to do
 		return
@@ -111,9 +114,6 @@ func (r *renderer) flush() {
 	// the place to do that.
 
 	out := new(bytes.Buffer)
-
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
 
 	// Clear any lines we painted in the last render.
 	if r.linesRendered > 0 {


### PR DESCRIPTION
Fix race by acquiring the mutex before accessing renderer.buf in flush.

	WARNING: DATA RACE
	Read at 0x00c0000ee0a0 by goroutine 11:
	  bytes.(*Buffer).Len()
	      /home/chlunde/opt/go/src/bytes/buffer.go:73 +0x64
	  github.com/charmbracelet/bubbletea.(*renderer).flush()
	      /home/chlunde/src/bubbletea/renderer.go:91 +0x45
	  github.com/charmbracelet/bubbletea.(*renderer).listen()
	      /home/chlunde/src/bubbletea/renderer.go:76 +0x185

	Previous write at 0x00c0000ee0a0 by main goroutine:
	  bytes.(*Buffer).Reset()
	      /home/chlunde/opt/go/src/bytes/buffer.go:98 +0xf5
	  github.com/charmbracelet/bubbletea.(*renderer).write()
	      /home/chlunde/src/bubbletea/renderer.go:195 +0x13c
	  github.com/charmbracelet/bubbletea.(*Program).Start()
	      /home/chlunde/src/bubbletea/tea.go:330 +0xbbb
	  main.main()
	      /home/chlunde/src/bubbletea/examples/spinner/main.go:27 +0x229

Fixes #54