### PR TITLE
docs: fix typo

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -39,7 +39,7 @@ func Exec(c ExecCommand, fn ExecCallback) Cmd {
 //	c := exec.Command("vim", "file.txt")
 //
 //	cmd := ExecProcess(c, func(err error) Msg {
-//	    return VimFinishedMsg{err: error}
+//	    return VimFinishedMsg{err: err}
 //	})
 //
 // Or, if you don't care about errors, you could simply:


### PR DESCRIPTION
The previous example was wrong and would result in the following
compiler error:
```
error (type) is not an expression
```
Just a simple typo, I've changed it to `err` to correctly reference the
function scoped variable named `err`.