### PR TITLE
feat: tea.Batch() returns nil if all Cmds were nil

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -111,6 +111,8 @@ type Program struct {
 
 // Batch performs a bunch of commands concurrently with no ordering guarantees
 // about the results. Use a Batch to return several commands.
+// If the slice of commands has a length of 0 or only contains nil commands,
+// the function itself returns nil.
 //
 // Example:
 //

--- a/tea.go
+++ b/tea.go
@@ -122,6 +122,17 @@ func Batch(cmds ...Cmd) Cmd {
 	if len(cmds) == 0 {
 		return nil
 	}
+
+	nilCount := 0
+	for _, cmd := range cmds {
+		if cmd == nil {
+			nilCount++
+		}
+	}
+	if nilCount == len(cmds) {
+		return nil
+	}
+
 	return func() Msg {
 		return batchMsg(cmds)
 	}


### PR DESCRIPTION
hi,

as far as i can tell, `tea.Batch()` semantically should return `nil` if there is no `tea.Cmd`. this is not documented, but i base this assumption on the length check in its implementation:
https://github.com/charmbracelet/bubbletea/blob/608fde59edde447d4f34ce7e8ddc8bb3d54b80fa/tea.go#L112-L128

however, if the `[]tea.Cmd` passed to it contains only `nil` item(s), a batch cmd containing only `nil` is returned, instead of just `nil`.
a `[]tea.Cmd` that just contains only `nil` can easily happen when you expect multiple `tea.Cmd` in your `Update()` function and start by initializing the slice, but then don't check every cmd returned by a subcall for `nil` first before appending to this slice.
this happens for example in `bubbles.List`:
https://github.com/charmbracelet/bubbles/blob/7ecce3fb97420ba2a44e3453c9291a98d5894d9d/list/list.go#L682-L683

this bit me a little bit, as i pass the `tea.Msg` to a submodel, and wanted to check if it "consumed" the message by checking if the returned `tea.Cmd` is `nil`. if it is not consumed, i consume it in the main model (think pressing `:` in vim insert mode vs normal mode). i used the pattern from the `List` bubble in my own code, but even when i checked everywhere for `nil` before appending, i realized that the `List` bubble itself returns a batch cmd with just a nil inside it and i'd have to check for that too.

for now i just worked around this by explicitly telling my main model if the message was consumed, which is fine too. but i think it would be more comfortable and true to the intention of the `tea.Batch()` function to e.g. check if the slice given to it contains only `nil`s. not only can i just still check whether the `tea.Cmd` a model returns is simply `nil` or not without having to know that it is a batch cmd, but i also don't have to check every returned cmd before appending it to such a slice to make this work.

the reasons i can think of against this are:
- the slight performance hit of iterating through the slice to check the items for `nil`
  - but i think generally the slice should be pretty short
- the behaviour change
  - but not if you consider this a bugfix to implement the intended behaviour

what do you think?

