### PR TITLE
Fix links in commands README

### DIFF
--- a/tutorials/commands/README.md
+++ b/tutorials/commands/README.md
@@ -7,8 +7,8 @@ understanding of [the first tutorial][basics].
 
 You can find the non-annotated version of this program [on GitHub][source].
 
-[basics]: http://github.com/charmbracelet/bubbletea/tree/master/tutorials/basics
-[source]: https://github.com/charmbracelet/bubbletea/master/tutorials/commands
+[basics]: https://github.com/charmbracelet/bubbletea/tree/master/tutorials/basics
+[source]: https://github.com/charmbracelet/bubbletea/tree/master/tutorials/commands
 
 ## Let's Go!
 
@@ -220,6 +220,10 @@ Bubble Tea [example programs][examples] as well as [Bubbles][bubbles],
 a component library for Bubble Tea.
 
 And, of course, check out the [Go Docs][docs].
+
+[bubbles]: https://github.com/charmbracelet/bubbles
+[docs]: https://pkg.go.dev/github.com/charmbracelet/bubbletea?tab=doc
+[examples]: https://github.com/charmbracelet/bubbletea/tree/master/examples
 
 ## Additional Resources
 


### PR DESCRIPTION
Slightly related: https://github.com/charmbracelet/bubbletea/pull/164/files

Although I think this PR fixes it more in line with the main README using Markdown variables instead of hardcoding the links.

The link in `[source]` was missing `tree/` which ended up in a 404. This can be seen by clicking 'on GitHub' in the first paragraph [here](https://github.com/charmbracelet/bubbletea/blob/master/tutorials/commands/README.md).

Also the `[bubbles]`, `[docs]` and `[examples]` variables were missing from this README. They're present in the main one [here](https://github.com/charmbracelet/bubbletea/blob/master/README.md?plain=1#L255-L256) and [here](https://github.com/charmbracelet/bubbletea/blob/master/README.md?plain=1#L266) but were just showing as unformatted when viewing the [commands README](https://github.com/charmbracelet/bubbletea/blob/master/tutorials/commands/README.md#now-what)

![image](https://user-images.githubusercontent.com/11819124/147705645-5801b0cb-0f1a-4880-9e5c-4cf196478c86.png)
