### PR TITLE
fix: Check if program cancelReader is is nil before invoking

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -459,11 +459,14 @@ func (p *Program) Run() (Model, error) {
 	// Tear down.
 	p.cancel()
 
-	// Wait for input loop to finish.
-	if p.cancelReader.Cancel() {
-		p.waitForReadLoop()
+	// Check if the cancel reader has been setup before waiting and closing.
+	if p.cancelReader != nil {
+		// Wait for input loop to finish.
+		if p.cancelReader.Cancel() {
+			p.waitForReadLoop()
+		}
+		_ = p.cancelReader.Close()
 	}
-	_ = p.cancelReader.Close()
 
 	// Wait for all handlers to finish.
 	handlers.shutdown()


### PR DESCRIPTION
This PR fixes an issue where a user may provide a nil input via `tea.WithInput(nil)`.  This option method does not check if the input is nil and sets the `withCustomInput` attribute with a nil input. This logic is sound since a Tea program may not necessarily want to handle any inputs from users (such as those in non-TTY environments).

However, a nil pointer exception is thrown during `tea.Run` because the `cancelReader` is always invoked after the main renderer.  Its instantiation is variable and dependent on whether an input is provided. To mitigate against this, this PR checks if `cancelReader` is non-nil.