### PR TITLE
Clear the bottom line before exiting to make room for the prompt

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -64,6 +64,7 @@ func (r *standardRenderer) start() {
 // stop permanently halts the renderer.
 func (r *standardRenderer) stop() {
 	r.flush()
+	clearLine(r.out)
 	r.done <- struct{}{}
 }
 


### PR DESCRIPTION
When using the standard renderer, this PR clears the bottom line before exiting a program. With inline programs, that final line is where the prompt will be drawn, so we need to clear that line to avoid situations where the prompt is overlaid onto part of the TUI.