### PR TITLE
fix: race condition on repaint

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -230,7 +230,9 @@ func (r *standardRenderer) write(s string) {
 }
 
 func (r *standardRenderer) repaint() {
+	r.mtx.Lock()
 	r.lastRender = ""
+	r.mtx.Unlock()
 }
 
 func (r *standardRenderer) altScreen() bool {
@@ -361,9 +363,7 @@ func (r *standardRenderer) handleMessages(msg Msg) {
 
 		// Force a repaint on the area where the scrollable stuff was in this
 		// update cycle
-		r.mtx.Lock()
-		r.lastRender = ""
-		r.mtx.Unlock()
+		r.repaint()
 
 	case syncScrollAreaMsg:
 		// Re-render scrolling area
@@ -372,9 +372,7 @@ func (r *standardRenderer) handleMessages(msg Msg) {
 		r.insertTop(msg.lines, msg.topBoundary, msg.bottomBoundary)
 
 		// Force non-scrolling stuff to repaint in this update cycle
-		r.mtx.Lock()
-		r.lastRender = ""
-		r.mtx.Unlock()
+		r.repaint()
 
 	case scrollUpMsg:
 		r.insertTop(msg.lines, msg.topBoundary, msg.bottomBoundary)


### PR DESCRIPTION
I noticed that there's a race condition when resizing windows. It's happening because the main tea Program loop calls `repaint()`

https://github.com/charmbracelet/bubbletea/blob/b566614c162466b0bc5830affe289ef960fb0746/tea.go#L506

and the renderer is also setting the value of its `lastRender`:

https://github.com/charmbracelet/bubbletea/blob/b566614c162466b0bc5830affe289ef960fb0746/standard_renderer.go#L210


This can be reproduced with the [textinput example](https://github.com/charmbracelet/bubbletea/blob/master/examples/textinput/main.go). Simply run it and resize your terminal window.

Output:

```shell
$ go run -race test.go
What’s your favorite Pokémon?

> Pikachu

(esc to quit)
==================
WARNING: DATA RACE
Write at 0x00c00014c198 by main goroutine:
  github.com/charmbracelet/bubbletea.(*standardRenderer).repaint()
      my-project/vendor/github.com/charmbracelet/bubbletea/standard_renderer.go:233 +0x39
  github.com/charmbracelet/bubbletea.(*Program).StartReturningModel()
      my-project/vendor/github.com/charmbracelet/bubbletea/tea.go:506 +0x1b17
  github.com/charmbracelet/bubbletea.(*Program).Start()
      my-project/vendor/github.com/charmbracelet/bubbletea/tea.go:547 +0xa4
  main.main()
      my-project/main.go:14 +0xa5

Previous write at 0x00c00014c198 by goroutine 9:
  github.com/charmbracelet/bubbletea.(*standardRenderer).flush()
      my-project/vendor/github.com/charmbracelet/bubbletea/standard_renderer.go:210 +0xd04
  github.com/charmbracelet/bubbletea.(*standardRenderer).listen()
      my-project/vendor/github.com/charmbracelet/bubbletea/standard_renderer.go:101 +0x124
  github.com/charmbracelet/bubbletea.(*standardRenderer).start.func1()
      my-project/vendor/github.com/charmbracelet/bubbletea/standard_renderer.go:69 +0x39

Goroutine 9 (running) created at:
  github.com/charmbracelet/bubbletea.(*standardRenderer).start()
      my-project/vendor/github.com/charmbracelet/bubbletea/standard_renderer.go:69 +0x156
  github.com/charmbracelet/bubbletea.(*Program).StartReturningModel()
      my-project/vendor/github.com/charmbracelet/bubbletea/tea.go:413 +0xda1
What’s your favorite Pokémon?

> Pikachu

(esc to quit)
```