### PR TITLE
fix: minor `tea.Cmd` tutorial syntax typo

### DIFF
--- a/tutorials/commands/README.md
+++ b/tutorials/commands/README.md
@@ -202,7 +202,7 @@ func checkSomeUrl(url string) tea.Cmd {
         c := &http.Client{Timeout: 10 * time.Second}
         res, err := c.Get(url)
         if err != nil {
-            return errMsg(err)
+            return errMsg{err}
         }
         return statusMsg(res.StatusCode)
     }


### PR DESCRIPTION
`errMsg(err)` -> `errMsg{err}`

Just noticed this while reading over the tutorial docs and figured I'd throw up a quick PR to address it.

Really enjoying the tooling so far, thank you for creating it!