### PR TITLE
Support multiline tea.Println() messages

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -680,7 +680,6 @@ func ScrollDown(newLines []string, topBoundary, bottomBoundary int) Cmd {
 
 type printLineMessage struct {
 	messageBody string
-	// if true, skips truncation of the message
 }
 
 // Println prints above the Program. This output is unmanaged by the program and


### PR DESCRIPTION
When logging something into the scrollback history of the standard renderer, the current approach temporarially increases the size of the UI by the number of logged messages. This has 2 issues:

- log lines are truncated according to the current width of the terminal UI. This truncation behaviour is desireable when writing into the TUI's controlled space, but is not desireable when Printf()ing messages into the scrollback, since the contents of the logged line will be truncated with no way to recover the history.
- User code pre-wrapping messages they want to print to the scrollback don't behave the way that you would want/expect log lines in a terminal to behave:
  - Resizing the terminal emulator does not reflow the lines to the new terminal's width
  - Manual wrapping breaks most terminal emulator's detection of clickable URLs and file paths

This change replaces that approach with a full clear of the previos UI + printing unwrapped messages into the terminal before the next render

this has a minor performance impact because it necessitates a full clear of the terminal UI on each Printf(). This breaks duplicate line detection between renders. However, the current approach will rarely hit duplicate line detection, since adding log messages to the front of the printout buffer offsets the new buffer. Therefore, the current line detection logic will only trigger when the buffer contains duplicate lines offset by the number of messages being logged in this render pass.