### PR TITLE
Fix list-default example

### DIFF
--- a/examples/list-default/main.go
+++ b/examples/list-default/main.go
@@ -77,8 +77,7 @@ func main() {
 	m := model{list: list.NewModel(items, list.NewDefaultDelegate(), 0, 0)}
 	m.list.Title = "My Fave Things"
 
-	p := tea.NewProgram(m)
-	p.EnterAltScreen()
+	p := tea.NewProgram(m, tea.WithAltScreen())
 
 	if err := p.Start(); err != nil {
 		fmt.Println("Error running program:", err)

--- a/examples/list-default/main.go
+++ b/examples/list-default/main.go
@@ -31,7 +31,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		if msg.String() == "ctrl+c" {
-			return m, nil
+			return m, tea.Quit
 		}
 	case tea.WindowSizeMsg:
 		top, right, bottom, left := docStyle.GetMargin()


### PR DESCRIPTION
- Application has been handling `Ctrl+c`, but not doing anything. So fixed it to exit the program like any other apps.
- Fix to use `WithAltScreen` option instead of the deprecated `EnterAltScreen`.