### PR TITLE
Mutex protect buffer access in standard renderer

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -88,15 +88,15 @@ func (r *standardRenderer) listen() {
 
 // flush renders the buffer.
 func (r *standardRenderer) flush() {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
 	if r.buf.Len() == 0 || r.buf.String() == r.lastRender {
 		// Nothing to do
 		return
 	}
 
 	out := new(bytes.Buffer)
-
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
 
 	// Clear any lines we painted in the last render.
 	if r.linesRendered > 0 {


### PR DESCRIPTION
Lock the mutex before checking the buffer's length / content.