### PR TITLE
feat: LogToFileWith

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -1,6 +1,7 @@
 package tea
 
 import (
+	"io"
 	"log"
 	"os"
 	"unicode"
@@ -19,6 +20,18 @@ import (
 //	  }
 //	  defer f.Close()
 func LogToFile(path string, prefix string) (*os.File, error) {
+	return LogToFileWith(path, prefix, log.Default())
+}
+
+// LogOptionsSetter is an interface implemented by stdlib's log and charm's log
+// libraries.
+type LogOptionsSetter interface {
+	SetOutput(io.Writer)
+	SetPrefix(string)
+}
+
+// LogToFileWith does allows to call LogToFile with a custom LogOptionsSetter.
+func LogToFileWith(path string, prefix string, log LogOptionsSetter) (*os.File, error) {
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Allows to log to file with custom loggers, provided they implement SetOutput and SetPrefix.

This would allow to do something like:

```go
// ...
import "github.com/charmbracelet/log"
// ...
// ...
  tea.LogToFileWith("foo.log", "prefix", log.Default())
// ...
```