### PR TITLE
WithOutput option should take io.Writer as argument type.

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -73,7 +73,7 @@ type ProgramOption func(*Program)
 
 // WithOutput sets the output which, by default, is stdout. In most cases you
 // won't need to use this.
-func WithOutput(output *os.File) ProgramOption {
+func WithOutput(output io.Writer) ProgramOption {
 	return func(m *Program) {
 		m.output = output
 	}


### PR DESCRIPTION
This can fix #63 but cause a breaking change.