### PR TITLE
fix: don't check terminal size if we're not writing to a terminal

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -439,7 +439,7 @@ func (p *Program) StartReturningModel() (Model, error) {
 		defer close(readLoopDone)
 	}
 
-	if f, ok := p.output.(*os.File); ok {
+	if f, ok := p.output.(*os.File); ok && isatty.IsTerminal(f.Fd()) {
 		// Get the initial terminal size and send it to the program.
 		go func() {
 			w, h, err := term.GetSize(int(f.Fd()))


### PR DESCRIPTION
If output isn't a terminal, we can't retrieve the size of terminal. Trying to do so causes an ioctl error.