### PR TITLE
Add separate sets of hard- and soft-enforced linters

### DIFF
--- a/.github/workflows/lint-soft.yml
+++ b/.github/workflows/lint-soft.yml
@@ -1,11 +1,11 @@
-name: lint
+name: lint-soft
 on:
   push:
   pull_request:
 
 jobs:
   golangci:
-    name: lint
+    name: lint-soft
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,6 +13,6 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: golangci-lint command line arguments.
-          #args:
+          args: --config .golangci-soft.yml --issues-exit-code=0
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true

--- a/.github/workflows/lint-soft.yml
+++ b/.github/workflows/lint-soft.yml
@@ -3,6 +3,11 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
 jobs:
   golangci:
     name: lint-soft

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,11 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+
 jobs:
   golangci:
     name: lint

--- a/.golangci-soft.yml
+++ b/.golangci-soft.yml
@@ -1,0 +1,47 @@
+run:
+  tests: false
+
+issues:
+  include:
+    - EXC0001
+    - EXC0005
+    - EXC0011
+    - EXC0012
+    - EXC0013
+
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  enable:
+    # - dupl
+    - exhaustive
+    # - exhaustivestruct
+    - goconst
+    - godot
+    - godox
+    - gomnd
+    - gomoddirectives
+    - goprintffuncname
+    - ifshort
+    # - lll
+    - misspell
+    - nakedret
+    - nestif
+    - noctx
+    - nolintlint
+    - prealloc
+    - wrapcheck
+
+  # disable default linters, they are already enabled in .golangci.yml
+  disable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,20 +15,15 @@ issues:
 linters:
   enable:
     - bodyclose
-    - dupl
     - exportloopref
-    - goconst
-    - godot
-    - godox
     - goimports
-    - goprintffuncname
     - gosec
-    - ifshort
-    - misspell
-    - prealloc
+    - nilerr
+    - predeclared
     - revive
     - rowserrcheck
     - sqlclosecheck
+    - tparallel
     - unconvert
     - unparam
     - whitespace

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -14,7 +14,7 @@ func (p *Program) initInput() error {
 	if f, ok := p.input.(*os.File); ok {
 		c, err := console.ConsoleFromFile(f)
 		if err != nil {
-			return nil
+			return nil //nolint:nilerr // ignore error, this was just a test
 		}
 		p.console = c
 	}


### PR DESCRIPTION
Soft-enforced linters will only annotate code changes, hard-enforced linters actually make the workflow fail if they encounter an issue.

You can run the soft linters manually on your machine:

```bash
golangci-lint run --config .golangci-soft.yml
```