### PR TITLE
feat: obliterate type `KeySpace`

### DIFF
--- a/key.go
+++ b/key.go
@@ -198,7 +198,6 @@ const (
 	KeyPgUp
 	KeyPgDown
 	KeyDelete
-	KeySpace
 	KeyCtrlUp
 	KeyCtrlDown
 	KeyCtrlRight
@@ -275,7 +274,6 @@ var keyNames = map[KeyType]string{
 	KeyUp:             "up",
 	KeyDown:           "down",
 	KeyRight:          "right",
-	KeySpace:          " ", // for backwards compatibility
 	KeyLeft:           "left",
 	KeyShiftTab:       "shift+tab",
 	KeyHome:           "home",
@@ -551,14 +549,6 @@ func readInputs(input io.Reader) ([]Msg, error) {
 	if numBytes == 1 && r <= keyUS || r == keyDEL {
 		return []Msg{
 			KeyMsg(Key{Type: r}),
-		}, nil
-	}
-
-	// If it's a space, override the type with KeySpace (but still include the
-	// rune).
-	if runes[0] == ' ' {
-		return []Msg{
-			KeyMsg(Key{Type: KeySpace, Runes: runes}),
 		}, nil
 	}
 

--- a/key_test.go
+++ b/key_test.go
@@ -8,8 +8,9 @@ import (
 func TestKeyString(t *testing.T) {
 	t.Run("alt+space", func(t *testing.T) {
 		if got := KeyMsg(Key{
-			Type: KeySpace,
-			Alt:  true,
+			Type:  KeyRunes,
+			Runes: []rune{' '},
+			Alt:   true,
 		}).String(); got != "alt+ " {
 			t.Fatalf(`expected a "alt+ ", got %q`, got)
 		}
@@ -35,7 +36,10 @@ func TestKeyString(t *testing.T) {
 
 func TestKeyTypeString(t *testing.T) {
 	t.Run("space", func(t *testing.T) {
-		if got := KeySpace.String(); got != " " {
+		if got := KeyMsg(Key{
+			Type:  KeyRunes,
+			Runes: []rune{' '},
+		}).String(); got != " " {
 			t.Fatalf(`expected a " ", got %q`, got)
 		}
 	})


### PR DESCRIPTION
Treating a space differently from other runes was proving to cause more confusion that clarity. A working `KeySpace` was added in #289, however it was never released in a tagged version.