### PR TITLE
chore: apply ProgramOptions before checking context

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -141,19 +141,18 @@ func NewProgram(model Model, opts ...ProgramOption) *Program {
 		msgs:         make(chan Msg),
 	}
 
+	// Apply all options to the program.
+	for _, opt := range opts {
+		opt(p)
+	}
+
 	// A context can be provided with a ProgramOption, but if none was provided
 	// we'll use the default background context.
 	if p.ctx == nil {
 		p.ctx = context.Background()
 	}
-
 	// Initialize context and teardown channel.
 	p.ctx, p.cancel = context.WithCancel(p.ctx)
-
-	// Apply all options to the program.
-	for _, opt := range opts {
-		opt(p)
-	}
 
 	// if no output was set, set it to stdout
 	if p.output == nil {


### PR DESCRIPTION
We don't need to set the background context if an outside context was supplied.