### PR TITLE
Allow users to supply a custom cancelReader

### DIFF
--- a/cancelreader.go
+++ b/cancelreader.go
@@ -30,6 +30,9 @@ type fallbackCancelReader struct {
 // actually cancel an ongoing read but will immediately return on future reads
 // if it has been cancelled.
 func newFallbackCancelReader(reader io.Reader) (cancelReader, error) {
+	if cancelReader, ok := reader.(cancelReader); ok {
+		return cancelReader, nil
+	}
 	return &fallbackCancelReader{r: reader}, nil
 }
 


### PR DESCRIPTION
This enables callers to supply their own form of TTY cancellation.

We have our own Windows TTY library based on ConPTY, and would like
to use it with bubbletea, but it's not possible unless we can provide
our own form of read cancellation.

I'm not certain this is the best approach by any means, so suggestions are welcome!