### PR TITLE
feat: add generic event filter

### DIFF
--- a/examples/prevent-quit/main.go
+++ b/examples/prevent-quit/main.go
@@ -1,0 +1,149 @@
+package main
+
+// A program demonstrating how to use the WithOnQuit option to intercept quit events
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var (
+	choiceStyle   = lipgloss.NewStyle().PaddingLeft(1).Foreground(lipgloss.Color("241"))
+	saveTextStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("170"))
+	quitViewStyle = lipgloss.NewStyle().Padding(1).Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("170"))
+)
+
+func main() {
+	p := tea.NewProgram(initialModel(), tea.WithOnQuit(onQuit))
+
+	if _, err := p.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func onQuit(teaModel tea.Model) tea.QuitBehavior {
+	m := teaModel.(model)
+	if m.hasChanges {
+		return tea.PreventShutdown
+	}
+	return tea.Shutdown
+}
+
+type model struct {
+	textarea   textarea.Model
+	help       help.Model
+	keymap     keymap
+	saveText   string
+	hasChanges bool
+	quitting   bool
+}
+
+type keymap struct {
+	save key.Binding
+	quit key.Binding
+}
+
+func initialModel() model {
+	ti := textarea.New()
+	ti.Placeholder = "Only the best words"
+	ti.Focus()
+
+	return model{
+		textarea: ti,
+		help:     help.NewModel(),
+		keymap: keymap{
+			save: key.NewBinding(
+				key.WithKeys("ctrl+s"),
+				key.WithHelp("ctrl+s", "save"),
+			),
+			quit: key.NewBinding(
+				key.WithKeys("esc", "ctrl+c"),
+				key.WithHelp("esc", "quit"),
+			),
+		},
+	}
+}
+
+func (m model) Init() tea.Cmd {
+	return textarea.Blink
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.quitting {
+		return m.updatePromptView(msg)
+	}
+
+	return m.updateTextView(msg)
+}
+
+func (m model) updateTextView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		m.saveText = ""
+		switch {
+		case key.Matches(msg, m.keymap.save):
+			m.saveText = "Changes saved!"
+			m.hasChanges = false
+		case key.Matches(msg, m.keymap.quit):
+			m.quitting = true
+			return m, tea.Quit
+		case msg.Type == tea.KeyRunes:
+			m.saveText = ""
+			m.hasChanges = true
+			fallthrough
+		default:
+			if !m.textarea.Focused() {
+				cmd = m.textarea.Focus()
+				cmds = append(cmds, cmd)
+			}
+		}
+	}
+	m.textarea, cmd = m.textarea.Update(msg)
+	cmds = append(cmds, cmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) updatePromptView(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		// For simplicity's sake, we'll treat any key besides "y" as "no"
+		if key.Matches(msg, m.keymap.quit) || msg.String() == "y" {
+			m.hasChanges = false
+			return m, tea.Quit
+		}
+		m.quitting = false
+	}
+
+	return m, nil
+}
+
+func (m model) View() string {
+	if m.quitting {
+		if m.hasChanges {
+			text := lipgloss.JoinHorizontal(lipgloss.Top, "You have unsaved changes. Quit without saving?", choiceStyle.Render("[yn]"))
+			return quitViewStyle.Render(text)
+		}
+		return "Very important, thank you\n"
+	}
+
+	helpView := m.help.ShortHelpView([]key.Binding{
+		m.keymap.save,
+		m.keymap.quit,
+	})
+
+	return fmt.Sprintf(
+		"\nType some important things.\n\n%s\n\n %s\n %s",
+		m.textarea.View(),
+		saveTextStyle.Render(m.saveText),
+		helpView,
+	) + "\n\n"
+}

--- a/examples/prevent-quit/main.go
+++ b/examples/prevent-quit/main.go
@@ -1,6 +1,6 @@
 package main
 
