### PR TITLE
Always redraw when toggling the altscreen

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -234,6 +234,7 @@ func (r *standardRenderer) altScreen() bool {
 
 func (r *standardRenderer) setAltScreen(v bool) {
 	r.altScreenActive = v
+	r.repaint()
 }
 
 // setIgnoredLines specifies lines not to be touched by the standard Bubble Tea


### PR DESCRIPTION
This update fixes an issue where toggling the altscreen results in a blank screen if the return value of the `View` has not changed.

Closes #183.