### PR TITLE
Automatically open a TTY if needed

### DIFF
--- a/examples/pipe/main.go
+++ b/examples/pipe/main.go
@@ -1,0 +1,94 @@
+package main
+
+// An example of how to pipe in data to a Bubble Tea application. It's actually
+// more of a proof that Bubble Tea will automatically listen for keystrokes
+// when input is not a TTY, such as when data is piped or redirected in.
+//
+// In the case of this example we're listing for a single keystroke used to
+// exit the program.
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func main() {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		panic(err)
+	}
+
+	if stat.Mode()&os.ModeNamedPipe == 0 && stat.Size() == 0 {
+		fmt.Println("Try piping in some text.")
+		os.Exit(1)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	var b strings.Builder
+
+	for {
+		r, _, err := reader.ReadRune()
+		if err != nil && err == io.EOF {
+			break
+		}
+		_, err = b.WriteRune(r)
+		if err != nil {
+			fmt.Println("Error getting input:", err)
+			os.Exit(1)
+		}
+	}
+
+	model := newModel(strings.TrimSpace(b.String()))
+
+	if err := tea.NewProgram(model).Start(); err != nil {
+		fmt.Println("Couldn't start program:", err)
+		os.Exit(1)
+	}
+}
+
+type model struct {
+	userInput textinput.Model
+}
+
+func newModel(initialValue string) (m model) {
+	i := textinput.NewModel()
+	i.Prompt = ""
+	i.CursorColor = "63"
+	i.Width = 48
+	i.SetValue(initialValue)
+	i.CursorEnd()
+	i.Focus()
+
+	m.userInput = i
+	return
+}
+
+func (m model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyMsg); ok {
+		switch key.Type {
+		case tea.KeyCtrlC, tea.KeyEscape, tea.KeyEnter:
+			return m, tea.Quit
+		}
+	}
+
+	var cmd tea.Cmd
+	m.userInput, cmd = m.userInput.Update(msg)
+	return m, cmd
+}
+
+func (m model) View() string {
+	return fmt.Sprintf(
+		"\nYou piped in: %s\n\nPress ^C to exit",
+		m.userInput.View(),
+	)
+}

--- a/tea.go
+++ b/tea.go
@@ -100,7 +100,7 @@ func WithoutCatchPanics() ProgramOption {
 type Program struct {
 	initialModel Model
 
-	mtx sync.Mutex
+	mtx *sync.Mutex
 
 	output          io.Writer // where to send output. this will usually be os.Stdout.
 	input           io.Reader // this will usually be os.Stdin.
@@ -152,6 +152,7 @@ type hideCursorMsg struct{}
 // NewProgram creates a new Program.
 func NewProgram(model Model, opts ...ProgramOption) *Program {
 	p := &Program{
+		mtx:          &sync.Mutex{},
 		initialModel: model,
 		output:       os.Stdout,
 		input:        os.Stdin,
@@ -221,7 +222,7 @@ func (p *Program) Start() error {
 		}()
 	}
 
-	p.renderer = newRenderer(p.output, &p.mtx)
+	p.renderer = newRenderer(p.output, p.mtx)
 
 	// Check if output is a TTY before entering raw mode, hiding the cursor and
 	// so on.

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -2,7 +2,59 @@
 
 package tea
 
-import "io"
+import (
+	"errors"
+	"io"
+	"os"
+
+	"github.com/containerd/console"
+)
+
+func (p *Program) initInput() error {
+	if !p.inputIsTTY {
+		return nil
+	}
+
+	// If input's a TTY this should always succeed.
+	f, ok := p.input.(*os.File)
+	if !ok {
+		return errInputIsNotAFile
+	}
+
+	c, err := console.ConsoleFromFile(f)
+	if err != nil {
+		return nil
+	}
+	p.console = c
+
+	return nil
+}
+
+// On unix systems, RestoreInput closes any TTYs we opened for input. Note that
+// we don't do this on Windows as it causes the prompt to not be drawn until the
+// terminal receives a keypress rather than appearing promptly after the program
+// exits.
+func (p *Program) restoreInput() error {
+	if p.inputStatus == managedInput {
+		f, ok := p.input.(*os.File)
+		if !ok {
+			return errors.New("could not close input")
+		}
+		err := f.Close()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func openInputTTY() (*os.File, error) {
+	f, err := os.Open("/dev/tty")
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
 
 // enableAnsiColors is only needed for Windows, so for other systems this is
 // a no-op.

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -6,8 +6,54 @@ import (
 	"io"
 	"os"
 
+	"github.com/containerd/console"
 	"golang.org/x/sys/windows"
 )
+
+func (p *Program) initInput() error {
+	if !p.inputIsTTY {
+		return nil
+	}
+
+	// If input's a TTY this should always succeed.
+	f, ok := p.input.(*os.File)
+	if !ok {
+		return errInputIsNotAFile
+	}
+
+	if p.inputStatus == managedInput {
+		// Save a reference to the current stdin then replace stdin with our
+		// input. We do this so we can hand input off to containerd/console to
+		// set raw mode, and do it in this fashion because the method
+		// console.ConsoleFromFile isn't supported on Windows.
+		p.windowsStdin = os.Stdin
+		os.Stdin = f
+	}
+
+	// Note: this will panic if it fails.
+	c := console.Current()
+	p.console = c
+
+	return nil
+}
+
+// restoreInput restores stdout in the event that we placed it aside to handle
+// input with CONIN$, above.
+func (p *Program) restoreInput() error {
+	if p.windowsStdin != nil {
+		os.Stdin = p.windowsStdin
+	}
+
+	return nil
+}
+
+func openInputTTY() (*os.File, error) {
+	f, err := os.OpenFile("CONIN$", os.O_RDWR, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
 
 // enableAnsiColors enables support for ANSI color sequences in Windows
 // default console. Note that this only works with Windows 10.
@@ -20,6 +66,6 @@ func enableAnsiColors(w io.Writer) {
 	stdout := windows.Handle(f.Fd())
 	var originalMode uint32
 
-	windows.GetConsoleMode(stdout, &originalMode)
-	windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	_ = windows.GetConsoleMode(stdout, &originalMode)
+	_ = windows.SetConsoleMode(stdout, originalMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
 }


### PR DESCRIPTION
This PR automatically opens a TTY for input if input is not a TTY. In practice, this means that if you pipe or redirect data into a Bubble Tea application it will “just work.” Note that if the user has explicitly set the input (via `tea.WithInput`) a TTY will not be opened.

Also note that this PR includes Windows support. On Windows we open a console process for input (`CONIN$`) which is effectively the same as a TTY on unix in this case.

An example illustrating this new functionality has been added in the `examples/pipe` directory.

Related: #39 (where we introduced custom inputs) and #24 (where there's an argument to always open a TTY for input) and #41 (which contains a proposed solution).