### PR TITLE
fix: do not create an output from an output

### DIFF
--- a/options.go
+++ b/options.go
@@ -28,7 +28,12 @@ func WithContext(ctx context.Context) ProgramOption {
 // won't need to use this.
 func WithOutput(output io.Writer) ProgramOption {
 	return func(p *Program) {
-		p.output = termenv.NewOutput(output, termenv.WithColorCache(true))
+		switch o := output.(type) {
+		case *termenv.Output:
+			p.output = o
+		default:
+			p.output = termenv.NewOutput(o, termenv.WithColorCache(true))
+		}
 	}
 }
 


### PR DESCRIPTION
if the user uses `WithOutput(o)`, and `o` is already a `*termenv.Output`, hell breaks loos (at least if you do it over SSH, haven't tested plain).

Anyway, we should probably not create a new output from an existing output? if so, this should do it.