### PR TITLE
docs: update README tutorial with Start function

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ The last step is to simply run our program. We pass our initial model to
 ```go
 func main() {
     p := tea.NewProgram(initialModel())
-    if _, err := p.Run(); err != nil {
+    if _, err := p.Start(); err != nil {
         fmt.Printf("Alas, there's been an error: %v", err)
         os.Exit(1)
     }


### PR DESCRIPTION
## Summary
Hello, I am new here, so please correct me if I am mistaken. 😄

I went through the tutorial mentioned in the README, and I received the following error:
```
./main.go:107:19: p.Run undefined (type *tea.Program has no field or method Run)
```

Therefore, I am guessing the line within the README should be `p.Start()`?

After switching to `p.Start()`, the program ran as expected:
```
$ go run main.go 
What should we buy at the market?

  [ ] Buy carrots
  [ ] Buy celery
> [ ] Buy kohlrabi

Press q to quit.
```

Please let me know if I should create an issue, or if there is anything else that I might be missing.

## Versions
Bubbletea: v0.22.1
Go: go1.17.7
OS: darwin/amd64