### PR TITLE
feat(frame-rate): add configurable frame-rate option

### DIFF
--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -1,5 +1,7 @@
 package tea
 
+import "time"
+
 type nilRenderer struct{}
 
 func (n nilRenderer) start()                  {}
@@ -17,3 +19,4 @@ func (n nilRenderer) enableMouseCellMotion()  {}
 func (n nilRenderer) disableMouseCellMotion() {}
 func (n nilRenderer) enableMouseAllMotion()   {}
 func (n nilRenderer) disableMouseAllMotion()  {}
+func (n nilRenderer) frameRate(time.Duration) {}

--- a/renderer.go
+++ b/renderer.go
@@ -1,5 +1,7 @@
 package tea
 
+import "time"
+
 // renderer is the interface for Bubble Tea renderers.
 type renderer interface {
 	// Start the renderer.
@@ -50,6 +52,10 @@ type renderer interface {
 
 	// DisableMouseAllMotion disables All Motion mouse tracking.
 	disableMouseAllMotion()
+
+	// FrameRate sets frame rate of program
+	// if not set; default will be used
+	frameRate(time.Duration)
 }
 
 // repaintMsg forces a full repaint.

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -539,6 +539,12 @@ func (r *standardRenderer) handleMessages(msg Msg) {
 	}
 }
 
+// FrameRate sets frame rate of program
+// if not set; default will be used
+func (r *standardRenderer) frameRate(d time.Duration) {
+	r.framerate = d
+}
+
 // HIGH-PERFORMANCE RENDERING STUFF
 
 type syncScrollAreaMsg struct {

--- a/tea.go
+++ b/tea.go
@@ -19,6 +19,7 @@ import (
 	"runtime/debug"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/containerd/console"
 	isatty "github.com/mattn/go-isatty"
@@ -468,6 +469,18 @@ func (p *Program) Run() (Model, error) {
 	p.shutdown(killed)
 
 	return model, err
+}
+
+// FrameRate will set the renderer frame rate
+// if not set, default (1/60s) will be used
+func (p *Program) FrameRate(d time.Duration) error {
+	if p.renderer != nil {
+		return errors.New("frame rate already being set")
+	}
+
+	p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor))
+	p.renderer.frameRate(d)
+	return nil
 }
 
 // StartReturningModel initializes the program and runs its event loops,


### PR DESCRIPTION
By this changes, we will be able to set frame rate before starting our program.

```go
p := tea.NewProgram(&m, tea.WithAltScreen())
p.FrameRate(time.Second) // setting frame rate to one second
if err := p.Start(); err != nil {
        fmt.Println("Error running program:", err)
        os.Exit(1)
}
```

fix #577 