### PR TITLE
chore: fix Println typo

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -483,10 +483,10 @@ type printLineMessage struct {
 	messageBody string
 }
 
-// Printf prints above the Program. This output is unmanaged by the program and
+// Println prints above the Program. This output is unmanaged by the program and
 // will persist across renders by the Program.
 //
-// Unlike fmt.Printf (but similar to log.Printf) the message will be print on
+// Unlike fmt.Println (but similar to log.Println) the message will be print on
 // its own line.
 //
 // If the altscreen is active no output will be printed.


### PR DESCRIPTION
## Changes:
- [x] change `Printf`to `Println` in the Godoc of the `Println` function
