### PR TITLE
fix: also lock mutex when accessing state read-only

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -264,6 +264,9 @@ func (r *standardRenderer) clearScreen() {
 }
 
 func (r *standardRenderer) altScreen() bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
 	return r.altScreenActive
 }
 


### PR DESCRIPTION
Missed that one in the last commit.