### PR TITLE
feat: allow to execute other things besides exec.Commands

### DIFF
--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -32,7 +32,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		case "e":
 			c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
-			return m, tea.Exec(c, func(err error) tea.Msg {
+			return m, tea.Exec(tea.WrapExecCommand(c), func(err error) tea.Msg {
 				return editorFinishedMsg{err}
 			})
 		case "ctrl+c", "q":

--- a/tea.go
+++ b/tea.go
@@ -267,7 +267,7 @@ func HideCursor() Msg {
 //     cmd := Exec(exec.Command("vim", "file.txt"), nil)
 //
 // For non-interactive i/o you should use a Cmd (that is, a tea.Cmd).
-func Exec(c *exec.Cmd, fn execCallback) Cmd {
+func Exec(c Command, fn execCallback) Cmd {
 	return func() Msg {
 		return execMsg{cmd: c, fn: fn}
 	}
@@ -279,7 +279,7 @@ type execCallback func(error) Msg
 
 // execMsg is used internally to run an *exec.Cmd sent with Exec.
 type execMsg struct {
-	cmd *exec.Cmd
+	cmd Command
 	fn  execCallback
 }
 
@@ -752,8 +752,42 @@ func (p *Program) RestoreTerminal() error {
 	return nil
 }
 
-// exec runs an *exec.Cmd and delivers the results to the program.
-func (p *Program) exec(c *exec.Cmd, fn execCallback) {
+// Command can be implemented to execute things in the current terminal using
+// the Exec message.
+type Command interface {
+	Run() error
+	SetStdin(io.Reader)
+	SetStdout(io.Writer)
+	SetStderr(io.Writer)
+}
+
+var _ Command = &ExecCmd{}
+
+// ExecCmd wraps a exec.Cmd to be compatible with the Command interface.
+type ExecCmd struct {
+	*exec.Cmd
+}
+
+func (c *ExecCmd) SetStdin(r io.Reader) {
+	if c.Stdin == nil {
+		c.Stdin = r
+	}
+}
+
+func (c *ExecCmd) SetStdout(w io.Writer) {
+	if c.Stdout == nil {
+		c.Stdout = w
+	}
+}
+
+func (c *ExecCmd) SetStderr(w io.Writer) {
+	if c.Stderr == nil {
+		c.Stderr = w
+	}
+}
+
+// exec runs a Command and delivers the results to the program.
+func (p *Program) exec(c Command, fn execCallback) {
 	if err := p.ReleaseTerminal(); err != nil {
 		// If we can't release input, abort.
 		if fn != nil {
@@ -764,17 +798,10 @@ func (p *Program) exec(c *exec.Cmd, fn execCallback) {
 
 	// If unset, have the command use the same input and output
 	// as the terminal.
-	if c.Stdin == nil {
-		c.Stdin = p.input
-	}
-	if c.Stdout == nil {
-		c.Stdout = p.output
-	}
-
+	c.SetStdin(p.input)
+	c.SetStdout(p.output)
 	// If unset, use stderr for the command's stderr
-	if c.Stderr == nil {
-		c.Stderr = os.Stderr
-	}
+	c.SetStderr(os.Stderr)
 
 	// Execute system command.
 	if err := c.Run(); err != nil {

--- a/tea.go
+++ b/tea.go
@@ -764,22 +764,23 @@ type Command interface {
 var _ Command = &ExecCmd{}
 
 // ExecCmd wraps a exec.Cmd to be compatible with the Command interface.
-type ExecCmd struct {
-	*exec.Cmd
-}
+type ExecCmd struct{ *exec.Cmd }
 
+// SetStdin to comply with the Command interface.
 func (c *ExecCmd) SetStdin(r io.Reader) {
 	if c.Stdin == nil {
 		c.Stdin = r
 	}
 }
 
+// SetStdout to comply with the Command interface.
 func (c *ExecCmd) SetStdout(w io.Writer) {
 	if c.Stdout == nil {
 		c.Stdout = w
 	}
 }
 
+// SetStderr to comply with the Command interface.
 func (c *ExecCmd) SetStderr(w io.Writer) {
 	if c.Stderr == nil {
 		c.Stderr = w


### PR DESCRIPTION
This provides an interface around exec.Cmd so users can execute other things as well (i.e. any go code).

The main usecase for this that I see is for wishlist, so we can ssh into something and back to the list later instead of quitting everything :)