### PR TITLE
fix: properly detect terminal size after exec

### DIFF
--- a/signals_unix.go
+++ b/signals_unix.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-
-	"golang.org/x/term"
 )
 
 // listenForResize sends messages (or errors) when the terminal resizes.
@@ -31,15 +29,6 @@ func listenForResize(ctx context.Context, output *os.File, msgs chan Msg, errs c
 		case <-sig:
 		}
 
-		w, h, err := term.GetSize(int(output.Fd()))
-		if err != nil {
-			errs <- err
-		}
-
-		select {
-		case <-ctx.Done():
-			return
-		case msgs <- WindowSizeMsg{w, h}:
-		}
+		checkResize(ctx, output, msgs, errs)
 	}
 }

--- a/tea.go
+++ b/tea.go
@@ -451,7 +451,10 @@ func (p *Program) Start() error {
 // If the program is not running this this will be a no-op, so it's safe to
 // send messages if the program is unstarted, or has exited.
 func (p *Program) Send(msg Msg) {
-	p.msgs <- msg
+	select {
+	case <-p.ctx.Done():
+	case p.msgs <- msg:
+	}
 }
 
 // Quit is a convenience function for quitting Bubble Tea programs. Use it


### PR DESCRIPTION
See commits for details. Found while investigating #497.

cc @muesli 