### PR TITLE
chore: clean up linter errors in examples

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -23,8 +23,7 @@ func main() {
 }
 
 type (
-	tickMsg struct{}
-	errMsg  error
+	errMsg error
 )
 
 type model struct {

--- a/examples/credit-card-form/main.go
+++ b/examples/credit-card-form/main.go
@@ -20,8 +20,7 @@ func main() {
 }
 
 type (
-	tickMsg struct{}
-	errMsg  error
+	errMsg error
 )
 
 const (
@@ -139,9 +138,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyEnter:
 			if m.focused == len(m.inputs)-1 {
 				return m, tea.Quit
-			} else {
-				m.nextInput()
 			}
+			m.nextInput()
 		case tea.KeyCtrlC, tea.KeyEsc:
 			return m, tea.Quit
 		case tea.KeyShiftTab, tea.KeyCtrlP:
@@ -172,7 +170,7 @@ func (m model) View() string {
 
  %s
  %s
- 
+
  %s  %s
  %s  %s
 

--- a/examples/fullscreen/main.go
+++ b/examples/fullscreen/main.go
@@ -28,7 +28,6 @@ func (m model) Init() tea.Cmd {
 
 func (m model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := message.(type) {
-
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "esc", "ctrl+c":
@@ -36,12 +35,11 @@ func (m model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tickMsg:
-		m -= 1
+		m--
 		if m <= 0 {
 			return m, tea.Quit
 		}
 		return m, tick()
-
 	}
 
 	return m, nil

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -37,7 +37,6 @@ func (m model) Init() tea.Cmd {
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "ctrl+c", "esc":
@@ -77,5 +76,7 @@ func checkServer() tea.Msg {
 	if err != nil {
 		return errMsg{err}
 	}
+	defer res.Body.Close()
+
 	return statusMsg(res.StatusCode)
 }

--- a/examples/list-simple/main.go
+++ b/examples/list-simple/main.go
@@ -45,12 +45,11 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 		}
 	}
 
-	fmt.Fprintf(w, fn(str))
+	fmt.Fprint(w, fn(str))
 }
 
 type model struct {
 	list     list.Model
-	items    []item
 	choice   string
 	quitting bool
 }

--- a/examples/package-manager/main.go
+++ b/examples/package-manager/main.go
@@ -25,7 +25,6 @@ type model struct {
 
 var (
 	currentPkgNameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("211"))
-	subtleStyle         = lipgloss.NewStyle().Foreground(lipgloss.Color("239"))
 	doneStyle           = lipgloss.NewStyle().Margin(1, 2)
 	checkMark           = lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓")
 )

--- a/examples/progress-animated/main.go
+++ b/examples/progress-animated/main.go
@@ -42,7 +42,7 @@ type model struct {
 	progress progress.Model
 }
 
-func (_ model) Init() tea.Cmd {
+func (m model) Init() tea.Cmd {
 	return tickCmd()
 }
 
@@ -79,10 +79,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 }
 
-func (e model) View() string {
+func (m model) View() string {
 	pad := strings.Repeat(" ", padding)
 	return "\n" +
-		pad + e.progress.View() + "\n\n" +
+		pad + m.progress.View() + "\n\n" +
 		pad + helpStyle("Press any key to quit")
 }
 

--- a/examples/progress-download/tui.go
+++ b/examples/progress-download/tui.go
@@ -27,10 +27,9 @@ func finalPause() tea.Cmd {
 }
 
 type model struct {
-	url, path string
-	pw        *progressWriter
-	progress  progress.Model
-	err       error
+	pw       *progressWriter
+	progress progress.Model
+	err      error
 }
 
 func (m model) Init() tea.Cmd {

--- a/examples/progress-static/main.go
+++ b/examples/progress-static/main.go
@@ -50,13 +50,12 @@ type model struct {
 	progress progress.Model
 }
 
-func (_ model) Init() tea.Cmd {
+func (m model) Init() tea.Cmd {
 	return tickCmd()
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-
 	case tea.KeyMsg:
 		return m, tea.Quit
 
@@ -80,10 +79,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 }
 
-func (e model) View() string {
+func (m model) View() string {
 	pad := strings.Repeat(" ", padding)
 	return "\n" +
-		pad + e.progress.ViewAs(e.percent) + "\n\n" +
+		pad + m.progress.ViewAs(m.percent) + "\n\n" +
 		pad + helpStyle("Press any key to quit")
 }
 

--- a/examples/send-msg/main.go
+++ b/examples/send-msg/main.go
@@ -19,7 +19,6 @@ var (
 	spinnerStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("63"))
 	helpStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Margin(1, 0)
 	dotStyle      = helpStyle.Copy().UnsetMargins()
-	foodStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("36"))
 	durationStyle = dotStyle.Copy()
 	appStyle      = lipgloss.NewStyle().Margin(1, 2, 0, 2)
 )

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -47,7 +47,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		return m, tea.Quit
 	case tickMsg:
-		m -= 1
+		m--
 		if m <= 0 {
 			return m, tea.Quit
 		}

--- a/examples/spinner/main.go
+++ b/examples/spinner/main.go
@@ -33,7 +33,6 @@ func (m model) Init() tea.Cmd {
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "q", "esc", "ctrl+c":

--- a/examples/tabs/main.go
+++ b/examples/tabs/main.go
@@ -46,8 +46,6 @@ func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
 }
 
 var (
-	defaultWidth = 20
-
 	inactiveTabBorder = tabBorderWithBottom("┴", "─", "┴")
 	activeTabBorder   = tabBorderWithBottom("┘", " ", "└")
 	docStyle          = lipgloss.NewStyle().Padding(1, 2, 1, 2)

--- a/examples/textinput/main.go
+++ b/examples/textinput/main.go
@@ -20,8 +20,7 @@ func main() {
 }
 
 type (
-	tickMsg struct{}
-	errMsg  error
+	errMsg error
 )
 
 type model struct {

--- a/examples/views/main.go
+++ b/examples/views/main.go
@@ -115,16 +115,15 @@ func (m model) View() string {
 // Update loop for the first view where you're choosing a task.
 func updateChoices(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "j", "down":
-			m.Choice += 1
+			m.Choice++
 			if m.Choice > 3 {
 				m.Choice = 3
 			}
 		case "k", "up":
-			m.Choice -= 1
+			m.Choice--
 			if m.Choice < 0 {
 				m.Choice = 0
 			}
@@ -138,7 +137,7 @@ func updateChoices(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 			m.Quitting = true
 			return m, tea.Quit
 		}
-		m.Ticks -= 1
+		m.Ticks--
 		return m, tick()
 	}
 
@@ -148,10 +147,9 @@ func updateChoices(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 // Update loop for the second view after a choice has been made
 func updateChosen(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 	switch msg.(type) {
-
 	case frameMsg:
 		if !m.Loaded {
-			m.Frames += 1
+			m.Frames++
 			m.Progress = ease.OutBounce(float64(m.Frames) / float64(100))
 			if m.Progress >= 1 {
 				m.Progress = 1
@@ -168,7 +166,7 @@ func updateChosen(msg tea.Msg, m model) (tea.Model, tea.Cmd) {
 				m.Quitting = true
 				return m, tea.Quit
 			}
-			m.Ticks -= 1
+			m.Ticks--
 			return m, tick()
 		}
 	}

--- a/tutorials/commands/main.go
+++ b/tutorials/commands/main.go
@@ -22,6 +22,8 @@ func checkServer() tea.Msg {
 	if err != nil {
 		return errMsg{err}
 	}
+	defer res.Body.Close()
+
 	return statusMsg(res.StatusCode)
 }
 
@@ -39,7 +41,6 @@ func (m model) Init() tea.Cmd {
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-
 	case statusMsg:
 		m.status = int(msg)
 		return m, tea.Quit


### PR DESCRIPTION
Removes unused variables, redundant newlines, and other inconsistencies.