### PR TITLE
add: Exec, program.ReleaseTerminal and RestoreTerminal to re-use input and terminal

### DIFF
--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -49,7 +49,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m model) View() string {
 	if m.err != nil {
-		return "Error: " + m.err.Error()
+		return "Error: " + m.err.Error() + "\n"
 	}
 	return "Press 'e' to open your EDITOR.\nPress 'a' to toggle the altscreen\nPress 'q' to quit.\n"
 }

--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -32,7 +32,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		case "e":
 			c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
-			return m, tea.Exec(c, func(err error) tea.Msg {
+			return m, tea.Exec(tea.WrapExecCommand(c), func(err error) tea.Msg {
 				return editorFinishedMsg{err}
 			})
 		case "ctrl+c", "q":

--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+var (
+	p *tea.Program
+)
+
+type model struct {
+	err error
+}
+
+func (m model) Init() tea.Cmd {
+	return nil
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "e":
+			if err := p.ReleaseTerminal(); err != nil {
+				m.err = err
+				return m, nil
+			}
+
+			c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
+			c.Stdin = os.Stdin
+			c.Stdout = os.Stdout
+			c.Stderr = os.Stderr
+			m.err = c.Run()
+
+			if err := p.RestoreTerminal(); err != nil {
+				m.err = err
+			}
+
+			return m, nil
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m model) View() string {
+	if m.err != nil {
+		return "Error: " + m.err.Error()
+	}
+	return "Press e to open Vim. Press q to quit."
+}
+
+func main() {
+	m := model{}
+	p = tea.NewProgram(m)
+	if err := p.Start(); err != nil {
+		fmt.Println("Error running program:", err)
+		os.Exit(1)
+	}
+}

--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -33,23 +33,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		case "e":
-			if err := p.ReleaseTerminal(); err != nil {
-				m.err = err
-				return m, nil
-			}
-
 			c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
-			c.Stdin = os.Stdin
-			c.Stdout = os.Stdout
-			c.Stderr = os.Stderr
-			m.err = c.Run()
-
-			if err := p.RestoreTerminal(); err != nil {
-				m.err = err
-			}
-
-			return m, nil
+			return m, tea.Exec("editor", c)
 		case "ctrl+c", "q":
+			return m, tea.Quit
+		}
+	case tea.ExecFinishedMsg:
+		if msg.Err != nil {
+			m.err = msg.Err
 			return m, tea.Quit
 		}
 	}

