### PR TITLE
(feat): Add option to set max FPS

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package tea
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/muesli/termenv"
 )
@@ -198,5 +199,16 @@ func WithANSICompressor() ProgramOption {
 func WithFilter(filter func(Model, Msg) Msg) ProgramOption {
 	return func(p *Program) {
 		p.filter = filter
+	}
+}
+
+// WithMaxFPS sets a custom maximum FPS at which we should
+// update the view.
+func WithMaxFPS(fps uint) ProgramOption {
+	if fps > maxFPS {
+		fps = maxFPS
+	}
+	return func(p *Program) {
+		p.framerate = time.Second / time.Duration(fps)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -3,7 +3,6 @@ package tea
 import (
 	"context"
 	"io"
-	"time"
 
 	"github.com/muesli/termenv"
 )
@@ -202,13 +201,11 @@ func WithFilter(filter func(Model, Msg) Msg) ProgramOption {
 	}
 }
 
-// WithMaxFPS sets a custom maximum FPS at which we should
-// update the view.
-func WithMaxFPS(fps uint) ProgramOption {
-	if fps > maxFPS {
-		fps = maxFPS
-	}
+// WithMaxFPS sets a custom maximum FPS at which the renderer should run. If
+// less than 1, the default value of 60 will be used. If over 120, the FPS
+// will be capped at 120.
+func WithFPS(fps int) ProgramOption {
 	return func(p *Program) {
-		p.framerate = time.Second / time.Duration(fps)
+		p.fps = fps
 	}
 }

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -16,9 +16,8 @@ import (
 const (
 	// defaultFramerate specifies the maximum interval at which we should
 	// update the view.
-	defaultFramerate = time.Second / 60
-
-	maxFPS = 120
+	defaultFPS = 60
+	maxFPS     = 120
 )
 
 // standardRenderer is a framerate-based terminal renderer, updating the view
@@ -56,15 +55,17 @@ type standardRenderer struct {
 
 // newRenderer creates a new renderer. Normally you'll want to initialize it
 // with os.Stdout as the first argument.
-func newRenderer(out *termenv.Output, useANSICompressor bool, framerate time.Duration) renderer {
-	if framerate == 0 {
-		framerate = defaultFramerate
+func newRenderer(out *termenv.Output, useANSICompressor bool, fps int) renderer {
+	if fps < 1 {
+		fps = defaultFPS
+	} else if fps > maxFPS {
+		fps = maxFPS
 	}
 	r := &standardRenderer{
 		out:                out,
 		mtx:                &sync.Mutex{},
 		done:               make(chan struct{}),
-		framerate:          framerate,
+		framerate:          time.Second / time.Duration(fps),
 		useANSICompressor:  useANSICompressor,
 		queuedMessageLines: []string{},
 	}

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -17,6 +17,8 @@ const (
 	// defaultFramerate specifies the maximum interval at which we should
 	// update the view.
 	defaultFramerate = time.Second / 60
+
+	maxFPS = 120
 )
 
 // standardRenderer is a framerate-based terminal renderer, updating the view
@@ -54,12 +56,15 @@ type standardRenderer struct {
 
 // newRenderer creates a new renderer. Normally you'll want to initialize it
 // with os.Stdout as the first argument.
-func newRenderer(out *termenv.Output, useANSICompressor bool) renderer {
+func newRenderer(out *termenv.Output, useANSICompressor bool, framerate time.Duration) renderer {
+	if framerate == 0 {
+		framerate = defaultFramerate
+	}
 	r := &standardRenderer{
 		out:                out,
 		mtx:                &sync.Mutex{},
 		done:               make(chan struct{}),
-		framerate:          defaultFramerate,
+		framerate:          framerate,
 		useANSICompressor:  useANSICompressor,
 		queuedMessageLines: []string{},
 	}

--- a/tea.go
+++ b/tea.go
@@ -19,7 +19,6 @@ import (
 	"runtime/debug"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/containerd/console"
 	isatty "github.com/mattn/go-isatty"
@@ -146,9 +145,9 @@ type Program struct {
 
 	filter func(Model, Msg) Msg
 
-	// framerate specifies a custom maximum interval at which we should
-	// update the view. If it is 0, the default value is used.
-	framerate time.Duration
+	// fps is the frames per second we should set on the renderer, if
+	// applicable,
+	fps int
 }
 
 // Quit is a special command that tells the Bubble Tea program to exit.
@@ -446,7 +445,7 @@ func (p *Program) Run() (Model, error) {
 
 	// If no renderer is set use the standard one.
 	if p.renderer == nil {
-		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor), p.framerate)
+		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor), p.fps)
 	}
 
 	// Check if output is a TTY before entering raw mode, hiding the cursor and

--- a/tea.go
+++ b/tea.go
@@ -19,6 +19,7 @@ import (
 	"runtime/debug"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/containerd/console"
 	isatty "github.com/mattn/go-isatty"
@@ -144,6 +145,10 @@ type Program struct {
 	windowsStdin *os.File //nolint:golint,structcheck,unused
 
 	filter func(Model, Msg) Msg
+
+	// framerate specifies a custom maximum interval at which we should
+	// update the view. If it is 0, the default value is used.
+	framerate time.Duration
 }
 
 // Quit is a special command that tells the Bubble Tea program to exit.
@@ -441,7 +446,7 @@ func (p *Program) Run() (Model, error) {
 
 	// If no renderer is set use the standard one.
 	if p.renderer == nil {
-		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor))
+		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor), p.framerate)
 	}
 
 	// Check if output is a TTY before entering raw mode, hiding the cursor and


### PR DESCRIPTION
Solves issue #577 

Added the ~`WithMaxFPS`~ `WithFPS` option to bubbletea program struct, if it is set with a non 0 value it will set the maximum interval at which the view is updated, if it is not set or set to 0, the interval will be the `defaultFramerate` constant.