### PR TITLE
docs: README progress-download folder + ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ examples/list-fancy/list-fancy
 examples/list-simple/list-simple
 examples/mouse/mouse
 examples/pager/pager
+examples/progress-download/color_vortex.blend
+examples/progress-download/progress-download
 examples/simple/simple
 examples/spinner/spinner
 examples/textinput/textinput

--- a/examples/progress-download/README.md
+++ b/examples/progress-download/README.md
@@ -12,7 +12,7 @@ Build the application with `go build .`, then run with a `--url` argument
 specifying the URL of the file to download. For example:
 
 ```
-./download-progress --url="https://download.blender.org/demo/color_vortex.blend"
+./progress-download --url="https://download.blender.org/demo/color_vortex.blend"
 ```
 
 Note that in this example a TUI will not be shown for URLs that do not respond


### PR DESCRIPTION
📝 Update folder name in README to `progress-download` as
 that is what generates with `go build .`

🙈 Add the files generated via README to root `.gitignore`