### PR TITLE
docs: remove british spelling

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,7 +12,7 @@ A clear and concise description of what the bug is.
 
 **Setup**
 Please complete the following information along with version numbers, if applicable.
- - OS [e.g. Ubuntu, Mac OS]
+ - OS [e.g. Ubuntu, macOS]
  - Shell [e.g. zsh, fish]
  - Terminal Emulator [e.g. kitty, iterm]
  - Terminal Multiplexer [e.g. tmux]
@@ -25,7 +25,7 @@ Steps to reproduce the behavior:
 4. See error
 
 **Source Code**
-Please include source code if needed to reproduce the behaviour. 
+Please include source code if needed to reproduce the behavior. 
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.


### PR DESCRIPTION
Wanted to correct spelling before carrying over the templates to other repos heh