### PR TITLE
fix: fix KeySpace with textinput bubble

### DIFF
--- a/key.go
+++ b/key.go
@@ -148,7 +148,6 @@ const (
 	KeyEnter     KeyType = keyCR
 	KeyBackspace KeyType = keyDEL
 	KeyTab       KeyType = keyHT
-	KeySpace     KeyType = keySP
 	KeyEsc       KeyType = keyESC
 	KeyEscape    KeyType = keyESC
 


### PR DESCRIPTION
## Changes

- [x] revert previous changes to KeySpace made in `master`
- [x] remove `KeySpace` and use `keySP` only

## Related Issues

https://github.com/charmbracelet/bubbles/issues/144
https://github.com/charmbracelet/bubbletea/issues/264

#264 - `tea.KeySpace` will no longer exist after this change, so their code will need to be refactored to check for " " instead