-// A program demonstrating how to use the WithOnQuit option to intercept quit events
+// A program demonstrating how to use the WithFilter option to intercept events.
 
 import (
 	"fmt"
@@ -20,19 +20,24 @@ var (
 )
 
 func main() {
-	p := tea.NewProgram(initialModel(), tea.WithOnQuit(onQuit))
+	p := tea.NewProgram(initialModel(), tea.WithFilter(filter))
 
 	if _, err := p.Run(); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func onQuit(teaModel tea.Model) tea.QuitBehavior {
+func filter(teaModel tea.Model, msg tea.Msg) tea.Msg {
+	if _, ok := msg.(tea.QuitMsg); !ok {
+		return msg
+	}
+
 	m := teaModel.(model)
 	if m.hasChanges {
-		return tea.PreventShutdown
+		return nil
 	}
-	return tea.Shutdown
+
+	return msg
 }
 
 type model struct {

--- a/options.go
+++ b/options.go
@@ -141,3 +141,32 @@ func WithANSICompressor() ProgramOption {
 		p.startupOptions |= withANSICompressor
 	}
 }
+
+// WithOnQuit supplies an event handler that will be invoked whenever Bubble
+// Tea receives a QuitMsg. The event handler can return tea.Shutdown to
+// instruct Bubble Tea to handle the QuitMsg normally and shut the program
+// down, or it can return tea.PreventShutdown to prevent the program from
+// shutting down and instead handle the QuitMsg like a normal message and
+// pass it along to the model's Update method.
+//
+// Example:
+//
+//	func onQuit(m tea.Model) tea.QuitBehavior {
+//	    model := m.(myModel)
+//	    if model.hasChanges {
+//	        return tea.PreventShutdown
+//	    }
+//	    return tea.Shutdown
+//	}
+//
+//	p := tea.NewProgram(Model{}, tea.WithOnQuit(onQuit));
+//
+//	if _,err := p.Run(); err != nil {
+//		fmt.Println("Error running program:", err)
+//		os.Exit(1)
+//	}
+func WithOnQuit(onQuit func(Model) QuitBehavior) ProgramOption {
+	return func(p *Program) {
+		p.onQuit = onQuit
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -35,10 +35,10 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("on quit", func(t *testing.T) {
-		p := NewProgram(nil, WithOnQuit(func(Model) QuitBehavior { return Shutdown }))
-		if p.onQuit == nil {
-			t.Errorf("expected onQuit to be set")
+	t.Run("filter", func(t *testing.T) {
+		p := NewProgram(nil, WithFilter(func(_ Model, msg Msg) Msg { return msg }))
+		if p.filter == nil {
+			t.Errorf("expected filter to be set")
 		}
 	})
 

--- a/options_test.go
+++ b/options_test.go
@@ -35,6 +35,13 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
+	t.Run("on quit", func(t *testing.T) {
+		p := NewProgram(nil, WithOnQuit(func(Model) QuitBehavior { return Shutdown }))
+		if p.onQuit == nil {
+			t.Errorf("expected onQuit to be set")
+		}
+	})
+
 	t.Run("startup options", func(t *testing.T) {
 		exercise := func(t *testing.T, opt ProgramOption, expect startupOptions) {
 			p := NewProgram(nil, opt)

--- a/tea_test.go
+++ b/tea_test.go
@@ -76,13 +76,13 @@ func TestTeaQuit(t *testing.T) {
 	}
 }
 
-func TestTeaWithOnQuit(t *testing.T) {
-	testTeaWithOnQuit(t, 0)
-	testTeaWithOnQuit(t, 1)
-	testTeaWithOnQuit(t, 2)
+func TestTeaWithFilter(t *testing.T) {
+	testTeaWithFilter(t, 0)
+	testTeaWithFilter(t, 1)
+	testTeaWithFilter(t, 2)
 }
 
-func testTeaWithOnQuit(t *testing.T, preventCount uint32) {
+func testTeaWithFilter(t *testing.T, preventCount uint32) {
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -91,12 +91,15 @@ func testTeaWithOnQuit(t *testing.T, preventCount uint32) {
 	p := NewProgram(m,
 		WithInput(&in),
 		WithOutput(&buf),
-		WithOnQuit(func(Model) QuitBehavior {
+		WithFilter(func(_ Model, msg Msg) Msg {
+			if _, ok := msg.(QuitMsg); !ok {
+				return msg
+			}
 			if shutdowns < preventCount {
 				atomic.AddUint32(&shutdowns, 1)
-				return PreventShutdown
+				return nil
 			}
-			return Shutdown
+			return msg
 		}))
 
 	go func() {


### PR DESCRIPTION
`WithFilter` lets you supply an event filter that will be invoked before Bubble Tea processes a `tea.Msg`. The event filter can return any `tea.Msg` which will then get handled by Bubble Tea instead of the original event. If the event filter returns `nil`, the event will be ignored and Bubble Tea will not process it.

As an example, this could be used to prevent a program from shutting down if there are unsaved changes.

Based on the fantastic work by @aschey and supersedes https://github.com/charmbracelet/bubbletea/pull/521.

Might make #114 more relevant.
Resolves https://github.com/charmbracelet/bubbletea/issues/472.