### PR TITLE
Support changing background color

### DIFF
--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -1,19 +1,23 @@
 package tea
 
+import "github.com/muesli/termenv"
+
 type nilRenderer struct{}
 
-func (n nilRenderer) start()                  {}
-func (n nilRenderer) stop()                   {}
-func (n nilRenderer) kill()                   {}
-func (n nilRenderer) write(v string)          {}
-func (n nilRenderer) repaint()                {}
-func (n nilRenderer) clearScreen()            {}
-func (n nilRenderer) altScreen() bool         { return false }
-func (n nilRenderer) enterAltScreen()         {}
-func (n nilRenderer) exitAltScreen()          {}
-func (n nilRenderer) showCursor()             {}
-func (n nilRenderer) hideCursor()             {}
-func (n nilRenderer) enableMouseCellMotion()  {}
-func (n nilRenderer) disableMouseCellMotion() {}
-func (n nilRenderer) enableMouseAllMotion()   {}
-func (n nilRenderer) disableMouseAllMotion()  {}
+func (n nilRenderer) start()                             {}
+func (n nilRenderer) stop()                              {}
+func (n nilRenderer) kill()                              {}
+func (n nilRenderer) write(v string)                     {}
+func (n nilRenderer) repaint()                           {}
+func (n nilRenderer) clearScreen()                       {}
+func (n nilRenderer) altScreen() bool                    { return false }
+func (n nilRenderer) enterAltScreen()                    {}
+func (n nilRenderer) exitAltScreen()                     {}
+func (n nilRenderer) showCursor()                        {}
+func (n nilRenderer) hideCursor()                        {}
+func (n nilRenderer) enableMouseCellMotion()             {}
+func (n nilRenderer) disableMouseCellMotion()            {}
+func (n nilRenderer) enableMouseAllMotion()              {}
+func (n nilRenderer) disableMouseAllMotion()             {}
+func (n nilRenderer) setBackgroundColor(c termenv.Color) {}
+func (n nilRenderer) resetBackgroundColor()              {}

--- a/nil_renderer_test.go
+++ b/nil_renderer_test.go
@@ -1,6 +1,10 @@
 package tea
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/muesli/termenv"
+)
 
 func TestNilRenderer(t *testing.T) {
 	r := nilRenderer{}
@@ -21,4 +25,6 @@ func TestNilRenderer(t *testing.T) {
 	r.disableMouseCellMotion()
 	r.enableMouseAllMotion()
 	r.disableMouseAllMotion()
+	r.setBackgroundColor(termenv.RGBColor("#ffffff"))
+	r.resetBackgroundColor()
 }

--- a/options.go
+++ b/options.go
@@ -141,3 +141,19 @@ func WithANSICompressor() ProgramOption {
 		p.startupOptions |= withANSICompressor
 	}
 }
