### PR TITLE
Update p.Run() to p.Start()

### DIFF
--- a/examples/realtime/main.go
+++ b/examples/realtime/main.go
@@ -85,8 +85,8 @@ func main() {
 		spinner: spinner.New(),
 	})
 
-	if _, err := p.Run(); err != nil {
-		fmt.Println("could not start program:", err)
+	if err := p.Start(); err != nil {
+		fmt.Println("could not start the program:", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
After copy pasting the code to start toying with it, I got an error: p.Run undefined (type *tea.Program has no field or method Run)compilerMissingFieldOrMethod. P.Start() doesn't error, and seems like the correct method. My GO version: go version go1.19.1 darwin/arm64. Using v0.22.1