### PR TITLE
Fix stack overflow in examples/http

### DIFF
--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -22,7 +22,7 @@ type statusMsg int
 
 type errMsg struct{ error }
 
-func (e errMsg) Error() string { return e.Error() }
+func (e errMsg) Error() string { return e.error.Error() }
 
 func main() {
 	p := tea.NewProgram(model{})


### PR DESCRIPTION
recursive call e.Error() leads to stack overflow.