+
+// WithBackgroundColor sets the background color of a program.
+// The background color is automatically reset when the program exits.
+//
+// Example:
+//
+//	p := tea.NewProgram(Model{}, tea.WithBackgroundColor(termenv.RGBColor("#eeeeee")))
+//	if _, err := p.Run(); err != nil {
+//	    fmt.Println("Error running program:", err)
+//	    os.Exit(1)
+//	}
+func WithBackgroundColor(c termenv.Color) ProgramOption {
+	return func(p *Program) {
+		p.backgroundColor = c
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -3,6 +3,8 @@ package tea
 import (
 	"bytes"
 	"testing"
+
+	"github.com/muesli/termenv"
 )
 
 func TestOptions(t *testing.T) {
@@ -32,6 +34,13 @@ func TestOptions(t *testing.T) {
 			return
 		default:
 			t.Errorf("expected renderer to be a nilRenderer, got %v", p.renderer)
+		}
+	})
+
+	t.Run("background color", func(t *testing.T) {
+		p := NewProgram(nil, WithBackgroundColor(termenv.ANSIBlack))
+		if p.backgroundColor == nil {
+			t.Error("expected background color to be set")
 		}
 	})
 

--- a/renderer.go
+++ b/renderer.go
@@ -1,5 +1,7 @@
 package tea
 
+import "github.com/muesli/termenv"
+
 // renderer is the interface for Bubble Tea renderers.
 type renderer interface {
 	// Start the renderer.
@@ -50,6 +52,11 @@ type renderer interface {
 
 	// DisableMouseAllMotion disables All Motion mouse tracking.
 	disableMouseAllMotion()
+
+	// Sets background color of the terminal.
+	setBackgroundColor(termenv.Color)
+	// Resets background color to the original color before the renderer started.
+	resetBackgroundColor()
 }
 
 // repaintMsg forces a full repaint.

--- a/screen.go
+++ b/screen.go
@@ -31,6 +31,14 @@ type clearScreenMsg struct{}
 // This can be used in the Init function to set a different background color for
 // the program. The background color is reset to the original state when the
 // program exits.
+//
+// Example:
+//
+//	func (m model) Init() tea.Cmd {
+//	    return tea.Cmd(func() tea.Msg {
+//	        return tea.SetBackgroundColor(termenv.RGBColor("#eeeeee"))
+//	    })
+//	}
 func SetBackgroundColor(c termenv.Color) Msg {
 	return backgroundColorMsg{color: c}
 }

--- a/screen.go
+++ b/screen.go
@@ -1,5 +1,7 @@
 package tea
 
+import "github.com/muesli/termenv"
+
 // WindowSizeMsg is used to report the terminal size. It's sent to Update once
 // initially and then on every terminal resize. Note that Windows does not
 // have support for reporting when resizes occur as it does not support the
@@ -22,6 +24,22 @@ func ClearScreen() Msg {
 // clearScreenMsg is an internal message that signals to clear the screen.
 // You can send a clearScreenMsg with ClearScreen.
 type clearScreenMsg struct{}
+
+// SetBackgroundColor is a special command that tells the Bubble Tea program to
+// set background color of the terminal.
+//
+// This can be used in the Init function to set a different background color for
+// the program. The background color is reset to the original state when the
+// program exits.
+func SetBackgroundColor(c termenv.Color) Msg {
+	return backgroundColorMsg{color: c}
+}
+
+// backgroundColorMsg is an internal message that signals to change the
+// background color. You can send a backgroundColorMsg with SetBackgroundColor.
+type backgroundColorMsg struct {
+	color termenv.Color
+}
 
 // EnterAltScreen is a special command that tells the Bubble Tea program to
 // enter the alternate screen buffer.

--- a/screen_test.go
+++ b/screen_test.go
@@ -3,9 +3,11 @@ package tea
 import (
 	"bytes"
 	"testing"
+
+	"github.com/muesli/termenv"
 )
 
-func TestClearMsg(t *testing.T) {
+func TestInternalMsg(t *testing.T) {
 	tests := []struct {
 		name     string
 		cmds     sequenceMsg
@@ -50,6 +52,11 @@ func TestClearMsg(t *testing.T) {
 			name:     "cursor_hideshow",
 			cmds:     []Cmd{HideCursor, ShowCursor},
 			expected: "\x1b[?25l\x1b[?25l\x1b[?25hsuccess\r\n\x1b[0D\x1b[2K\x1b[?25h\x1b[?1002l\x1b[?1003l",
+		},
+		{
+			name:     "set_background_color",
+			cmds:     []Cmd{func() Msg { return SetBackgroundColor(termenv.RGBColor("#eeeeee")) }},
+			expected: "\x1b[?25l\x1b]11;#eeeeee\asuccess\r\n\x1b[0D\x1b[2K\x1b[?25h\x1b[?1002l\x1b[?1003l",
 		},
 	}
 

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -47,17 +47,21 @@ type standardRenderer struct {
 
 	// lines explicitly set not to render
 	ignoreLines map[int]struct{}
+
+	// background color when renderer is created
+	defaultBackgroundColor termenv.Color
 }
 
 // newRenderer creates a new renderer. Normally you'll want to initialize it
 // with os.Stdout as the first argument.
 func newRenderer(out *termenv.Output, useANSICompressor bool) renderer {
 	r := &standardRenderer{
-		out:                out,
-		mtx:                &sync.Mutex{},
-		framerate:          defaultFramerate,
-		useANSICompressor:  useANSICompressor,
-		queuedMessageLines: []string{},
+		out:                    out,
+		mtx:                    &sync.Mutex{},
+		framerate:              defaultFramerate,
+		useANSICompressor:      useANSICompressor,
+		queuedMessageLines:     []string{},
+		defaultBackgroundColor: out.BackgroundColor(),
 	}
 	if r.useANSICompressor {
 		r.out = termenv.NewOutput(&compressor.Writer{Forward: out})
@@ -356,6 +360,20 @@ func (r *standardRenderer) disableMouseAllMotion() {
 	defer r.mtx.Unlock()
 
 	r.out.DisableMouseAllMotion()
+}
+
+func (r *standardRenderer) setBackgroundColor(c termenv.Color) {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	r.out.SetBackgroundColor(c)
+}
+
+func (r *standardRenderer) resetBackgroundColor() {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	r.out.SetBackgroundColor(r.defaultBackgroundColor)
 }
 
 // setIgnoredLines specifies lines not to be touched by the standard Bubble Tea

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -373,7 +373,9 @@ func (r *standardRenderer) resetBackgroundColor() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	r.out.SetBackgroundColor(r.defaultBackgroundColor)
+	if r.out.BackgroundColor() != r.defaultBackgroundColor {
+		r.out.SetBackgroundColor(r.defaultBackgroundColor)
+	}
 }
 
 // setIgnoredLines specifies lines not to be touched by the standard Bubble Tea

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -50,6 +50,8 @@ type standardRenderer struct {
 
 	// background color when renderer is created
 	defaultBackgroundColor termenv.Color
+	// flag if background color has been changed
+	backgroundColorChanged bool
 }
 
 // newRenderer creates a new renderer. Normally you'll want to initialize it
@@ -62,6 +64,7 @@ func newRenderer(out *termenv.Output, useANSICompressor bool) renderer {
 		useANSICompressor:      useANSICompressor,
 		queuedMessageLines:     []string{},
 		defaultBackgroundColor: out.BackgroundColor(),
+		backgroundColorChanged: false,
 	}
 	if r.useANSICompressor {
 		r.out = termenv.NewOutput(&compressor.Writer{Forward: out})
@@ -366,6 +369,7 @@ func (r *standardRenderer) setBackgroundColor(c termenv.Color) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
+	r.backgroundColorChanged = true
 	r.out.SetBackgroundColor(c)
 }
 
@@ -373,7 +377,7 @@ func (r *standardRenderer) resetBackgroundColor() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
-	if r.out.BackgroundColor() != r.defaultBackgroundColor {
+	if r.backgroundColorChanged && r.defaultBackgroundColor.Sequence(true) != "" {
 		r.out.SetBackgroundColor(r.defaultBackgroundColor)
 	}
 }

--- a/tea.go
+++ b/tea.go
@@ -302,6 +302,9 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			case hideCursorMsg:
 				p.renderer.hideCursor()
 
+			case backgroundColorMsg:
+				p.renderer.setBackgroundColor(msg.color)
+
 			case execMsg:
 				// NB: this blocks.
 				p.exec(msg.cmd, msg.fn)

--- a/tea.go
+++ b/tea.go
@@ -115,6 +115,9 @@ type Program struct {
 	altScreenWasActive bool
 	ignoreSignals      bool
 
+	// color to be used for background when program starts
+	backgroundColor termenv.Color
+
 	// Stores the original reference to stdin for cases where input is not a
 	// TTY on windows and we've automatically opened CONIN$ to receive input.
 	// When the program exits this will be restored.
@@ -416,6 +419,11 @@ func (p *Program) Run() (Model, error) {
 		p.renderer.enableMouseCellMotion()
 	} else if p.startupOptions&withMouseAllMotion != 0 {
 		p.renderer.enableMouseAllMotion()
+	}
+
+	// Set background color
+	if p.backgroundColor != nil {
+		p.renderer.setBackgroundColor(p.backgroundColor)
 	}
 
 	// Initialize the program.

--- a/tty.go
+++ b/tty.go
@@ -32,6 +32,7 @@ func (p *Program) restoreTerminalState() error {
 		p.renderer.showCursor()
 		p.renderer.disableMouseCellMotion()
 		p.renderer.disableMouseAllMotion()
+		p.renderer.resetBackgroundColor()
 
 		if p.renderer.altScreen() {
 			p.renderer.exitAltScreen()


### PR DESCRIPTION
Closes #207 

This PR adds support for changing background color of a terminal and resets it back to the original color when a program exits.
The color can be changed by sending a special internal message, for example in the init function, such as:

```go
func (m model) Init() tea.Cmd {
  return tea.Cmd(func() tea.Msg {
    return tea.SetBackgroundColor(termenv.RGBColor("#eeeeee"))
  })
}
```

This is the first method in the `renderer` which accepts an argument.
Happy to discuss alternatives in case this breaks renderer's design.

The method `SetBackgroundColor(c termenv.Color) Msg` could be changed to accept hex colors via a string `SetBackgroundColor(c string) Msg`, but the former provides more flexibility with color definition format.