### PR TITLE
ANSI compression is now opt-in

### DIFF
--- a/options.go
+++ b/options.go
@@ -119,3 +119,14 @@ func WithoutRenderer() ProgramOption {
 		m.renderer = &nilRenderer{}
 	}
 }
+
+// WithANSICompressor removes redundant ANSI sequences to produce potentially
+// smaller output, at the cost of some processing overhead.
+//
+// This feature is provisional, and may be changed removed in a future version
+// of this package.
+func WithANSICompressor() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withANSICompressor
+	}
+}

--- a/tea.go
+++ b/tea.go
@@ -71,6 +71,7 @@ const (
 	withMouseAllMotion
 	withInputTTY
 	withCustomInput
+	withANSICompressor
 )
 
 // Program is a terminal user interface.
@@ -360,7 +361,7 @@ func (p *Program) StartReturningModel() (Model, error) {
 
 	// If no renderer is set use the standard one.
 	if p.renderer == nil {
-		p.renderer = newRenderer(p.output, p.mtx)
+		p.renderer = newRenderer(p.output, p.mtx, p.startupOptions.has(withANSICompressor))
 	}
 
 	// Honor program startup options.


### PR DESCRIPTION
To enable the ANSICompressor use the `WithANSICompressor()` program option:

```go
tea.NewProgram(model, tea.WithANSICompressor())
```