### PR TITLE
Handle nil cmds in tea.Sequentially

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -68,6 +68,9 @@ func Tick(d time.Duration, fn func(time.Time) Msg) Cmd {
 func Sequentially(cmds ...Cmd) Cmd {
 	return func() Msg {
 		for _, cmd := range cmds {
+			if cmd == nil {
+				continue
+			}
 			if msg := cmd(); msg != nil {
 				return msg
 			}


### PR DESCRIPTION
There are functions which may or may not return a `tea.Cmd` when they're done. Currently, I have to handle these nil values myself, leading to a lot of extra code.

It would be fantastic if `tea.Sequentially` would handle this for me.