### PR TITLE
Migrate from `NewModel()` to `New()` in examples for Bubbles-related stuff

### DIFF
--- a/examples/help/main.go
+++ b/examples/help/main.go
@@ -75,7 +75,7 @@ type model struct {
 func newModel() model {
 	return model{
 		keys:       keys,
-		help:       help.NewModel(),
+		help:       help.New(),
 		inputStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("#FF75B7")),
 	}
 }

--- a/examples/list-default/main.go
+++ b/examples/list-default/main.go
@@ -74,7 +74,7 @@ func main() {
 		item{title: "Terrycloth", desc: "In other words, towel fabric"},
 	}
 
-	m := model{list: list.NewModel(items, list.NewDefaultDelegate(), 0, 0)}
+	m := model{list: list.New(items, list.NewDefaultDelegate(), 0, 0)}
 	m.list.Title = "My Fave Things"
 
 	p := tea.NewProgram(m, tea.WithAltScreen())

--- a/examples/list-fancy/main.go
+++ b/examples/list-fancy/main.go
@@ -95,7 +95,7 @@ func newModel() model {
 
 	// Setup list
 	delegate := newItemDelegate(delegateKeys)
-	groceryList := list.NewModel(items, delegate, 0, 0)
+	groceryList := list.New(items, delegate, 0, 0)
 	groceryList.Title = "Groceries"
 	groceryList.Styles.Title = titleStyle
 	groceryList.AdditionalFullHelpKeys = func() []key.Binding {

--- a/examples/list-simple/main.go
+++ b/examples/list-simple/main.go
@@ -111,7 +111,7 @@ func main() {
 
 	const defaultWidth = 20
 
-	l := list.NewModel(items, itemDelegate{}, defaultWidth, listHeight)
+	l := list.New(items, itemDelegate{}, defaultWidth, listHeight)
 	l.Title = "What do you want for dinner?"
 	l.SetShowStatusBar(false)
 	l.SetFilteringEnabled(false)

--- a/examples/paginator/main.go
+++ b/examples/paginator/main.go
@@ -21,7 +21,7 @@ func newModel() model {
 		items = append(items, text)
 	}
 
-	p := paginator.NewModel()
+	p := paginator.New()
 	p.Type = paginator.Dots
 	p.PerPage = 10
 	p.ActiveDot = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{Light: "235", Dark: "252"}).Render("•")

--- a/examples/pipe/main.go
+++ b/examples/pipe/main.go
@@ -56,7 +56,7 @@ type model struct {
 }
 
 func newModel(initialValue string) (m model) {
-	i := textinput.NewModel()
+	i := textinput.New()
 	i.Prompt = ""
 	i.CursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
 	i.Width = 48

--- a/examples/progress-animated/main.go
+++ b/examples/progress-animated/main.go
@@ -27,7 +27,7 @@ var helpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#626262")).Render
 
 func main() {
 	m := model{
-		progress: progress.NewModel(progress.WithDefaultGradient()),
+		progress: progress.New(progress.WithDefaultGradient()),
 	}
 
 	if err := tea.NewProgram(m).Start(); err != nil {

--- a/examples/progress-static/main.go
+++ b/examples/progress-static/main.go
@@ -35,7 +35,7 @@ const (
 var helpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#626262")).Render
 
 func main() {
-	prog := progress.NewModel(progress.WithScaledGradient("#FF7CCB", "#FDFF8C"))
+	prog := progress.New(progress.WithScaledGradient("#FF7CCB", "#FDFF8C"))
 
 	if err := tea.NewProgram(model{progress: prog}).Start(); err != nil {
 		fmt.Println("Oh no!", err)

--- a/examples/realtime/main.go
+++ b/examples/realtime/main.go
@@ -82,7 +82,7 @@ func main() {
 
 	p := tea.NewProgram(model{
 		sub:     make(chan struct{}),
-		spinner: spinner.NewModel(),
+		spinner: spinner.New(),
 	})
 
 	if p.Start() != nil {

--- a/examples/send-msg/main.go
+++ b/examples/send-msg/main.go
@@ -45,7 +45,7 @@ type model struct {
 
 func newModel() model {
 	const numLastResults = 5
-	s := spinner.NewModel()
+	s := spinner.New()
 	s.Style = spinnerStyle
 	return model{
 		spinner: s,

--- a/examples/spinner/main.go
+++ b/examples/spinner/main.go
@@ -21,7 +21,7 @@ type model struct {
 }
 
 func initialModel() model {
-	s := spinner.NewModel()
+	s := spinner.New()
 	s.Spinner = spinner.Dot
 	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
 	return model{spinner: s}

--- a/examples/spinners/main.go
+++ b/examples/spinners/main.go
@@ -80,7 +80,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m *model) resetSpinner() {
-	m.spinner = spinner.NewModel()
+	m.spinner = spinner.New()
 	m.spinner.Style = spinnerStyle
 	m.spinner.Spinner = spinners[m.index]
 }

--- a/examples/textinput/main.go
+++ b/examples/textinput/main.go
@@ -28,7 +28,7 @@ type model struct {
 }
 
 func initialModel() model {
-	ti := textinput.NewModel()
+	ti := textinput.New()
 	ti.Placeholder = "Pikachu"
 	ti.Focus()
 	ti.CharLimit = 156

--- a/examples/textinputs/main.go
+++ b/examples/textinputs/main.go
@@ -38,7 +38,7 @@ func initialModel() model {
 
 	var t textinput.Model
 	for i := range m.inputs {
-		t = textinput.NewModel()
+		t = textinput.New()
 		t.CursorStyle = cursorStyle
 		t.CharLimit = 32
 

--- a/examples/tui-daemon-combo/main.go
+++ b/examples/tui-daemon-combo/main.go
@@ -65,7 +65,7 @@ type model struct {
 func newModel() model {
 	const showLastResults = 5
 
-	sp := spinner.NewModel()
+	sp := spinner.New()
 	sp.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("206"))
 
 	return model{


### PR DESCRIPTION
As of Bubbles `v0.10.0` the convention has changed from `NewModel` to `New`. `NewModel` will still work for now, in a deprecated fashion, in packages where it existed previously.