### PR TITLE
fix: Possible Goroutine hang if input occurs during program exit

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -89,7 +89,11 @@ func (p *Program) readLoop() {
 		}
 
 		for _, msg := range msgs {
-			p.msgs <- msg
+			select {
+			case p.msgs <- msg:
+			case <-p.ctx.Done():
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
This only seems to happen in some cases, but I have noticed if I use bubbletea with the `tea.WithInput` option there's a chance `readLoop` will hang on line 92 if a user inputs characters at the same time as the program exits. This results in a very gradual memory leak.

This PR allows `readLoop` to short-circuit when reading input if the program has been killed.