### PR TITLE
Add missing build tags to fix builds on BSD systems

### DIFF
--- a/cancelreader_select.go
+++ b/cancelreader_select.go
@@ -1,5 +1,5 @@
-//go:build solaris || darwin
-// +build solaris darwin
+//go:build solaris || darwin || freebsd || netbsd || openbsd
+// +build solaris darwin freebsd netbsd openbsd
 
 // nolint:revive
 package tea


### PR DESCRIPTION
This adds some missing build tags to one of the cancelreader files so Bubble Tea will build on FreeBSD.