### PR TITLE
change(keys): spacebar sends a `KeySpace`

### DIFF
--- a/key.go
+++ b/key.go
@@ -198,6 +198,7 @@ const (
 	KeyPgUp
 	KeyPgDown
 	KeyDelete
+	KeySpace
 	KeyCtrlUp
 	KeyCtrlDown
 	KeyCtrlRight
@@ -274,6 +275,7 @@ var keyNames = map[KeyType]string{
 	KeyUp:             "up",
 	KeyDown:           "down",
 	KeyRight:          "right",
+	KeySpace:          " ", // for backwards compatibility
 	KeyLeft:           "left",
 	KeyShiftTab:       "shift+tab",
 	KeyHome:           "home",
@@ -549,6 +551,14 @@ func readInputs(input io.Reader) ([]Msg, error) {
 	if numBytes == 1 && r <= keyUS || r == keyDEL {
 		return []Msg{
 			KeyMsg(Key{Type: r}),
+		}, nil
+	}
+
+	// If it's a space, override the type with KeySpace (but still include the
+	// rune).
+	if runes[0] == ' ' {
+		return []Msg{
+			KeyMsg(Key{Type: KeySpace, Runes: runes}),
 		}, nil
 	}
 

--- a/key_test.go
+++ b/key_test.go
@@ -8,9 +8,8 @@ import (
 func TestKeyString(t *testing.T) {
 	t.Run("alt+space", func(t *testing.T) {
 		if got := KeyMsg(Key{
-			Type:  KeyRunes,
-			Runes: []rune{' '},
-			Alt:   true,
+			Type: KeySpace,
+			Alt:  true,
 		}).String(); got != "alt+ " {
 			t.Fatalf(`expected a "alt+ ", got %q`, got)
 		}
@@ -36,10 +35,7 @@ func TestKeyString(t *testing.T) {
 
 func TestKeyTypeString(t *testing.T) {
 	t.Run("space", func(t *testing.T) {
-		if got := KeyMsg(Key{
-			Type:  KeyRunes,
-			Runes: []rune{' '},
-		}).String(); got != " " {
+		if got := KeySpace.String(); got != " " {
 			t.Fatalf(`expected a " ", got %q`, got)
 		}
 	})


### PR DESCRIPTION
This update reverts the hasty #311 and reimplements @bashbunni's excellent #289.

After further pondering we've decided it makes the most sense to make the following small change to the message produced by the spacebar after all:

```go
// Before
Key{Type: KeyRunes, Runes: []rune{' '}}

// After!
Key{Type: KeySpace, Runes: []rune{' '}}
```

Note that the `String()` method will still return `" "` for backwards compatibility.

The reasoning for this change is that binding things to the spacebar is common, but doing so in a "safe" manner is currently a bit cumbersome. Consider the following:

```go
// For comparison
if msg.Type == tea.KeyEnter {

// Similar and straightforward
if msg.Type == tea.KeySpace {

// Urgh
if msg.Type == tea.KeyRunes && msg.String() == " " {

// Urghhhhh
if msg.Type == tea.KeyRunes && len(msg.Runes) == 1 && msg.Runes[0] == ' ' {
```

If course most of the time people simply:

```go
if msg.String() == " " {
```

So all-in-all this effectively is a minor change.

Also note that after this is released we'll need to address the issue in https://github.com/charmbracelet/bubbles/issues/144 accordingly.