### PR TITLE
Fix a performance rendering size miscalculation in the pager example

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module examples
 go 1.13
 
 require (
-	github.com/charmbracelet/bubbles v0.8.1-0.20210907175746-b691d7f07e25
+	github.com/charmbracelet/bubbles v0.9.1-0.20210917202525-0ac5ecdf8170
 	github.com/charmbracelet/bubbletea v0.14.1
 	github.com/charmbracelet/glamour v0.2.0
 	github.com/charmbracelet/lipgloss v0.3.0

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -9,8 +9,8 @@ github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897 h1:p9Sln00KOTlrYkx
 github.com/alecthomas/repr v0.0.0-20180818092828-117648cd9897/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
-github.com/charmbracelet/bubbles v0.8.1-0.20210907175746-b691d7f07e25 h1:iivPooBtdJV/i//6Zktuvr6CnF11xKp9H+Poy497PqY=
-github.com/charmbracelet/bubbles v0.8.1-0.20210907175746-b691d7f07e25/go.mod h1:NWT/c+0rYEnYChz5qCyX4Lj6fDw9gGToh9EFJPajghU=
+github.com/charmbracelet/bubbles v0.9.1-0.20210917202525-0ac5ecdf8170 h1:6gFVr0CeUQ4JHScJlBY/jeflgN70PLZ/gqG6st99tdo=
+github.com/charmbracelet/bubbles v0.9.1-0.20210917202525-0ac5ecdf8170/go.mod h1:NWT/c+0rYEnYChz5qCyX4Lj6fDw9gGToh9EFJPajghU=
 github.com/charmbracelet/glamour v0.2.0 h1:mTgaiNiumpqTZp3qVM6DH9UB0NlbY17wejoMf1kM8Pg=
 github.com/charmbracelet/glamour v0.2.0/go.mod h1:UA27Kwj3QHialP74iU6C+Gpc8Y7IOAKupeKMLLBURWM=
 github.com/charmbracelet/harmonica v0.1.0 h1:lFKeSd6OAckQ/CEzPVd2mqj+YMEubQ/3FM2IYY3xNm0=

--- a/examples/pager/main.go
+++ b/examples/pager/main.go
@@ -101,10 +101,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// quickly, though asynchronously, which is why we wait for them
 			// here.
 			m.viewport = viewport.Model{Width: msg.Width, Height: msg.Height - verticalMargins}
-			m.viewport.YPosition = headerHeight
 			m.viewport.HighPerformanceRendering = useHighPerformanceRenderer
 			m.viewport.SetContent(m.content)
 			m.ready = true
+
+			// This is only necessary for high performance rendering, which in
+			// most cases you won't need.
+			//
+			// Render the viewport one line below the header.
+			m.viewport.YPosition = headerHeight + 1
 		} else {
 			m.viewport.Width = msg.Width
 			m.viewport.Height = msg.Height - verticalMargins


### PR DESCRIPTION
This update fixes a small miscalculation in the `pager` example when the performance `viewport` is in use. Bubbles has also been pinned to master for some `viewport` fixes.