### PR TITLE
docs: Fix README.md example's main function (`p.Run` -> `p.Start`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The last step is to simply run our program. We pass our initial model to
 ```go
 func main() {
     p := tea.NewProgram(initialModel())
-    if _, err := p.Run(); err != nil {
+    if err := p.Start(); err != nil {
         fmt.Printf("Alas, there's been an error: %v", err)
         os.Exit(1)
     }


### PR DESCRIPTION
There's a bug in the example's `main` function, because `*tea.Program` does not have a `Run` method, it has a `Start` method.

This patch fixes the issue by replacing the `p.Run` call with `p.Start`.