### PR TITLE
Bugfixes: Races and Rendering

### DIFF
--- a/examples/fullscreen/main.go
+++ b/examples/fullscreen/main.go
@@ -16,7 +16,8 @@ type model int
 type tickMsg time.Time
 
 func main() {
-	if err := tea.NewProgram(model(5)).Start(); err != nil {
+	p := tea.NewProgram(model(5), tea.WithAltScreen())
+	if err := p.Start(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/examples/mouse/main.go
+++ b/examples/mouse/main.go
@@ -11,7 +11,8 @@ import (
 )
 
 func main() {
-	if err := tea.NewProgram(model{}).Start(); err != nil {
+	p := tea.NewProgram(model{}, tea.WithAltScreen(), tea.WithMouseAllMotion())
+	if err := p.Start(); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -22,7 +23,7 @@ type model struct {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(tea.EnterAltScreen, tea.EnableMouseAllMotion)
+	return nil
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/examples/pager/main.go
+++ b/examples/pager/main.go
@@ -53,15 +53,15 @@ func main() {
 		defer f.Close()
 	}
 
-	p := tea.NewProgram(model{content: string(content)})
+	p := tea.NewProgram(
+		model{content: string(content)},
 
-	// Use the full size of the terminal in its "alternate screen buffer"
-	p.EnterAltScreen()
-	defer p.ExitAltScreen()
+		// Use the full size of the terminal in its "alternate screen buffer"
+		tea.WithAltScreen(),
 
-	// We also turn on mouse support so we can track the mouse wheel
-	p.EnableMouseCellMotion()
-	defer p.DisableMouseCellMotion()
+		// Also turn on mouse support so we can track the mouse wheel
+		tea.WithMouseCellMotion(),
+	)
 
 	if err := p.Start(); err != nil {
 		fmt.Println("could not run program:", err)

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -4,6 +4,7 @@ type nilRenderer struct{}
 
 func (n nilRenderer) start()              {}
 func (n nilRenderer) stop()               {}
+func (n nilRenderer) kill()               {}
 func (n nilRenderer) write(v string)      {}
 func (n nilRenderer) repaint()            {}
 func (n nilRenderer) altScreen() bool     { return false }

--- a/renderer.go
+++ b/renderer.go
@@ -2,10 +2,26 @@ package tea
 
 // renderer is the interface for Bubble Tea renderers.
 type renderer interface {
+	// Start the renderer.
 	start()
+
+	// Stop the renderer, but render the final frame in the buffer, if any.
 	stop()
+
+	// Stop the renderer without doing any final rendering.
+	kill()
+
+	// Write a frame to the renderer. The renderer can write this data to ouput
+	// at its discretion.
 	write(string)
+
+	// Request a full re-render.
 	repaint()
+
+	// Whether or not the alternate screen buffer is enabled.
 	altScreen() bool
+
+	// Record internally that the alternate screen buffer is enabled. This does
+	// should not actually toggle the alternate screen buffer.
 	setAltScreen(bool)
 }

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -61,9 +61,15 @@ func (r *standardRenderer) start() {
 	go r.listen()
 }
 
-// stop permanently halts the renderer.
+// stop permanently halts the renderer, rendering the final frame.
 func (r *standardRenderer) stop() {
 	r.flush()
+	clearLine(r.out)
+	close(r.done)
+}
+
+// kill halts the renderer. The final frame will not be rendered.
+func (r *standardRenderer) kill() {
 	clearLine(r.out)
 	close(r.done)
 }

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -205,6 +205,15 @@ func (r *standardRenderer) write(s string) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 	r.buf.Reset()
+
+	// If an empty string was passed we should clear existing output and
+	// rendering nothing. Rather than introduce additional state to manage
+	// this, we render a single space as a simple (albeit less correct)
+	// solution.
+	if s == "" {
+		s = " "
+	}
+
 	_, _ = r.buf.WriteString(s)
 }
 


### PR DESCRIPTION
This PR introduces three new `ProgramOption`s for starting programs with the altscreen and mouse enabled:

```go
// New! This is the recommended way to start your program with the mouse and altscreen active.
p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseAllMotion())

// Deprecated as this will only operate on stdout, as opposed to a custom output you may have set.
p := tea.NewProgram(model)
p.EnableAltScreen()
p.EnableMouseAllMotion()

// Strongly discouraged as these commands could be sent before starting  the renderer, resulting
// in rendering artifacts. This is due to the fact that commands run asynchronously in a goroutine.
func (m model) Init() tea.Cmd {
    return tea.Batch(tea.EnterAltScreen, tea.EnableMouseAllMotion)
}
```

Also included are subtle rendering improvements and bug fixes.

***

### New

* Added `WithAltScreen` for starting programs in the alternate screen buffer.
* Added `WithMouseCellMotion` and `WithMouseAllMotion` for starting programs with the mouse enabled.

### Fixed

* Programs will no longer render artifacts when exiting due to an error or panic.
* If a view returns the empty string output will be cleared. Previously, rendering would skip rendering entirely.