### PR TITLE
adds Program.Write method

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -111,6 +111,14 @@ type Program struct {
 	windowsStdin *os.File //nolint:golint,structcheck,unused
 }
 
+// Write gives direct access to the underlying Writer. Useful for an inline
+// program that wants to print things to the terminal during its execution.
+func (p Program) Write(b []byte) (n int, err error) {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+	return p.output.Write(b)
+}
+
 // Batch performs a bunch of commands concurrently with no ordering guarantees
 // about the results. Use a Batch to return several commands.
 //


### PR DESCRIPTION
This method gives access to Program.output so one can write directly to the terminal's output.

# Use case

Your app is not fullscreen, and you want to print out some stuff to the terminal while the application is running.

You can do so by using `fmt.Println`, but looking at bubbleatea's code, there is a mutex for accessing `Program.output`. So this method politely grabs the mutex before trying to write to `Program.output`.

# Considerations

Maybe we don't want `tea.Program` to implement the `Writer` interface - in which case the method can be renamed to something else.