### PR TITLE
chore: break up Start into several, more maintainable methods

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -51,12 +51,12 @@ func (p *Program) initCancelReader() error {
 	}
 
 	p.readLoopDone = make(chan struct{})
-	go p.eventLoop()
+	go p.readLoop()
 
 	return nil
 }
 
-func (p *Program) eventLoop() {
+func (p *Program) readLoop() {
 	defer close(p.readLoopDone)
 
 	for {


### PR DESCRIPTION
The purpose of this change is breaking up the monstrous `StartReturningModel` into several smaller handler methods. That makes this function a bit easier to maintain and unifies the exit paths.