### PR TITLE
fix: use more bulletproof GetFrameSize() list examples

### DIFF
--- a/examples/list-default/main.go
+++ b/examples/list-default/main.go
@@ -34,8 +34,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 	case tea.WindowSizeMsg:
-		top, right, bottom, left := docStyle.GetMargin()
-		m.list.SetSize(msg.Width-left-right, msg.Height-top-bottom)
+		h, v := docStyle.GetFrameSize()
+		m.list.SetSize(msg.Width-h, msg.Height-v)
 	}
 
 	var cmd tea.Cmd

--- a/examples/list-fancy/main.go
+++ b/examples/list-fancy/main.go
@@ -126,8 +126,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		topGap, rightGap, bottomGap, leftGap := appStyle.GetPadding()
-		m.list.SetSize(msg.Width-leftGap-rightGap, msg.Height-topGap-bottomGap)
+		h, v := appStyle.GetFrameSize()
+		m.list.SetSize(msg.Width-h, msg.Height-v)
 
 	case tea.KeyMsg:
 		// Don't match any of the keys below if we're actively filtering.


### PR DESCRIPTION
This is a small improvement to the list examples to help avoid a common pitfall we've been seeing with regard to lists being too tall in alt screen views. Thanks to @mrusme for spurring the fix.