### PR TITLE
Add dragonfly build tags where appropriate

### DIFF
--- a/cancelreader_bsd.go
+++ b/cancelreader_bsd.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || netbsd || openbsd
-// +build darwin freebsd netbsd openbsd
+//go:build darwin || freebsd || netbsd || openbsd || dragonfly
+// +build darwin freebsd netbsd openbsd dragonfly
 
 // nolint:revive
 package tea

--- a/cancelreader_default.go
+++ b/cancelreader_default.go
@@ -1,5 +1,5 @@
-//go:build !darwin && !windows && !linux && !solaris && !freebsd && !netbsd && !openbsd
-// +build !darwin,!windows,!linux,!solaris,!freebsd,!netbsd,!openbsd
+//go:build !darwin && !windows && !linux && !solaris && !freebsd && !netbsd && !openbsd && !dragonfly
+// +build !darwin,!windows,!linux,!solaris,!freebsd,!netbsd,!openbsd,!dragonfly
 
 package tea
 

--- a/cancelreader_select.go
+++ b/cancelreader_select.go
@@ -1,5 +1,5 @@
-//go:build solaris || darwin || freebsd || netbsd || openbsd
-// +build solaris darwin freebsd netbsd openbsd
+//go:build solaris || darwin || freebsd || netbsd || openbsd || dragonfly
+// +build solaris darwin freebsd netbsd openbsd dragonfly
 
 // nolint:revive
 package tea


### PR DESCRIPTION
I'm noticing `dragonfly` build tags are missing in places where we otherwise support BSD. This update corrects that.