### PR TITLE
feat: add quit event handler

### DIFF
--- a/examples/prevent-quit/main.go
+++ b/examples/prevent-quit/main.go
@@ -1,0 +1,149 @@
+package main
+
+// A program demonstrating how to use the WithOnQuit option to intercept quit events
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	choiceStyle   = lipgloss.NewStyle().PaddingLeft(1).Foreground(lipgloss.Color("241"))
+	saveTextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
+	quitViewStyle = lipgloss.NewStyle().Padding(1).Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("170"))
+)
+
+func main() {
+	p := tea.NewProgram(initialModel(), tea.WithOnQuit(onQuit))
+
+	if _, err := p.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func onQuit(teaModel tea.Model) tea.QuitBehavior {
+	m := teaModel.(model)
+	if m.hasChanges {
+		return tea.PreventShutdown
+	}
+	return tea.Shutdown
+}
+
+type model struct {
+	textarea   textarea.Model
+	help       help.Model
+	keymap     keymap
+	saveText   string
+	hasChanges bool
+	quitting   bool
+}
+
+type keymap struct {
+	save key.Binding
+	quit key.Binding
+}
+
+func initialModel() model {
+	ti := textarea.New()
+	ti.Placeholder = "Only the best words"
+	ti.Focus()
+
+	return model{
+		textarea: ti,
+		help:     help.NewModel(),
+		keymap: keymap{
+			save: key.NewBinding(
+				key.WithKeys("ctrl+s"),
+				key.WithHelp("ctrl+s", "save"),
+			),
+			quit: key.NewBinding(
+				key.WithKeys("esc", "ctrl+c"),
+				key.WithHelp("esc", "quit"),
+			),
+		},
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return textarea.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.quitting {
+		return m.updatePromptView(msg)
+	}
+
+	return m.updateTextView(msg)
+}
+
+func (m model) updateTextView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		m.saveText = ""
+		switch {
+		case key.Matches(msg, m.keymap.save):
+			m.saveText = "Changes saved!"
+			m.hasChanges = false
+		case key.Matches(msg, m.keymap.quit):
+			m.quitting = true
+			return m, tea.Quit
+		case msg.Type == tea.KeyRunes:
+			m.saveText = ""
+			m.hasChanges = true
+			fallthrough
+		default:
+			if !m.textarea.Focused() {
+				cmd = m.textarea.Focus()
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+	m.textarea, cmd = m.textarea.Update(msg)
+	cmds = append(cmds, cmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) updatePromptView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// For simplicity's sake, we'll treat any key besides "y" as "no"
+		if key.Matches(msg, m.keymap.quit) || msg.String() == "y" {
+			m.hasChanges = false
+			return m, tea.Quit
+		}
+		m.quitting = false
+	}
+
+	return m, nil
+}
+
+func (m model) View() string {
+	if m.quitting {
+		if m.hasChanges {
+			text := lipgloss.JoinHorizontal(lipgloss.Top, "You have unsaved changes. Quit without saving?", choiceStyle.Render("[yn]"))
+			return quitViewStyle.Render(text)
+		}
+		return "Very important, thank you\n"
+	}
+
+	helpView := m.help.ShortHelpView([]key.Binding{
+		m.keymap.save,
+		m.keymap.quit,
+	})
+
+	return fmt.Sprintf(
+		"\nType some important things.\n\n%s\n\n %s\n %s",
+		m.textarea.View(),
+		saveTextStyle.Render(m.saveText),
+		helpView,
+	) + "\n\n"
+}

--- a/options.go
+++ b/options.go
@@ -141,3 +141,32 @@ func WithANSICompressor() ProgramOption {
 		p.startupOptions |= withANSICompressor
 	}
 }
+
+// WithOnQuit supplies an event handler that will be invoked whenever Bubble
+// Tea receives a QuitMsg. The event handler can return tea.Shutdown to
+// instruct Bubble Tea to handle the QuitMsg normally and shut the program
+// down, or it can return tea.PreventShutdown to prevent the program from
+// shutting down and instead handle the QuitMsg like a normal message and
+// pass it along to the model's Update method.
+//
+// Example:
+//
+//	func onQuit(m tea.Model) tea.QuitBehavior {
+//	    model := m.(myModel)
+//	    if model.hasChanges {
+//	        return tea.PreventShutdown
+//	    }
+//	    return tea.Shutdown
+//	}
+//
+//	p := tea.NewProgram(Model{}, tea.WithOnQuit(onQuit));
+//
+//	if _,err := p.Run(); err != nil {
+//		fmt.Println("Error running program:", err)
+//		os.Exit(1)
+//	}
+func WithOnQuit(onQuit func(Model) QuitBehavior) ProgramOption {
+	return func(p *Program) {
+		p.onQuit = onQuit
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -35,6 +35,13 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("on quit", func(t *testing.T) {
+		p := NewProgram(nil, WithOnQuit(func(Model) QuitBehavior { return Shutdown }))
+		if p.onQuit == nil {
+			t.Errorf("expected onQuit to be set")
+		}
+	})
+
 	t.Run("startup options", func(t *testing.T) {
 		exercise := func(t *testing.T, opt ProgramOption, expect startupOptions) {
 			p := NewProgram(nil, opt)

--- a/tea.go
+++ b/tea.go
@@ -121,16 +121,31 @@ type Program struct {
 	// as this value only comes into play on Windows, hence the ignore comment
 	// below.
 	windowsStdin *os.File //nolint:golint,structcheck,unused
+
+	onQuit func(Model) QuitBehavior
 }
+
+// QuitBehavior defines how Bubble Tea handles QuitMsgs.
+type QuitBehavior int
+
+const (
+	// Shutdown instructs Bubble Tea to shut down the program normally when a
+	// QuitMsg is received.
+	Shutdown QuitBehavior = iota
+	// PreventShutdown instructs Bubble Tea to ignore the QuitMsg that it
+	// received and instead pass the message to the model's Update function.
+	PreventShutdown
+)
 
 // Quit is a special command that tells the Bubble Tea program to exit.
+// This behavior can be controlled using the WithOnQuit option.
 func Quit() Msg {
-	return quitMsg{}
+	return QuitMsg{}
 }
 
-// quitMsg in an internal message signals that the program should quit. You can
-// send a quitMsg with Quit.
-type quitMsg struct{}
+// QuitMsg signals that the program should quit. You can send a QuitMsg with
+// Quit.
+type QuitMsg struct{}
 
 // NewProgram creates a new Program.
 func NewProgram(model Model, opts ...ProgramOption) *Program {
@@ -185,7 +200,7 @@ func (p *Program) handleSignals() chan struct{} {
 
 			case <-sig:
 				if !p.ignoreSignals {
-					p.msgs <- quitMsg{}
+					p.msgs <- QuitMsg{}
 					return
 				}
 			}
@@ -272,7 +287,10 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 		case msg := <-p.msgs:
 			// Handle special internal messages.
 			switch msg := msg.(type) {
-			case quitMsg:
+			case QuitMsg:
+				if p.onQuit != nil && p.onQuit(model) == PreventShutdown {
+					break
+				}
 				return model, nil
 
 			case clearScreenMsg:


### PR DESCRIPTION
Resolves #472 

As discussed in #472, this change adds the `WithOnQuit` option so users can intercept quit events and prevent the program from shutting down. This is useful in cases when you want to prompt the user before shutting down or when writing a library on top of Bubble Tea that accepts any `tea.Model` from the user and needs to prevent these child models from shutting the whole program down. This required making `tea.quitMsg` public so users can handle it in their own code if shutdown is prevented. 

I've added an example that demonstrates the former use case (the latter would be hard to model in a simple demo I think). I was hoping to upload a gif to match the other examples, but I couldn't get it to look quite right with the same font size and prompt and everything, so it just looked out of place among the list of other examples. Here's a demo below showing what it looks like.

![out](https://user-images.githubusercontent.com/5882266/194799092-21ef6b15-d35b-4067-93ac-b8482ba8d8ca.gif)
