### PR TITLE
fix: don't access output from outside renderer

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -257,15 +257,15 @@ func (p *Program) StartReturningModel() (Model, error) {
 		}()
 	}
 
+	// If no renderer is set use the standard one.
+	if p.renderer == nil {
+		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor))
+	}
+
 	// Check if output is a TTY before entering raw mode, hiding the cursor and
 	// so on.
 	if err := p.initTerminal(); err != nil {
 		return p.initialModel, err
-	}
-
-	// If no renderer is set use the standard one.
-	if p.renderer == nil {
-		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor))
 	}
 
 	// Honor program startup options.

--- a/tty.go
+++ b/tty.go
@@ -21,14 +21,16 @@ func (p *Program) initTerminal() error {
 		}
 	}
 
-	p.output.HideCursor()
+	p.renderer.hideCursor()
 	return nil
 }
 
 // restoreTerminalState restores the terminal to the state prior to running the
 // Bubble Tea program.
 func (p *Program) restoreTerminalState() error {
-	p.output.ShowCursor()
+	if p.renderer != nil {
+		p.renderer.showCursor()
+	}
 
 	if p.console != nil {
 		err := p.console.Reset()


### PR DESCRIPTION
Ensures exclusive output access by renderer.