### PR TITLE
fix: pass actual stdout's fd to command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -109,7 +109,7 @@ func (p *Program) exec(c ExecCommand, fn ExecCallback) {
 	}
 
 	c.SetStdin(p.input)
-	c.SetStdout(p.output)
+	c.SetStdout(p.output.TTY())
 	c.SetStderr(os.Stderr)
 
 	// Execute system command.


### PR DESCRIPTION
Commands need the actual fd, not our internal output writer. Regression from 6c449e55bf0033e3d7176f48832e83d1470566d3.