### PR TITLE
fix: restore Windows console mode on shutdown

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -442,7 +442,6 @@ func (p *Program) Run() (Model, error) {
 		if err := p.initCancelReader(); err != nil {
 			return model, err
 		}
-		defer p.cancelReader.Close() //nolint:errcheck
 	}
 
 	// Handle resize events.
@@ -468,6 +467,7 @@ func (p *Program) Run() (Model, error) {
 	if p.cancelReader.Cancel() {
 		p.waitForReadLoop()
 	}
+	_ = p.cancelReader.Close()
 
 	// Wait for all handlers to finish.
 	handlers.shutdown()


### PR DESCRIPTION
The deferred Close call on our input reader caused the console mode to be reset twice, and the incorrect, inner mode was applied last.

Fixes #408.
Potentially fixes #563.

Fixes gum#119.
Potentially fixes gum#32.