### PR TITLE
fix(keys): spacebar now sends a `KeySpace`

### DIFF
--- a/key.go
+++ b/key.go
@@ -221,8 +221,9 @@ const (
 	KeyF20
 )
 
-// Mapping for control keys to friendly consts.
+// Mappings for control keys and other special keys to friendly consts.
 var keyNames = map[KeyType]string{
+	// Control keys.
 	keyNUL: "ctrl+@", // also ctrl+`
 	keySOH: "ctrl+a",
 	keySTX: "ctrl+b",
@@ -257,11 +258,12 @@ var keyNames = map[KeyType]string{
 	keyUS:  "ctrl+_",
 	keyDEL: "backspace",
 
+	// Other keys.
 	KeyRunes:    "runes",
 	KeyUp:       "up",
 	KeyDown:     "down",
 	KeyRight:    "right",
-	KeySpace:    " ",
+	KeySpace:    " ", // for backwards compatibility
 	KeyLeft:     "left",
 	KeyShiftTab: "shift+tab",
 	KeyHome:     "home",

--- a/key.go
+++ b/key.go
@@ -137,7 +137,6 @@ const (
 	keyGS  KeyType = 29  // group separator
 	keyRS  KeyType = 30  // record separator
 	keyUS  KeyType = 31  // unit separator
-	keySP  KeyType = 32  // space
 	keyDEL KeyType = 127 // delete. on most systems this is mapped to backspace, I hear
 )
 
@@ -148,7 +147,6 @@ const (
 	KeyEnter     KeyType = keyCR
 	KeyBackspace KeyType = keyDEL
 	KeyTab       KeyType = keyHT
-	KeySpace     KeyType = keySP
 	KeyEsc       KeyType = keyESC
 	KeyEscape    KeyType = keyESC
 
@@ -200,6 +198,7 @@ const (
 	KeyPgUp
 	KeyPgDown
 	KeyDelete
+	KeySpace
 	KeyF1
 	KeyF2
 	KeyF3
@@ -256,13 +255,13 @@ var keyNames = map[KeyType]string{
 	keyGS:  "ctrl+]",
 	keyRS:  "ctrl+^",
 	keyUS:  "ctrl+_",
-	keySP:  "space",
 	keyDEL: "backspace",
 
 	KeyRunes:    "runes",
 	KeyUp:       "up",
 	KeyDown:     "down",
 	KeyRight:    "right",
+	KeySpace:    " ",
 	KeyLeft:     "left",
 	KeyShiftTab: "shift+tab",
 	KeyHome:     "home",

--- a/key.go
+++ b/key.go
@@ -479,7 +479,15 @@ func readInputs(input io.Reader) ([]Msg, error) {
 		}, nil
 	}
 
-	// Welp, it's just a regular, ol' single rune
+	// If it's a space, override the type with KeySpace (but still include the
+	// rune).
+	if len(runes) == 1 && runes[0] == ' ' {
+		return []Msg{
+			KeyMsg(Key{Type: KeySpace, Runes: runes}),
+		}, nil
+	}
+
+	// Welp, it's just a regular, ol' single rune.
 	return []Msg{
 		KeyMsg(Key{Type: KeyRunes, Runes: runes}),
 	}, nil

--- a/key_test.go
+++ b/key_test.go
@@ -10,8 +10,8 @@ func TestKeyString(t *testing.T) {
 		if got := KeyMsg(Key{
 			Type: KeySpace,
 			Alt:  true,
-		}).String(); got != "alt+space" {
-			t.Fatalf(`expected a "alt+space", got %q`, got)
+		}).String(); got != "alt+ " {
+			t.Fatalf(`expected a "alt+ ", got %q`, got)
 		}
 	})
 

--- a/key_test.go
+++ b/key_test.go
@@ -8,7 +8,7 @@ import (
 func TestKeyString(t *testing.T) {
 	t.Run("alt+space", func(t *testing.T) {
 		if got := KeyMsg(Key{
-			Type: keySP,
+			Type: KeySpace,
 			Alt:  true,
 		}).String(); got != "alt+space" {
 			t.Fatalf(`expected a "alt+space", got %q`, got)
@@ -35,8 +35,8 @@ func TestKeyString(t *testing.T) {
 
 func TestKeyTypeString(t *testing.T) {
 	t.Run("space", func(t *testing.T) {
-		if got := keySP.String(); got != "space" {
-			t.Fatalf(`expected a "space", got %q`, got)
+		if got := KeySpace.String(); got != " " {
+			t.Fatalf(`expected a " ", got %q`, got)
 		}
 	})
 


### PR DESCRIPTION
This fixes a bug where the spacebar would send a `Key` with type `KeyRunes` instead of `KeySpace`. The `Runes` portion of `Key` will still contain a space after this fix.

```go
// This is what is sent when you press spacebar now
type Key struct {
    Type: KeySpace,
    Runes: []rune{' '},
}
```

* * *

## Changes:

- [x] remove keySP
- [x] assign KeySpace to " "
- [x] update tests to expect " " instead of "space"

I didn't make any changes to `readInput`. 
Manually tested `KeySpace` in addition to the tests with no issues and `KeySpace` worked as expected