### PR TITLE
Remove redundant lock in standard renderer listen

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -65,7 +65,7 @@ func (r *standardRenderer) start() {
 func (r *standardRenderer) stop() {
 	r.flush()
 	clearLine(r.out)
-	r.done <- struct{}{}
+	close(r.done)
 }
 
 // listen waits for ticks on the ticker, or a signal to stop the renderer.
@@ -77,11 +77,8 @@ func (r *standardRenderer) listen() {
 				r.flush()
 			}
 		case <-r.done:
-			r.mtx.Lock()
 			r.ticker.Stop()
 			r.ticker = nil
-			r.mtx.Unlock()
-			close(r.done)
 			return
 		}
 	}


### PR DESCRIPTION
Remove redundant lock in standard renderer listen.

And we can close `r.done` directly in this case, because we only send `struct{}{}` to `r.done` once.