### PR TITLE
Remove references to io/ioutil package

### DIFF
--- a/examples/pager/main.go
+++ b/examples/pager/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -129,7 +128,7 @@ func max(a, b int) int {
 
 func main() {
 	// Load some text for our viewport
-	content, err := ioutil.ReadFile("artichoke.md")
+	content, err := os.ReadFile("artichoke.md")
 	if err != nil {
 		fmt.Println("could not load file:", err)
 		os.Exit(1)

--- a/examples/tui-daemon-combo/main.go
+++ b/examples/tui-daemon-combo/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"os"
@@ -41,7 +41,7 @@ func main() {
 		opts = []tea.ProgramOption{tea.WithoutRenderer()}
 	} else {
 		// If we're in TUI mode, discard log output
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	p := tea.NewProgram(newModel(), opts...)


### PR DESCRIPTION
Package io/ioutil has been marked deprecated starting in Go 1.16.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>