### PR TITLE
Add cancelreader bsd go1.17 compilation flags

### DIFF
--- a/cancelreader_bsd.go
+++ b/cancelreader_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || netbsd || openbsd
 // +build darwin freebsd netbsd openbsd
 
 // nolint:revive
@@ -133,7 +134,8 @@ func (r *kqueueCancelReader) wait() error {
 		break
 	}
 
-	switch events[0].Ident {
+	ident := uint64(events[0].Ident)
+	switch ident {
 	case uint64(r.file.Fd()):
 		return nil
 	case uint64(r.cancelSignalReader.Fd()):


### PR DESCRIPTION
and fix "in switch on ident (mismatched types uint64 and uint32)" error
when building for 32-bit bsd