### PR TITLE
Add border to split-editors example

### DIFF
--- a/examples/split-editors/main.go
+++ b/examples/split-editors/main.go
@@ -18,6 +18,8 @@ const (
 )
 
 var (
+	cursorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
+
 	cursorLineStyle = lipgloss.NewStyle().
 			Background(lipgloss.Color("57")).
 			Foreground(lipgloss.Color("230"))
@@ -27,6 +29,13 @@ var (
 
 	focusedPlaceholderStyle = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("99"))
+
+	focusedBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(lipgloss.Color("60"))
+
+	blurredBorderStyle = lipgloss.NewStyle().
+				Border(lipgloss.HiddenBorder())
 )
 
 type keymap = struct {
@@ -39,10 +48,12 @@ func newTextarea() textarea.Model {
 	t.Prompt = ""
 	t.Placeholder = "Type something"
 	t.ShowLineNumbers = true
-	t.Cursor.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("212"))
+	t.Cursor.Style = cursorStyle
 	t.FocusedStyle.Placeholder = focusedPlaceholderStyle
 	t.BlurredStyle.Placeholder = placeholderStyle
 	t.FocusedStyle.CursorLine = cursorLineStyle
+	t.FocusedStyle.Base = focusedBorderStyle
+	t.BlurredStyle.Base = blurredBorderStyle
 	t.KeyMap.DeleteWordBackward.SetEnabled(false)
 	t.KeyMap.LineNext = key.NewBinding(key.WithKeys("down"))
 	t.KeyMap.LinePrevious = key.NewBinding(key.WithKeys("up"))

--- a/examples/split-editors/main.go
+++ b/examples/split-editors/main.go
@@ -32,7 +32,7 @@ var (
 
 	focusedBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.RoundedBorder()).
-				BorderForeground(lipgloss.Color("60"))
+				BorderForeground(lipgloss.Color("238"))
 
 	blurredBorderStyle = lipgloss.NewStyle().
 				Border(lipgloss.HiddenBorder())


### PR DESCRIPTION
Add border to focused `textarea` in split-editors example.
