### PR TITLE
Add Go 1.17 build tags syntax

### DIFF
--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package tea

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package tea


### PR DESCRIPTION
At Charm, we’re all about hot, new styles. That’s why we’re proud to introduce Go 1.17 build tags into Bubble Tea.