### PR TITLE
fix: close input on shutdown whenever possible

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -351,9 +351,6 @@ func (p *Program) StartReturningModel() (Model, error) {
 		if err != nil {
 			return p.initialModel, err
 		}
-
-		defer f.Close() //nolint:errcheck
-
 		p.input = f
 
 	case !p.startupOptions.has(withCustomInput):
@@ -373,10 +370,11 @@ func (p *Program) StartReturningModel() (Model, error) {
 		if err != nil {
 			return p.initialModel, err
 		}
-
-		defer f.Close() //nolint:errcheck
-
 		p.input = f
+	}
+
+	if f, ok := p.input.(io.ReadCloser); ok {
+		defer f.Close() //nolint:errcheck
 	}
 
 	// Handle signals.


### PR DESCRIPTION
I'm a simple man, if I see a `Close`, I call it.