### PR TITLE
Examples: Basic Chat Application with Multi-line Input

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -1,0 +1,102 @@
+package main
+
+// A simple program demonstrating the text input component from the Bubbles
+// component library.
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func main() {
+	p := tea.NewProgram(initialModel())
+
+	if err := p.Start(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type tickMsg struct{}
+type errMsg error
+
+type model struct {
+	viewport    viewport.Model
+	messages    []string
+	textInput   textinput.Model
+	senderStyle lipgloss.Style
+	err         error
+}
+
+func initialModel() model {
+	ti := textinput.New()
+	ti.Placeholder = "Send a message..."
+	ti.Focus()
+	ti.Prompt = "┃ "
+	ti.CharLimit = 280
+	ti.Width = 30
+	ti.Height = 3
+	ti.LineLimit = 10
+
+	vp := viewport.New(30, 10)
+	vp.SetContent(`Welcome to the Bubbles multi-line text input!
+Try typing any message and pressing ENTER.
+If you write a long message, it will automatically wrap :D
+	`)
+
+	return model{
+		textInput:   ti,
+		messages:    []string{},
+		viewport:    vp,
+		senderStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("5")),
+		err:         nil,
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var (
+		tiCmd tea.Cmd
+		vpCmd tea.Cmd
+	)
+
+	m.textInput, tiCmd = m.textInput.Update(msg)
+	m.viewport, vpCmd = m.viewport.Update(msg)
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			fmt.Println(m.textInput.Value())
+			return m, tea.Quit
+		case tea.KeyEnter:
+			m.messages = append(m.messages, m.senderStyle.Render("You: ")+m.textInput.Value())
+			m.viewport.SetContent(strings.Join(m.messages, "\n"))
+			m.textInput.Reset()
+			m.viewport.GotoBottom()
+		}
+
+	// We handle errors just like any other message
+	case errMsg:
+		m.err = msg
+		return m, nil
+	}
+
+	return m, tea.Batch(tiCmd, vpCmd)
+}
+
+func (m model) View() string {
+	return fmt.Sprintf(
+		"%s\n\n%s",
+		m.viewport.View(),
+		m.textInput.View(),
+	) + "\n\n"
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -15,3 +15,4 @@ require (
 )
 
 replace github.com/charmbracelet/bubbletea => ../
+replace github.com/charmbracelet/bubbles => ../../bubbles

--- a/examples/multiline-textinput/main.go
+++ b/examples/multiline-textinput/main.go
@@ -1,0 +1,80 @@
+package main
+
+// A simple program demonstrating the text input component from the Bubbles
+// component library.
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func main() {
+	p := tea.NewProgram(initialModel())
+
+	if err := p.Start(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type tickMsg struct{}
+type errMsg error
+
+type model struct {
+	textInput textinput.Model
+	err       error
+}
+
+func initialModel() model {
+	ti := textinput.New()
+	ti.Placeholder = "Once upon a time..."
+	ti.Focus()
+	ti.Prompt = "┃ "
+	ti.CharLimit = 400
+	ti.Width = 60
+	ti.LineLimit = 10
+	ti.Height = 10
+
+	return model{
+		textInput: ti,
+		err:       nil,
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return textinput.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.Type {
+		case tea.KeyCtrlC, tea.KeyEsc:
+			fmt.Println(m.textInput.Value())
+			return m, tea.Quit
+		}
+
+	// We handle errors just like any other message
+	case errMsg:
+		m.err = msg
+		return m, nil
+	}
+
+	m.textInput, cmd = m.textInput.Update(msg)
+	return m, cmd
+}
+
+func (m model) View() string {
+	return fmt.Sprintf(
+		"Tell me a story.\n\n%s\nColumn: %d\nRow: %d\nLength: %d\n\n%s",
+		m.textInput.View(),
+		m.textInput.Cursor(),
+		m.textInput.Line(),
+		m.textInput.Length(),
+		"(esc to quit)",
+	) + "\n\n"
+}

--- a/examples/multiline-textinput/main.go
+++ b/examples/multiline-textinput/main.go
@@ -33,9 +33,9 @@ func initialModel() model {
 	ti.Focus()
 	ti.Prompt = "┃ "
 	ti.CharLimit = 400
-	ti.Width = 60
-	ti.LineLimit = 10
-	ti.Height = 10
+	ti.Width = 20
+	ti.Height = 5
+	ti.LineLimit = 20
 
 	return model{
 		textInput: ti,
@@ -70,11 +70,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m model) View() string {
 	return fmt.Sprintf(
-		"Tell me a story.\n\n%s\nColumn: %d\nRow: %d\nLength: %d\n\n%s",
+		"Tell me a story.\n\n%s\n\nColumn: %d\nRow: %d\nLength: %d\nOffset: %d\n\n%s",
 		m.textInput.View(),
 		m.textInput.Cursor(),
 		m.textInput.Line(),
 		m.textInput.Length(),
+		m.textInput.Viewport.YOffset,
 		"(esc to quit)",
 	) + "\n\n"
 }

--- a/examples/textarea/main.go
+++ b/examples/textarea/main.go
@@ -7,8 +7,9 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func main() {
@@ -23,28 +24,28 @@ type tickMsg struct{}
 type errMsg error
 
 type model struct {
-	textInput textinput.Model
-	err       error
+	textarea textarea.Model
+	err      error
 }
 
 func initialModel() model {
-	ti := textinput.New()
+	ti := textarea.New()
 	ti.Placeholder = "Once upon a time..."
 	ti.Focus()
-	ti.Prompt = "┃ "
 	ti.CharLimit = 400
 	ti.Width = 20
-	ti.Height = 5
-	ti.LineLimit = 20
+	ti.Height = 3
+	ti.LineLimit = 10
+	ti.CursorLineStyle = lipgloss.NewStyle().Background(lipgloss.Color("0"))
 
 	return model{
-		textInput: ti,
-		err:       nil,
+		textarea: ti,
+		err:      nil,
 	}
 }
 
 func (m model) Init() tea.Cmd {
-	return textinput.Blink
+	return textarea.Blink
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -54,7 +55,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyCtrlC, tea.KeyEsc:
-			fmt.Println(m.textInput.Value())
+			fmt.Println(m.textarea.Value())
 			return m, tea.Quit
 		}
 
@@ -64,18 +65,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	m.textInput, cmd = m.textInput.Update(msg)
+	m.textarea, cmd = m.textarea.Update(msg)
 	return m, cmd
 }
 
 func (m model) View() string {
 	return fmt.Sprintf(
-		"Tell me a story.\n\n%s\n\nColumn: %d\nRow: %d\nLength: %d\nOffset: %d\n\n%s",
-		m.textInput.View(),
-		m.textInput.Cursor(),
-		m.textInput.Line(),
-		m.textInput.Length(),
-		m.textInput.Viewport.YOffset,
+		"Tell me a story.\n\n%s\n\nColumn: %d\n\n\n%s",
+		m.textarea.View(),
+		m.textarea.Cursor(),
 		"(esc to quit)",
 	) + "\n\n"
 }

--- a/examples/textarea/main.go
+++ b/examples/textarea/main.go
@@ -37,6 +37,7 @@ func initialModel() model {
 	ti.Height = 3
 	ti.LineLimit = 10
 	ti.CursorLineStyle = lipgloss.NewStyle().Background(lipgloss.Color("0"))
+	ti.ShowLineNumbers = true
 
 	return model{
 		textarea: ti,


### PR DESCRIPTION
Requires https://github.com/charmbracelet/bubbles/pull/164

To test:
1. Checkout this branch (`multiline-input`) on `bubbles` and `bubbletea`
2. Add the following to `bubbletea/examples/go.mod`:
```go.mod
replace github.com/charmbracelet/bubbles => ../../bubbles
```
3. Run `cd bubbletea/examples/{chat,multiline-textinput} && go run main.go` 

## Example One: Chat Application with multi-line input

https://user-images.githubusercontent.com/42545625/171959090-9aaf4dd8-6591-44ee-8496-cfe0efabe9e0.mov

## Example Two: Multi-line input

https://user-images.githubusercontent.com/42545625/171959130-4b4c66ae-6203-4083-8dda-6a3eab7c67a9.mov


