### PR TITLE
docs: default to vim if no EDITOR on exec example

### DIFF
--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -11,7 +11,11 @@ import (
 type editorFinishedMsg struct{ err error }
 
 func openEditor() tea.Cmd {
-	c := exec.Command(os.Getenv("EDITOR")) //nolint:gosec
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vim"
+	}
+	c := exec.Command(editor) //nolint:gosec
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return editorFinishedMsg{err}
 	})


### PR DESCRIPTION
avoids `Error: fork/exec : no such file or directory` by using vim by default if no EDITOR is set.