### PR TITLE
docs: add chezmoi to users of Bubble Tea in the wild

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ For some Bubble Tea programs in production, see:
 * [Aztify](https://github.com/Azure/aztfy): bring Microsoft Azure resources under Terraform
 * [Canard](https://github.com/mrusme/canard): an RSS client
 * [charm](https://github.com/charmbracelet/charm): the official Charm user account manager
+* [chezmoi](https://github.com/twpayne/chezmoi): manage your dotfiles across multiple machines, securely
 * [circumflex](https://github.com/bensadeh/circumflex): read Hacker News in your terminal
 * [clidle](https://github.com/ajeetdsouza/clidle): a Wordle clone for your terminal
 * [container-canary](https://github.com/NVIDIA/container-canary): a container validator


### PR DESCRIPTION
Thank you for this great library!

As of [v2.23.0](https://github.com/twpayne/chezmoi/releases/tag/v2.23.0), chezmoi, a [popular dotfile manager](https://dotfiles.github.io/utilities/), uses Bubble Tea for [user interaction](https://github.com/twpayne/chezmoi/pull/2359) and [progress reporting](https://github.com/twpayne/chezmoi/pull/2369). 