### PR TITLE
fix: off-by-one error in spinner example

### DIFF
--- a/examples/spinners/main.go
+++ b/examples/spinners/main.go
@@ -55,7 +55,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "h", "left":
 			m.index--
-			if m.index <= 0 {
+			if m.index < 0 {
 				m.index = len(spinners) - 1
 			}
 			m.resetSpinner()


### PR DESCRIPTION
Sorry for the noise in `go.mod` and `go.sum`. I had to `go get github.com/charmbracelet/bubbles/spinner` in order to run the example.