### PR TITLE
fix: prevent double repaint when restoring terminal

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -572,9 +572,10 @@ func (p *Program) RestoreTerminal() error {
 
 	if p.altScreenWasActive {
 		p.renderer.enterAltScreen()
+	} else {
+		// entering alt screen already causes a repaint.
+		go p.Send(repaintMsg{})
 	}
-
-	go p.Send(repaintMsg{})
 
 	return nil
 }


### PR DESCRIPTION
Entering alt screen already causes a repaint, no need to do it twice.