### PR TITLE
Set ENABLE_VIRUTAL_TERMINAL_INPUT on Windows

### DIFF
--- a/cancelreader_windows.go
+++ b/cancelreader_windows.go
@@ -206,7 +206,13 @@ func prepareConsole(input windows.Handle) (reset func() error, err error) {
 	newMode |= windows.ENABLE_INSERT_MODE
 	newMode |= windows.ENABLE_QUICK_EDIT_MODE
 
-	newMode &^= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+	// Enabling virutal terminal input is necessary for processing certain
+	// types of input like X10 mouse events and arrows keys with the current
+	// bytes-based input reader. It does, however, prevent cancelReader from
+	// being able to cancel input. The planned solution for this is to read
+	// Windows events in a more native fashion, rather than the current simple
+	// bytes-based input reader which works well on unix systems.
+	newMode |= windows.ENABLE_VIRTUAL_TERMINAL_INPUT
 
 	err = windows.SetConsoleMode(input, newMode)
 	if err != nil {

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package tea

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package tea


### PR DESCRIPTION
This update sets `ENABLE_VIRUTAL_TERMINAL_INPUT` on Windows to fix a regression introduced in #120 which prevents the arrow keys on Windows from being read. As a bonus side effect, mouse events are now available to Bubble Tea programs in Windows.

Unfortunately, this update also nullifies `cancelReader`'s ability to cancel input on Windows. A solution, however, is in the works.

Closes #103.