### PR TITLE
Fix typo in examples/result

### DIFF
--- a/examples/result/main.go
+++ b/examples/result/main.go
@@ -29,7 +29,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q", "esc":
-			close(m.choice) // If we're quitting just chose the channel.
+			close(m.choice) // If we're quitting just close the channel.
 			return m, tea.Quit
 
 		case "enter":


### PR DESCRIPTION
Changes ```chose``` to ```close``` on line **32**