--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -10,6 +10,13 @@ import (
 
 type editorFinishedMsg struct{ err error }
 
+func openEditor() tea.Cmd {
+	c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
+	return tea.Exec(tea.WrapExecCommand(c), func(err error) tea.Msg {
+		return editorFinishedMsg{err}
+	})
+}
+
 type model struct {
 	altscreenActive bool
 	err             error
@@ -31,10 +38,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		case "e":
-			c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
-			return m, tea.Exec(tea.WrapExecCommand(c), func(err error) tea.Msg {
-				return editorFinishedMsg{err}
-			})
+			return m, openEditor()
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		}

--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -13,7 +13,8 @@ var (
 )
 
 type model struct {
-	err error
+	altscreenActive bool
+	err             error
 }
 
 func (m model) Init() tea.Cmd {
@@ -24,6 +25,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "a":
+			m.altscreenActive = !m.altscreenActive
+			cmd := tea.EnterAltScreen
+			if !m.altscreenActive {
+				cmd = tea.ExitAltScreen
+			}
+			return m, cmd
 		case "e":
 			if err := p.ReleaseTerminal(); err != nil {
 				m.err = err
@@ -52,7 +60,7 @@ func (m model) View() string {
 	if m.err != nil {
 		return "Error: " + m.err.Error()
 	}
-	return "Press e to open Vim. Press q to quit."
+	return "Press 'e' to open your EDITOR.\nPress 'a' to toggle the altscreen\nPress 'q' to quit.\n"
 }
 
 func main() {

--- a/renderer.go
+++ b/renderer.go
@@ -15,7 +15,10 @@ type renderer interface {
 	// output at its discretion.
 	write(string)
 
-	// Request a full re-render.
+	// Request a full re-render. Note that this will not trigger a render
+	// immediately. Rather, this method causes the next render to be a full
+	// repaint. Because of this, it's safe to call this method multiple times
+	// in succession.
 	repaint()
 
 	// Whether or not the alternate screen buffer is enabled.
@@ -25,3 +28,6 @@ type renderer interface {
 	// does not actually toggle the alternate screen buffer.
 	setAltScreen(bool)
 }
+
+// repaintMsg forces a full repaint.
+type repaintMsg struct{}

--- a/screen.go
+++ b/screen.go
@@ -42,3 +42,12 @@ func changeScrollingRegion(w io.Writer, top, bottom int) {
 func cursorBack(w io.Writer, n int) {
 	fmt.Fprintf(w, te.CSI+te.CursorBackSeq, n)
 }
+
+func enterAltScreen(w io.Writer) {
+	fmt.Fprintf(w, te.CSI+te.AltScreenSeq)
+	moveCursor(w, 0, 0)
+}
+
+func exitAltScreen(w io.Writer) {
+	fmt.Fprintf(w, te.CSI+te.ExitAltScreenSeq)
+}

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -345,6 +345,11 @@ func (r *standardRenderer) insertBottom(lines []string, topBoundary, bottomBound
 // handleMessages handles internal messages for the renderer.
 func (r *standardRenderer) handleMessages(msg Msg) {
 	switch msg := msg.(type) {
+	case repaintMsg:
+		// Force a repaint by clearing the render cache as we slide into a
+		// render.
+		r.repaint()
+
 	case WindowSizeMsg:
 		r.mtx.Lock()
 		r.width = msg.Width

--- a/tea.go
+++ b/tea.go
@@ -677,6 +677,9 @@ func (p *Program) RestoreTerminal() error {
 		return err
 	}
 
-	p.renderer.repaint()
+	go func() {
+		p.msgs <- repaintMsg{}
+	}()
+
 	return nil
 }

--- a/tea.go
+++ b/tea.go
@@ -660,14 +660,15 @@ func (p *Program) DisableMouseAllMotion() {
 }
 
 // ReleaseTerminal restores the original terminal state and cancels the input
-// reader.
+// reader. You can return control to the Program with RestoreTerminal.
 func (p *Program) ReleaseTerminal() error {
 	p.cancelInput()
 	return p.restoreTerminal()
 }
 
-// RestoreTerminal sets up the input reader & terminal state and triggers a
-// repaint.
+// RestoreTerminal reinitializes the Program's input reader, restores the
+// terminal to the former state when the program was running, and repaints.
+// Use it to reinitialize a Program after running ReleaseTerminal.
 func (p *Program) RestoreTerminal() error {
 	if err := p.initTerminal(); err != nil {
 		return err

--- a/tea.go
+++ b/tea.go
@@ -249,29 +249,33 @@ func HideCursor() Msg {
 // resumes. It's useful for spawning other interactive applications such as
 // editors and shells from within a Program.
 //
+// To produce the command, pass an *exec.Command and a function which returns
+// a message containing the error which may have occured when running the
+// *exec.Command.
+//
+//     type VimFinishedMsg struct { err error }
+//
+//     c := exec.Command("vim file.txt")
+//
+//     cmd := Exec(c, func(err error) Msg {
+//         return VimFinishedMsg{err: error}
+//     })
+//
 // For non-interactive i/o you should use a Cmd (that is, a tea.Cmd).
-func Exec(id string, cmd *exec.Cmd) Cmd {
+func Exec(c *exec.Cmd, fn execCallback) Cmd {
 	return func() Msg {
-		return execMsg{id: id, cmd: cmd}
+		return execMsg{cmd: c, fn: fn}
 	}
 }
 
+// execCallback is used when executing an *exec.Command to return a message
+// with an error, which may or may not be nil.
+type execCallback func(error) Msg
+
 // execMsg is used internally to run an *exec.Cmd sent with Exec.
 type execMsg struct {
-	id  string
 	cmd *exec.Cmd
-}
-
-// ExecFinishedMsg is sent afer executing an *exec.Cmd with the Exec command.
-// If an error
-type ExecFinishedMsg struct {
-	ID  string
-	Err error
-}
-
-// Error implements the Error interface.
-func (e ExecFinishedMsg) Error() string {
-	return e.Err.Error()
+	fn  execCallback
 }
 
 // hideCursorMsg is an internal command used to hide the cursor. You can send
@@ -549,7 +553,7 @@ func (p *Program) StartReturningModel() (Model, error) {
 
 			case execMsg:
 				// Note: this blocks.
-				p.exec(msg.cmd, msg.id)
+				p.exec(msg.cmd, msg.fn)
 			}
 
 			// Process internal messages for the renderer.
@@ -726,10 +730,10 @@ func (p *Program) RestoreTerminal() error {
 }
 
 // exec runs an *exec.Cmd and delivers the results to the program.
-func (p *Program) exec(c *exec.Cmd, id string) {
+func (p *Program) exec(c *exec.Cmd, fn execCallback) {
 	if err := p.ReleaseTerminal(); err != nil {
 		// If we can't release input, abort.
-		go p.Send(ExecFinishedMsg{ID: id, Err: err})
+		go p.Send(fn(err))
 		return
 	}
 
@@ -750,11 +754,11 @@ func (p *Program) exec(c *exec.Cmd, id string) {
 	// Execute system command.
 	if err := c.Run(); err != nil {
 		_ = p.RestoreTerminal() // also try to restore the terminal.
-		go p.Send(ExecFinishedMsg{ID: id, Err: err})
+		go p.Send(fn(err))
 		return
 	}
 
 	// Have the program re-capture input.
 	err := p.RestoreTerminal()
-	go p.Send(ExecFinishedMsg{ID: id, Err: err})
+	go p.Send(fn(err))
 }

--- a/tea.go
+++ b/tea.go
@@ -261,6 +261,10 @@ func HideCursor() Msg {
 //         return VimFinishedMsg{err: error}
 //     })
 //
+// Or, if you don't care about errors you could simply:
+//
+//     cmd := Exec(exec.Command(vim file.txt"), nil)
+//
 // For non-interactive i/o you should use a Cmd (that is, a tea.Cmd).
 func Exec(c *exec.Cmd, fn execCallback) Cmd {
 	return func() Msg {
@@ -733,7 +737,9 @@ func (p *Program) RestoreTerminal() error {
 func (p *Program) exec(c *exec.Cmd, fn execCallback) {
 	if err := p.ReleaseTerminal(); err != nil {
 		// If we can't release input, abort.
-		go p.Send(fn(err))
+		if fn != nil {
+			go p.Send(fn(err))
+		}
 		return
 	}
 
@@ -754,11 +760,15 @@ func (p *Program) exec(c *exec.Cmd, fn execCallback) {
 	// Execute system command.
 	if err := c.Run(); err != nil {
 		_ = p.RestoreTerminal() // also try to restore the terminal.
-		go p.Send(fn(err))
+		if fn != nil {
+			go p.Send(fn(err))
+		}
 		return
 	}
 
 	// Have the program re-capture input.
 	err := p.RestoreTerminal()
-	go p.Send(fn(err))
+	if fn != nil {
+		go p.Send(fn(err))
+	}
 }

--- a/tea.go
+++ b/tea.go
@@ -717,7 +717,10 @@ func (p *Program) ReleaseTerminal() error {
 	p.ignoreSignals = true
 	p.cancelInput()
 	p.altScreenWasActive = p.altScreenActive
-	p.ExitAltScreen() // no-op if not active
+	if p.altScreenActive {
+		p.ExitAltScreen()
+		time.Sleep(time.Millisecond * 10) // give the terminal a moment to catch up
+	}
 	return p.restoreTerminal()
 }
 

--- a/tea.go
+++ b/tea.go
@@ -591,8 +591,7 @@ func (p *Program) EnterAltScreen() {
 		return
 	}
 
-	fmt.Fprintf(p.output, te.CSI+te.AltScreenSeq)
-	moveCursor(p.output, 0, 0)
+	enterAltScreen(p.output)
 
 	p.altScreenActive = true
 	if p.renderer != nil {
@@ -611,7 +610,7 @@ func (p *Program) ExitAltScreen() {
 		return
 	}
 
-	fmt.Fprintf(p.output, te.CSI+te.ExitAltScreenSeq)
+	exitAltScreen(p.output)
 
 	p.altScreenActive = false
 	if p.renderer != nil {

--- a/tea.go
+++ b/tea.go
@@ -246,10 +246,10 @@ func HideCursor() Msg {
 	return hideCursorMsg{}
 }
 
-// Exec runs the given ExecCommand in a blocking fashion, effectively pausing the
-// Program while the command is running. After the *exec.Cmd exists the Program
-// resumes. It's useful for spawning other interactive applications such as
-// editors and shells from within a Program.
+// Exec runs the given ExecCommand in a blocking fashion, effectively pausing
+// the Program while the command is running. After the *exec.Cmd exists the
+// Program resumes. It's useful for spawning other interactive applications
+// such as editors and shells from within a Program.
 //
 // To produce the command, pass an *exec.Command and a function which returns
 // a message containing the error which may have occurred when running the
@@ -756,14 +756,17 @@ type ExecCommand interface {
 	SetStderr(io.Writer)
 }
 
-// WrapExecCommand wraps a exec.Cmd to be compatible with the Command interface.
+// WrapExecCommand wraps an exec.Cmd so that it satisfies the ExecCommand
+// interface.
 func WrapExecCommand(c *exec.Cmd) ExecCommand {
 	return &osExecCommand{Cmd: c}
 }
 
+// osExecCommand is a layer over an exec.Cmd that satisfies the ExecCommand
+// interface.
 type osExecCommand struct{ *exec.Cmd }
 
-// SetStdin to comply with the Command interface.
+// SetStdin sets stdin on underlying exec.Cmd to the given io.Reader.
 func (c *osExecCommand) SetStdin(r io.Reader) {
 	// If unset, have the command use the same input as the terminal.
 	if c.Stdin == nil {
@@ -771,7 +774,7 @@ func (c *osExecCommand) SetStdin(r io.Reader) {
 	}
 }
 
-// SetStdout to comply with the Command interface.
+// SetStdout sets stdout on underlying exec.Cmd to the given io.Writer.
 func (c *osExecCommand) SetStdout(w io.Writer) {
 	// If unset, have the command use the same output as the terminal.
 	if c.Stdout == nil {
@@ -779,7 +782,7 @@ func (c *osExecCommand) SetStdout(w io.Writer) {
 	}
 }
 
-// SetStderr to comply with the Command interface.
+// SetStderr sets stderr on the underlying exec.Cmd to the given io.Writer.
 func (c *osExecCommand) SetStderr(w io.Writer) {
 	// If unset, use stderr for the command's stderr
 	if c.Stderr == nil {
@@ -787,7 +790,7 @@ func (c *osExecCommand) SetStderr(w io.Writer) {
 	}
 }
 
-// exec runs a Command and delivers the results to the program.
+// exec runs an ExecCommand and delivers the results to the program as a Msg.
 func (p *Program) exec(c ExecCommand, fn ExecCallback) {
 	if err := p.ReleaseTerminal(); err != nil {
 		// If we can't release input, abort.

--- a/tea.go
+++ b/tea.go
@@ -250,7 +250,7 @@ func HideCursor() Msg {
 // editors and shells from within a Program.
 //
 // To produce the command, pass an *exec.Command and a function which returns
-// a message containing the error which may have occured when running the
+// a message containing the error which may have occurred when running the
 // *exec.Command.
 //
 //     type VimFinishedMsg struct { err error }

--- a/tea.go
+++ b/tea.go
@@ -745,7 +745,7 @@ func (p *Program) RestoreTerminal() error {
 }
 
 // ExecCommand can be implemented to execute things in the current
-// terminal using the Exec message.
+// terminal using the Exec Cmd.
 type ExecCommand interface {
 	Run() error
 	SetStdin(io.Reader)

--- a/tea.go
+++ b/tea.go
@@ -628,7 +628,7 @@ func (p *Program) shutdown(kill bool) {
 	p.ExitAltScreen()
 	p.DisableMouseCellMotion()
 	p.DisableMouseAllMotion()
-	_ = p.restoreTerminal()
+	_ = p.restoreTerminalState()
 }
 
 // EnterAltScreen enters the alternate screen buffer, which consumes the entire
@@ -721,7 +721,7 @@ func (p *Program) ReleaseTerminal() error {
 		p.ExitAltScreen()
 		time.Sleep(time.Millisecond * 10) // give the terminal a moment to catch up
 	}
-	return p.restoreTerminal()
+	return p.restoreTerminalState()
 }
 
 // RestoreTerminal reinitializes the Program's input reader, restores the

--- a/tea.go
+++ b/tea.go
@@ -255,7 +255,7 @@ func HideCursor() Msg {
 //
 //     type VimFinishedMsg struct { err error }
 //
-//     c := exec.Command("vim file.txt")
+//     c := exec.Command("vim", "file.txt")
 //
 //     cmd := Exec(c, func(err error) Msg {
 //         return VimFinishedMsg{err: error}
@@ -263,7 +263,7 @@ func HideCursor() Msg {
 //
 // Or, if you don't care about errors you could simply:
 //
-//     cmd := Exec(exec.Command(vim file.txt"), nil)
+//     cmd := Exec(exec.Command("vim", "file.txt"), nil)
 //
 // For non-interactive i/o you should use a Cmd (that is, a tea.Cmd).
 func Exec(c *exec.Cmd, fn execCallback) Cmd {

--- a/tea.go
+++ b/tea.go
@@ -268,20 +268,20 @@ func HideCursor() Msg {
 //     cmd := Exec(exec.Command("vim", "file.txt"), nil)
 //
 // For non-interactive i/o you should use a Cmd (that is, a tea.Cmd).
-func Exec(c ExecCommand, fn execCallback) Cmd {
+func Exec(c ExecCommand, fn ExecCallback) Cmd {
 	return func() Msg {
 		return execMsg{cmd: c, fn: fn}
 	}
 }
 
-// execCallback is used when executing an *exec.Command to return a message
+// ExecCallback is used when executing an *exec.Command to return a message
 // with an error, which may or may not be nil.
-type execCallback func(error) Msg
+type ExecCallback func(error) Msg
 
 // execMsg is used internally to run an *exec.Cmd sent with Exec.
 type execMsg struct {
 	cmd ExecCommand
-	fn  execCallback
+	fn  ExecCallback
 }
 
 // hideCursorMsg is an internal command used to hide the cursor. You can send
@@ -782,7 +782,7 @@ func (c *osExecCommand) SetStderr(w io.Writer) {
 }
 
 // exec runs a Command and delivers the results to the program.
-func (p *Program) exec(c ExecCommand, fn execCallback) {
+func (p *Program) exec(c ExecCommand, fn ExecCallback) {
 	if err := p.ReleaseTerminal(); err != nil {
 		// If we can't release input, abort.
 		if fn != nil {

--- a/tty.go
+++ b/tty.go
@@ -1,5 +1,12 @@
 package tea
 
+import (
+	"errors"
+	"io"
+
+	"github.com/muesli/cancelreader"
+)
+
 func (p *Program) initTerminal() error {
 	err := p.initInput()
 	if err != nil {
@@ -28,4 +35,44 @@ func (p Program) restoreTerminal() error {
 	}
 
 	return p.restoreInput()
+}
+
+// initCancelReader (re)commences reading inputs.
+func (p *Program) initCancelReader() error {
+	var err error
+	p.cancelReader, err = cancelreader.NewReader(p.input)
+	if err != nil {
+		return err
+	}
+
+	p.readLoopDone = make(chan struct{})
+	go func() {
+		defer close(p.readLoopDone)
+
+		for {
+			if p.ctx.Err() != nil {
+				return
+			}
+
+			msgs, err := readInputs(p.cancelReader)
+			if err != nil {
+				if !errors.Is(err, io.EOF) && !errors.Is(err, cancelreader.ErrCanceled) {
+					p.errs <- err
+				}
+
+				return
+			}
+
+			for _, msg := range msgs {
+				p.msgs <- msg
+			}
+		}
+	}()
+
+	return nil
+}
+
+// cancelInput cancels the input reader.
+func (p *Program) cancelInput() {
+	p.cancelReader.Cancel()
 }

--- a/tty.go
+++ b/tty.go
@@ -24,7 +24,9 @@ func (p *Program) initTerminal() error {
 	return nil
 }
 
-func (p Program) restoreTerminal() error {
+// restoreTerminalState restores the terminal to the state prior to running the
+// Bubble Tea program.
+func (p Program) restoreTerminalState() error {
 	showCursor(p.output)
 
 	if p.console != nil {


### PR DESCRIPTION
`Program.ReleaseTerminal` makes Bubble Tea release the input / terminal, so users can spawn a sub-command. `Program.RestoreTerminal` sets the input reader up again and triggers a repaint.

`Exec` is provided as a `Cmd` interface, and should be the primary method for running a blocking `exec.Command` from within Bubble Tea.

Fixes #171.