### PR TITLE
Render view before quitting

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -373,6 +373,7 @@ func (p *Program) StartReturningModel() (Model, error) {
 			// Handle special internal messages.
 			switch msg := msg.(type) {
 			case quitMsg:
+				p.renderer.write(model.View())
 				cancelContext()
 				waitForGoroutines(p.cancelReader.Cancel())
 				p.shutdown(false)


### PR DESCRIPTION
Closes #274 

Consolidate behavior before quitting so that final render is not skipped when calling `p.Quit()`.

Current state:
- `tea.Quit()` renders the model before quitting
- `p.Quit()` does not render the model before quitting

**Notes**
There does not seem to be a way to flush the buffer before quitting.
Could there be a race-condition where the model is not rendered before quitting?
Happy to update the PR if maybe `flush` method shall be exposed in the `renderer` interface.