### PR TITLE
Only render lines that have changed

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -1,5 +1,6 @@
 package tea
 
+// renderer is the interface for Bubble Tea renderers.
 type renderer interface {
 	start()
 	stop()


### PR DESCRIPTION
This PR introduces a performance optimization in the Bubble Tea standard renderer where only lines that have changed since the last render will be cleared and drawn.

Note that there's already an optimization in place that will skip renders entirely if nothing has changed.