### PR TITLE
fix(examples): update textinputs code to remove deprecated mouse mode handling

### DIFF
--- a/examples/textinputs/main.go
+++ b/examples/textinputs/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -28,7 +29,7 @@ var (
 type model struct {
 	focusIndex int
 	inputs     []textinput.Model
-	cursorMode textinput.CursorMode
+	cursorMode cursor.Mode
 }
 
 func initialModel() model {
@@ -77,12 +78,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Change cursor mode
 		case "ctrl+r":
 			m.cursorMode++
-			if m.cursorMode > textinput.CursorHide {
-				m.cursorMode = textinput.CursorBlink
+			if m.cursorMode > cursor.CursorHide {
+				m.cursorMode = cursor.CursorBlink
 			}
 			cmds := make([]tea.Cmd, len(m.inputs))
 			for i := range m.inputs {
-				cmds[i] = m.inputs[i].SetCursorMode(m.cursorMode)
+				cmds[i] = m.inputs[i].Cursor.SetMode(m.cursorMode)
 			}
 			return m, tea.Batch(cmds...)
 


### PR DESCRIPTION
This PR includes some small corrections to the textinputs example, regarding how mouse modes should now be handled by [bubbles](https://github.com/charmbracelet/bubbles). The old ways to set and get the modes are now deprecated.