### PR TITLE
Force a full repaint when resizing the window

### DIFF
--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -5,5 +5,6 @@ type nilRenderer struct{}
 func (n nilRenderer) start()              {}
 func (n nilRenderer) stop()               {}
 func (n nilRenderer) write(v string)      {}
+func (n nilRenderer) repaint()            {}
 func (n nilRenderer) altScreen() bool     { return false }
 func (n nilRenderer) setAltScreen(v bool) {}

--- a/renderer.go
+++ b/renderer.go
@@ -5,6 +5,7 @@ type renderer interface {
 	start()
 	stop()
 	write(string)
+	repaint()
 	altScreen() bool
 	setAltScreen(bool)
 }

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -202,6 +202,10 @@ func (r *standardRenderer) write(s string) {
 	_, _ = r.buf.WriteString(s)
 }
 
+func (r *standardRenderer) repaint() {
+	r.lastRender = ""
+}
+
 func (r *standardRenderer) altScreen() bool {
 	return r.altScreenActive
 }

--- a/tea.go
+++ b/tea.go
@@ -438,6 +438,9 @@ func (p *Program) Start() error {
 				}
 				continue
 
+			case WindowSizeMsg:
+				p.renderer.repaint()
+
 			case enterAltScreenMsg:
 				p.EnterAltScreen()
 


### PR DESCRIPTION
v0.13.4 introduced a regression where lines weren't always cleared when resizing the window, resulting in the occasional presence of rendering artifacts. This commit fixes that.