### PR TITLE
Mouse Commands

### DIFF
--- a/examples/mouse/main.go
+++ b/examples/mouse/main.go
@@ -11,14 +11,7 @@ import (
 )
 
 func main() {
-	p := tea.NewProgram(model{})
-
-	p.EnterAltScreen()
-	defer p.ExitAltScreen()
-	p.EnableMouseAllMotion()
-	defer p.DisableMouseAllMotion()
-
-	if err := p.Start(); err != nil {
+	if err := tea.NewProgram(model{}).Start(); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -29,7 +22,7 @@ type model struct {
 }
 
 func (m model) Init() tea.Cmd {
-	return nil
+	return tea.Batch(tea.EnterAltScreen, tea.EnableMouseAllMotion)
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/tea.go
+++ b/tea.go
@@ -325,6 +325,8 @@ func (p *Program) Start() error {
 		defer func() {
 			if r := recover(); r != nil {
 				p.ExitAltScreen()
+				p.DisableMouseCellMotion()
+				p.DisableMouseAllMotion()
 				fmt.Printf("Caught panic:\n\n%s\n\nRestoring terminal...\n\n", r)
 				debug.PrintStack()
 				return

--- a/tea.go
+++ b/tea.go
@@ -168,14 +168,15 @@ func Quit() Msg {
 // send a quitMsg with Quit.
 type quitMsg struct{}
 
-// EnterAltScreen is a special command that tells the Bubble Tea program to enter
-// alternate screen buffer.
+// EnterAltScreen is a special command that tells the Bubble Tea program to
+// enter alternate screen buffer.
 func EnterAltScreen() Msg {
 	return enterAltScreenMsg{}
 }
 
-// enterAltScreenMsg in an internal message signals that the program should enter
-// alternate screen buffer. You can send a enterAltScreenMsg with EnterAltScreen.
+// enterAltScreenMsg in an internal message signals that the program should
+// enter alternate screen buffer. You can send a enterAltScreenMsg with
+// EnterAltScreen.
 type enterAltScreenMsg struct{}
 
 // ExitAltScreen is a special command that tells the Bubble Tea program to exit
@@ -472,6 +473,8 @@ func (p *Program) Start() error {
 
 // EnterAltScreen enters the alternate screen buffer, which consumes the entire
 // terminal window. ExitAltScreen will return the terminal to its former state.
+//
+// Deprecated. Use the EnterAltScreen() command instead.
 func (p *Program) EnterAltScreen() {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()
@@ -490,6 +493,8 @@ func (p *Program) EnterAltScreen() {
 }
 
 // ExitAltScreen exits the alternate screen buffer.
+//
+// Deprecated. Use the ExitAltScreen() command instead.
 func (p *Program) ExitAltScreen() {
 	p.mtx.Lock()
 	defer p.mtx.Unlock()


### PR DESCRIPTION
This PR improves mouse support and deprecates mouse and altscreen program-level methods in favor of commands.

### New

* Added `EnableMouseCellMotion`, `EnableMouseAllMotion` and `DisableMouse` commands for enabling and disabling the mouse.

### Changed

* Mouse modes are automatically disabled when quitting a program.
* Program-level mouse methods are now deprecated: `Program.EnableMouseCellMotion`, `Program.DisableMouseCellMotion`, `Program.EnableMouseAllMotion`, `Program.DisableMouseAllMotion`. Use the new commands instead.
* Program-level altscreen methods are now deprecated: `Program.EnterAltScreen` and `Program.ExitAltScreen`. Use the corresponding commands instead.

### Fixed

* Mouse modes are automatically disabled when exiting after a panic.