### PR TITLE
docs: remove redundant 'of'

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ there are [Go Docs][docs].
 
 ## Debugging with Delve
 
-Since Bubble Tea apps assume control of of stdin and stdout, you’ll need to run
+Since Bubble Tea apps assume control of stdin and stdout, you’ll need to run
 delve in headless mode and then connect to it:
 
 ```bash


### PR DESCRIPTION
Small update to the README to remove a redundant 'of'