### PR TITLE
feat: allow specifying window size file descriptor

### DIFF
--- a/options.go
+++ b/options.go
@@ -130,3 +130,16 @@ func WithANSICompressor() ProgramOption {
 		p.startupOptions |= withANSICompressor
 	}
 }
+
+// WithWindowSizeSource sets the file descriptor to be used when determining
+// the window size. By the default, it's the program's stdout.
+// In most cases you won't need to use this. It's useful in situations where
+// the program's output file descriptor is not a terminal but the program's
+// stdin might be. Then it's useful to use the stdin instead as a source of
+// information for the window size. If the stdin is not a terminal either there
+// isn't much that can be done and WindowSizeMsg events won't be sent.
+func WithWindowSizeSource(s WindowSizeSource) ProgramOption {
+	return func(p *Program) {
+		p.windowSizeSource = s
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -91,4 +91,20 @@ func TestOptions(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("window size source default", func(t *testing.T) {
+		expected := WindowSizeSourceOutput
+		p := NewProgram(nil)
+		if expected != p.windowSizeSource {
+			t.Errorf("expected windowSizeSource to be %s, got %s", expected, p.windowSizeSource)
+		}
+	})
+
+	t.Run("window size source custom", func(t *testing.T) {
+		expected := WindowSizeSourceInput
+		p := NewProgram(nil, WithWindowSizeSource(expected))
+		if expected != p.windowSizeSource {
+			t.Errorf("expected windowSizeSource to be %s, got %s", expected, p.windowSizeSource)
+		}
+	})
 }

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -13,9 +13,9 @@ import (
 )
 
 // listenForResize sends messages (or errors) when the terminal resizes.
-// Argument output should be the file descriptor for the terminal; usually
+// Argument source should be the file descriptor for the terminal; usually
 // os.Stdout.
-func listenForResize(ctx context.Context, output *os.File, msgs chan Msg, errs chan error, done chan struct{}) {
+func listenForResize(ctx context.Context, source *os.File, msgs chan Msg, errs chan error, done chan struct{}) {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGWINCH)
 
@@ -31,7 +31,7 @@ func listenForResize(ctx context.Context, output *os.File, msgs chan Msg, errs c
 		case <-sig:
 		}
 
-		w, h, err := term.GetSize(int(output.Fd()))
+		w, h, err := term.GetSize(int(source.Fd()))
 		if err != nil {
 			errs <- err
 		}

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -10,7 +10,6 @@ import (
 
 // listenForResize is not available on windows because windows does not
 // implement syscall.SIGWINCH.
-func listenForResize(ctx context.Context, output *os.File, msgs chan Msg,
-	errs chan error, done chan struct{}) {
+func listenForResize(_ context.Context, _ *os.File, _ chan Msg, _ chan error, done chan struct{}) {
 	close(done)
 }

--- a/window_size.go
+++ b/window_size.go
@@ -1,0 +1,22 @@
+package tea
+
+// WindowSizeSource is used to specify which file descriptor to be used when
+// determining the window size.
+// Either output or input can be used.
+type WindowSizeSource int
+
+const (
+	WindowSizeSourceOutput WindowSizeSource = iota
+	WindowSizeSourceInput
+)
+
+func (w WindowSizeSource) String() string {
+	switch w {
+	case WindowSizeSourceOutput:
+		return "output"
+	case WindowSizeSourceInput:
+		return "input"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
Allow setting the file descriptor to be used when determining the window
size. The default remains the program's stdout. In most cases you won't
need to use this. It's useful in situations where the program's output
file descriptor is not a terminal but the program's stdin might be.
Then it's useful to use the stdin instead as a source of information for
the window size. If the stdin is not a terminal either there isn't much
that can be done and WindowSizeMsg events won't be sent.