### PR TITLE
renderer: only clear new line if it's shorter than the old one

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -116,7 +116,11 @@ func (r *standardRenderer) flush() {
 			if (len(newLines) <= len(oldLines)) && (len(newLines) > i && len(oldLines) > i) && (newLines[i] == oldLines[i]) {
 				skipLines[i] = struct{}{}
 			} else if _, exists := r.ignoreLines[i]; !exists {
-				clearLine(out)
+                // But only clear the line if it's shorter than the old one,
+                // otherwise it gets overwritten by the new line anyway.
+                if len(newLines[i]) < len(oldLines[i]) {
+                    clearLine(out)
+                }
 			}
 
 			cursorUp(out)


### PR DESCRIPTION
avoids clearing lines that will get overwritten by new lines anyway. (ie if the new line has the same length or are longer then the old one)

I've tested this with most examples. but only on my system.