### PR TITLE
Catch SIGTERM so that bubbletea cleans up terminal

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -337,11 +337,14 @@ func (p *Program) StartReturningModel() (Model, error) {
 		p.input = f
 	}
 
-	// Listen for SIGINT and SIGTERM. Note that in most cases ^C will not send an
-	// interrupt because the terminal will be in raw mode and thus capture
-	// that keystroke and send it along to Program.Update. If input is not a
-	// TTY, however, ^C will be caught here. SIGTERM is sent by Unix utilities
-	// like kill to terminate a process.
+	// Listen for SIGINT and SIGTERM.
+	//
+	// In most cases ^C will not send an interrupt because the terminal will be
+	// in raw mode and ^C will be captured as a keystroke and sent along to
+	// Program.Update as a KeyMsg. When input is not a TTY, however, ^C will be
+	// caught here.
+	//
+	// SIGTERM is sent by unix utilities (like kill) to terminate a process.
 	go func() {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/tea.go
+++ b/tea.go
@@ -337,13 +337,14 @@ func (p *Program) StartReturningModel() (Model, error) {
 		p.input = f
 	}
 
-	// Listen for SIGINT. Note that in most cases ^C will not send an
+	// Listen for SIGINT and SIGTERM. Note that in most cases ^C will not send an
 	// interrupt because the terminal will be in raw mode and thus capture
 	// that keystroke and send it along to Program.Update. If input is not a
-	// TTY, however, ^C will be caught here.
+	// TTY, however, ^C will be caught here. SIGTERM is sent by Unix utilities
+	// like kill to terminate a process.
 	go func() {
 		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, syscall.SIGINT)
+		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 		defer func() {
 			signal.Stop(sig)
 			close(sigintLoopDone)


### PR DESCRIPTION
Add [SIGTERM](https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html#index-SIGTERM) to signals caught so that bubbletea cleans up the screen when exiting because of that signal.

Unix utilities commonly send SIGTERM as the signal to terminate a process. Currently bubbletea doesn't catch SIGTERM and if a application receives this type of signal it will exit leaving the terminal in an unusable state. This PR causes this package to prevent this behavior and clean the terminal on exit. Examples of Unix utilities that send SIGTERM as default include `kill` and `timeout`.

To reproduce this bug run: `timeout 10 ./bubbletea-progam` 

I have tested this PR with both `timeout` and `kill`. 



