### PR TITLE
More Inclusive Inputs

### DIFF
--- a/examples/go.sum
+++ b/examples/go.sum
@@ -17,8 +17,8 @@ github.com/charmbracelet/harmonica v0.1.0 h1:lFKeSd6OAckQ/CEzPVd2mqj+YMEubQ/3FM2
 github.com/charmbracelet/harmonica v0.1.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.1.2 h1:D+LUMg34W7n2pkuMrevKVxT7HXqnoRHm7IoomkX3/ZU=
 github.com/charmbracelet/lipgloss v0.1.2/go.mod h1:5D8zradw52m7QmxRF6QgwbwJi9je84g8MkWiGN07uKg=
-github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
-github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
+github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
+github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
 github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -76,10 +76,10 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200413165638-669c56c373c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed h1:Ei4bQjjpYUsS4efOUz+5Nz++IVkHk87n2zBA0NxBWc0=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/charmbracelet/bubbletea
 go 1.13
 
 require (
-	github.com/containerd/console v1.0.1
+	github.com/containerd/console v1.0.2
 	github.com/mattn/go-isatty v0.0.12
 	github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68
 	github.com/muesli/termenv v0.8.1
-	golang.org/x/sys v0.0.0-20201119102817-f84b799fce68
+	golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c
 	golang.org/x/term v0.0.0-20210422114643-f5beecf764ed
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
-github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
+github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
+github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -16,8 +16,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed h1:Ei4bQjjpYUsS4efOUz+5Nz++IVkHk87n2zBA0NxBWc0=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/options.go
+++ b/options.go
@@ -1,0 +1,114 @@
+package tea
+
+import "io"
+
+// ProgramOption is used to set options when initializing a Program. Program can
+// accept a variable number of options.
+//
+// Example usage:
+//
+//     p := NewProgram(model, WithInput(someInput), WithOutput(someOutput))
+//
+type ProgramOption func(*Program)
+
+// WithOutput sets the output which, by default, is stdout. In most cases you
+// won't need to use this.
+func WithOutput(output io.Writer) ProgramOption {
+	return func(m *Program) {
+		m.output = output
+	}
+}
+
+// WithInput sets the input which, by default, is stdin. In most cases you
+// won't need to use this.
+func WithInput(input io.Reader) ProgramOption {
+	return func(m *Program) {
+		m.input = input
+		m.inputStatus = customInput
+	}
+}
+
+// WithoutCatchPanics disables the panic catching that Bubble Tea does by
+// default. If panic catching is disabled the terminal will be in a fairly
+// unusable state after a panic because Bubble Tea will not perform its usual
+// cleanup on exit.
+func WithoutCatchPanics() ProgramOption {
+	return func(m *Program) {
+		m.CatchPanics = false
+	}
+}
+
+// WithAltScreen starts the program with the alternate screen buffer enabled
+// (i.e. the program starts in full window mode). Note that the altscreen will
+// be automatically exited when the program quits.
+//
+// Example:
+//
+//     p := tea.NewProgram(Model{}, tea.WithAltScreen())
+//     if err := p.Start(); err != nil {
+//         fmt.Println("Error running program:", err)
+//         os.Exit(1)
+//     }
+//
+// To enter the altscreen once the program has already started running use the
+// EnterAltScreen command.
+func WithAltScreen() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withAltScreen
+	}
+}
+
+// WithMouseCellMotion starts the program with the mouse enabled in "cell
+// motion" mode.
+//
+// Cell motion mode enables mouse click, release, and wheel events. Mouse
+// movement events are also captured if a mouse button is pressed (i.e., drag
+// events). Cell motion mode is better supported than all motion mode.
+//
+// To enable mouse cell motion once the program has already started running use
+// the EnableMouseCellMotion command. To disable the mouse when the program is
+// running use the DisableMouse command.
+//
+// The mouse will be automatically disabled when the program exits.
+func WithMouseCellMotion() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withMouseCellMotion // set
+		p.startupOptions &^= withMouseAllMotion // clear
+	}
+}
+
+// WithMouseAllMotion starts the program with the mouse enabled in "all motion"
+// mode.
+//
+// EnableMouseAllMotion is a special command that enables mouse click, release,
+// wheel, and motion events, which are delivered regardless of whether a mouse
+// button is pressed, effectively enabling support for hover interactions.
+//
+// Many modern terminals support this, but not all. If in doubt, use
+// EnableMouseCellMotion instead.
+//
+// To enable the mouse once the program has already started running use the
+// EnableMouseAllMotion command. To disable the mouse when the program is
+// running use the DisableMouse command.
+//
+// The mouse will be automatically disabled when the program exits.
+func WithMouseAllMotion() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withMouseAllMotion   // set
+		p.startupOptions &^= withMouseCellMotion // clear
+	}
+}
+
+// WithoutRenderer disables the renderer. When this is set output and log
+// statements will be plainly sent to stdout (or another output if one is set)
+// without any rendering and redrawing logic. In other words, printing and
+// logging will behave the same way it would in a non-TUI commandline tool.
+// This can be useful if you want to use the Bubble Tea framework for a non-TUI
+// application, or to provide an additional non-TUI mode to your Bubble Tea
+// programs. For example, your program could behave like a daemon if output is
+// not a TTY.
+func WithoutRenderer() ProgramOption {
+	return func(m *Program) {
+		m.renderer = &nilRenderer{}
+	}
+}

