### PR TITLE
fix: remove unnecessary build tags

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,5 +1,3 @@
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
-
 package tea
 
 import (

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -1,5 +1,3 @@
-// +build windows
-
 package tea
 
 import (


### PR DESCRIPTION
closes #35

the filename suffix (`_unix` and `_windows`) already do this, no need to specify in build tags too afaik...