### PR TITLE
fix(key): recover the insert key

### DIFF
--- a/key.go
+++ b/key.go
@@ -390,6 +390,10 @@ var sequences = map[string]Key{
 	// Miscellaneous keys
 	"\x1b[Z": {Type: KeyShiftTab},
 
+	"\x1b[2~":     {Type: KeyInsert},
+	"\x1b[3;2~":   {Type: KeyInsert, Alt: true},
+	"\x1b\x1b[2~": {Type: KeyInsert, Alt: true}, // urxvt
+
 	"\x1b[3~":     {Type: KeyDelete},
 	"\x1b[3;3~":   {Type: KeyDelete, Alt: true},
 	"\x1b\x1b[3~": {Type: KeyDelete, Alt: true}, // urxvt

--- a/key_test.go
+++ b/key_test.go
@@ -145,6 +145,14 @@ func TestReadInput(t *testing.T) {
 				},
 			},
 		},
+		{"insert",
+			[]byte{'\x1b', '[', '2', '~'},
+			[]Msg{
+				KeyMsg{
+					Type: KeyInsert,
+				},
+			},
+		},
 		{"alt+ctrl+a",
 			[]byte{'\x1b', byte(keySOH)},
 			[]Msg{


### PR DESCRIPTION
We started supporting insert in #418, but then accidentally removed it during a rebase in #396. Oops.

:facepalm: 

cc @muesli @meowgorithm 