--- a/options.go
+++ b/options.go
@@ -24,7 +24,7 @@ func WithOutput(output io.Writer) ProgramOption {
 func WithInput(input io.Reader) ProgramOption {
 	return func(m *Program) {
 		m.input = input
-		m.inputStatus = customInput
+		m.startupOptions |= withCustomInput
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -28,6 +28,13 @@ func WithInput(input io.Reader) ProgramOption {
 	}
 }
 
+// WithInputTTY open a new TTY for input (or console input device on Windows).
+func WithInputTTY() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withInputTTY
+	}
+}
+
 // WithoutCatchPanics disables the panic catching that Bubble Tea does by
 // default. If panic catching is disabled the terminal will be in a fairly
 // unusable state after a panic because Bubble Tea will not perform its usual

--- a/tea.go
+++ b/tea.go
@@ -455,11 +455,8 @@ func (p *Program) Start() error {
 
 	// Check if output is a TTY before entering raw mode, hiding the cursor and
 	// so on.
-	{
-		err := p.initTerminal()
-		if err != nil {
-			return err
-		}
+	if err := p.initTerminal(); err != nil {
+		return err
 	}
 
 	// If no renderer is set use the standard one.

--- a/tea.go
+++ b/tea.go
@@ -52,117 +52,6 @@ type Model interface {
 // function.
 type Cmd func() Msg
 
-// ProgramOption is used to set options when initializing a Program. Program can
-// accept a variable number of options.
-//
-// Example usage:
-//
-//     p := NewProgram(model, WithInput(someInput), WithOutput(someOutput))
-//
-type ProgramOption func(*Program)
-
-// WithOutput sets the output which, by default, is stdout. In most cases you
-// won't need to use this.
-func WithOutput(output io.Writer) ProgramOption {
-	return func(m *Program) {
-		m.output = output
-	}
-}
-
-// WithInput sets the input which, by default, is stdin. In most cases you
-// won't need to use this.
-func WithInput(input io.Reader) ProgramOption {
-	return func(m *Program) {
-		m.input = input
-		m.inputStatus = customInput
-	}
-}
-
-// WithoutCatchPanics disables the panic catching that Bubble Tea does by
-// default. If panic catching is disabled the terminal will be in a fairly
-// unusable state after a panic because Bubble Tea will not perform its usual
-// cleanup on exit.
-func WithoutCatchPanics() ProgramOption {
-	return func(m *Program) {
-		m.CatchPanics = false
-	}
-}
-
-// WithAltScreen starts the program with the alternate screen buffer enabled
-// (i.e. the program starts in full window mode). Note that the altscreen will
-// be automatically exited when the program quits.
-//
-// Example:
-//
-//     p := tea.NewProgram(Model{}, tea.WithAltScreen())
-//     if err := p.Start(); err != nil {
-//         fmt.Println("Error running program:", err)
-//         os.Exit(1)
-//     }
-//
-// To enter the altscreen once the program has already started running use the
-// EnterAltScreen command.
-func WithAltScreen() ProgramOption {
-	return func(p *Program) {
-		p.startupOptions |= withAltScreen
-	}
-}
-
-// WithMouseCellMotion starts the program with the mouse enabled in "cell
-// motion" mode.
-//
-// Cell motion mode enables mouse click, release, and wheel events. Mouse
-// movement events are also captured if a mouse button is pressed (i.e., drag
-// events). Cell motion mode is better supported than all motion mode.
-//
-// To enable mouse cell motion once the program has already started running use
-// the EnableMouseCellMotion command. To disable the mouse when the program is
-// running use the DisableMouse command.
-//
-// The mouse will be automatically disabled when the program exits.
-func WithMouseCellMotion() ProgramOption {
-	return func(p *Program) {
-		p.startupOptions |= withMouseCellMotion // set
-		p.startupOptions &^= withMouseAllMotion // clear
-	}
-}
-
-// WithMouseAllMotion starts the program with the mouse enabled in "all motion"
-// mode.
-//
-// EnableMouseAllMotion is a special command that enables mouse click, release,
-// wheel, and motion events, which are delivered regardless of whether a mouse
-// button is pressed, effectively enabling support for hover interactions.
-//
-// Many modern terminals support this, but not all. If in doubt, use
-// EnableMouseCellMotion instead.
-//
-// To enable the mouse once the program has already started running use the
-// EnableMouseAllMotion command. To disable the mouse when the program is
-// running use the DisableMouse command.
-//
-// The mouse will be automatically disabled when the program exits.
-func WithMouseAllMotion() ProgramOption {
-	return func(p *Program) {
-		p.startupOptions |= withMouseAllMotion   // set
-		p.startupOptions &^= withMouseCellMotion // clear
-	}
-}
-
-// WithoutRenderer disables the renderer. When this is set output and log
-// statements will be plainly sent to stdout (or another output if one is set)
-// without any rendering and redrawing logic. In other words, printing and
-// logging will behave the same way it would in a non-TUI commandline tool.
-// This can be useful if you want to use the Bubble Tea framework for a non-TUI
-// application, or to provide an additional non-TUI mode to your Bubble Tea
-// programs. For example, your program could behave like a daemon if output is
-// not a TTY.
-func WithoutRenderer() ProgramOption {
-	return func(m *Program) {
-		m.renderer = &nilRenderer{}
-	}
-}
-
 // startupOptions contains configuration options to be run while the program
 // is initializing.
 //
@@ -209,7 +98,7 @@ type Program struct {
 	initialModel Model
 
 	// Configuration options that will set as the program is initializing,
-	// treated as bits.  These options can be set via various ProgramOptions.
+	// treated as bits. These options can be set via various ProgramOptions.
 	startupOptions startupOptions
 
 	mtx  *sync.Mutex

--- a/tea.go
+++ b/tea.go
@@ -371,9 +371,8 @@ func (p *Program) Start() error {
 		}()
 	}
 
-	// Is output a terminal?
 	if f, ok := p.output.(*os.File); ok {
-		// Get initial terminal size
+		// Get initial terminal size and send it to the program
 		go func() {
 			w, h, err := term.GetSize(int(f.Fd()))
 			if err != nil {

--- a/tea.go
+++ b/tea.go
@@ -481,8 +481,6 @@ func (p *Program) shutdown(kill bool) {
 		p.renderer.stop()
 	}
 	close(p.done)
-	close(p.msgs)
-	p.msgs = nil
 	p.ExitAltScreen()
 	p.DisableMouseCellMotion()
 	p.DisableMouseAllMotion()

--- a/tty.go
+++ b/tty.go
@@ -19,17 +19,12 @@ func (p *Program) initTerminal() error {
 		}
 	}
 
-	if p.outputIsTTY {
-		hideCursor(p.output)
-	}
-
+	hideCursor(p.output)
 	return nil
 }
 
 func (p Program) restoreTerminal() error {
-	if p.outputIsTTY {
-		showCursor(p.output)
-	}
+	showCursor(p.output)
 
 	if p.console != nil {
 		err := p.console.Reset()

--- a/tty.go
+++ b/tty.go
@@ -1,11 +1,5 @@
 package tea
 
-import (
-	"errors"
-)
-
-var errInputIsNotAFile = errors.New("input is not a file")
-
 func (p *Program) initTerminal() error {
 	err := p.initInput()
 	if err != nil {

--- a/tty.go
+++ b/tty.go
@@ -20,7 +20,6 @@ func (p *Program) initTerminal() error {
 	}
 
 	if p.outputIsTTY {
-		enableAnsiColors(p.output)
 		hideCursor(p.output)
 	}
 

--- a/tty.go
+++ b/tty.go
@@ -12,10 +12,7 @@ func (p *Program) initTerminal() error {
 		return err
 	}
 
-	if p.inputIsTTY {
-		if p.console == nil {
-			return errors.New("no console")
-		}
+	if p.console != nil {
 		err = p.console.SetRaw()
 		if err != nil {
 			return err
@@ -35,16 +32,15 @@ func (p Program) restoreTerminal() error {
 		showCursor(p.output)
 	}
 
-	if err := p.restoreInput(); err != nil {
-		return err
-	}
-
-	// Console will only be set if input is a TTY.
 	if p.console != nil {
 		err := p.console.Reset()
 		if err != nil {
 			return err
 		}
+	}
+
+	if err := p.restoreInput(); err != nil {
+		return err
 	}
 
 	return nil

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -3,7 +3,6 @@
 package tea
 
 import (
-	"io"
 	"os"
 
 	"github.com/containerd/console"
@@ -40,7 +39,3 @@ func openInputTTY() (*os.File, error) {
 	}
 	return f, nil
 }
-
-// enableAnsiColors is only needed for Windows, so for other systems this is
-// a no-op.
-func enableAnsiColors(_ io.Writer) {}

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -47,6 +47,7 @@ func (p *Program) restoreInput() error {
 	return nil
 }
 
+// Open the Windows equivalent of a TTY.
 func openInputTTY() (*os.File, error) {
 	f, err := os.OpenFile("CONIN$", os.O_RDWR, 0644)
 	if err != nil {

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -34,6 +34,8 @@ func (p *Program) initInput() error {
 	c := console.Current()
 	p.console = c
 
+	enableAnsiColors(p.output)
+
 	return nil
 }
 

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -11,28 +11,19 @@ import (
 )
 
 func (p *Program) initInput() error {
-	if !p.inputIsTTY {
-		return nil
-	}
-
-	// If input's a TTY this should always succeed.
-	f, ok := p.input.(*os.File)
-	if !ok {
-		return errInputIsNotAFile
-	}
-
-	if p.inputStatus == managedInput {
+	// If input's a file, use console to manage it
+	if f, ok := p.input.(*os.File); ok {
 		// Save a reference to the current stdin then replace stdin with our
 		// input. We do this so we can hand input off to containerd/console to
 		// set raw mode, and do it in this fashion because the method
 		// console.ConsoleFromFile isn't supported on Windows.
 		p.windowsStdin = os.Stdin
 		os.Stdin = f
-	}
 
-	// Note: this will panic if it fails.
-	c := console.Current()
-	p.console = c
+		// Note: this will panic if it fails.
+		c := console.Current()
+		p.console = c
+	}
 
 	enableAnsiColors(p.output)
 

--- a/tutorials/go.mod
+++ b/tutorials/go.mod
@@ -2,6 +2,6 @@ module tutorial
 
 go 1.14
 
-require github.com/charmbracelet/bubbletea v0.13.1
+require github.com/charmbracelet/bubbletea v0.14.1
 
 replace github.com/charmbracelet/bubbletea => ../

--- a/tutorials/go.sum
+++ b/tutorials/go.sum
@@ -1,5 +1,5 @@
-github.com/containerd/console v1.0.1 h1:u7SFAJyRqWcG6ogaMAx3KjSTy1e3hT9QxqX7Jco7dRc=
-github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
+github.com/containerd/console v1.0.2 h1:Pi6D+aZXM+oUw1czuKgH5IJ+y0jhYcwBJfx5/Ghn9dE=
+github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
@@ -16,8 +16,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c h1:VwygUrnw9jn88c4u8GD3rZQbqrP/tgas88tPUbBxQrk=
+golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed h1:Ei4bQjjpYUsS4efOUz+5Nz++IVkHk87n2zBA0NxBWc0=
 golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
This update allows Bubble Tea to accept a wider range of input types such as PTYs from SSH connections. Additionally, `WithInputTTY`, a new `ProgramOption`, has been added for explicitly requesting a new TTY (or console on Windows) to be opened for input.

The codebase has also grown quite a bit since it's initial release! To that end, this update includes some tidying up under the hood.

## New

* Bubble Tea will now work with a wider range of inputs, such as PTYs
* Program option `WithInputTTY` will explicitly open a new TTY for input on unix systems or console on Windows (`CONIN$`)

## Fixed

* Programs will no longer panic when receiving messages during shutdown