### PR TITLE
Doc: Add `Noted` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ For some Bubble Tea programs in production, see:
 * [tz](https://github.com/oz/tz): an aid for scheduling across multiple time zones
 * [Typer](https://github.com/maaslalani/typer): a typing test
 * [wishlist](https://github.com/charmbracelet/wishlist): an SSH directory
+* [Noted](https://github.com/torbratsberg/noted): Note viewer and manager
 
 [portal]: https://github.com/ZinoKader/portal
 


### PR DESCRIPTION
Added a project I've been working on to find and preview notes, to the README file.

Noted shows one of many ways you can use `viewports` from `bubbles` with `bubbletea`.

There might be enough bubbletea in the wild at this point, but here's another one.