### PR TITLE
fix: force repaint after clearing the screen

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -251,6 +251,8 @@ func (r *standardRenderer) clearScreen() {
 
 	r.out.ClearScreen()
 	r.out.MoveCursor(1, 1)
+
+	r.repaint()
 }
 
 func (r *standardRenderer) altScreen() bool {


### PR DESCRIPTION
Enforcing a repaint after clearing the screen prevents the line caching from interfering with the subsequent render.