### PR TITLE
Use latest commit for tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ import (
 )
 ```
 
+Be sure to pull the latest version of the Bubble Tea library for this tutorial.
+
+```
+go get github.com/charmbracelet/bubbletea@master
+```
+
 Bubble Tea programs are comprised of a **model** that describes the application
 state and three simple methods on that model:
 

--- a/tutorials/basics/README.md
+++ b/tutorials/basics/README.md
@@ -31,6 +31,12 @@ import (
 )
 ```
 
+Be sure to pull the latest version of the Bubble Tea library for this tutorial.
+
+```
+go get github.com/charmbracelet/bubbletea@master
+```
+
 Bubble Tea programs are comprised of a **model** that describes the application
 state and three simple methods on that model:
 

--- a/tutorials/commands/README.md
+++ b/tutorials/commands/README.md
@@ -33,6 +33,12 @@ import (
 const url = "https://charm.sh/"
 ```
 
+Be sure to pull the latest version of the Bubble Tea library for this tutorial.
+
+```
+go get github.com/charmbracelet/bubbletea@master
+```
+
 ## The Model
 
 Next we'll define our model. The only things we need to store are the status


### PR DESCRIPTION
I started going through the tutorial after stumbling upon your [beautiful website](https://charm.sh/). I used `go get ./...` to pull down the `bubbletea` dependency which pulls down version `v0.22.1`, but this release does not include the `.Run()` method (added in https://github.com/charmbracelet/bubbletea/pull/509). Hence, the tutorial in the README includes a compilation error unless you use a non-tagged version.

This PR adds an explicit callout to use `@master`. I thought this might be a nice tip in case others discovery this library before the next tag (assuming it includes the `.Run()` change).