### PR TITLE
fix: don't try to set alt screen when already in desired mode

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -260,6 +260,10 @@ func (r *standardRenderer) altScreen() bool {
 }
 
 func (r *standardRenderer) enterAltScreen() {
+	if r.altScreenActive {
+		return
+	}
+
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
@@ -279,6 +283,10 @@ func (r *standardRenderer) enterAltScreen() {
 }
 
 func (r *standardRenderer) exitAltScreen() {
+	if !r.altScreenActive {
+		return
+	}
+
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 


### PR DESCRIPTION
Shortcuts switching alt mode when we're already in the desired mode.