### PR TITLE
fix: Index out of range in examples/credit-card-form when ccn is empty

### DIFF
--- a/examples/credit-card-form/main.go
+++ b/examples/credit-card-form/main.go
@@ -53,13 +53,14 @@ func ccnValidator(s string) error {
 		return fmt.Errorf("CCN is too long")
 	}
 
+	if len(s) == 0 || len(s)%5 != 0 && (s[len(s)-1] < '0' || s[len(s)-1] > '9') {
+		return fmt.Errorf("CCN is invalid")
+	}
+
 	// The last digit should be a number unless it is a multiple of 4 in which
 	// case it should be a space
 	if len(s)%5 == 0 && s[len(s)-1] != ' ' {
 		return fmt.Errorf("CCN must separate groups with spaces")
-	}
-	if len(s)%5 != 0 && (s[len(s)-1] < '0' || s[len(s)-1] > '9') {
-		return fmt.Errorf("CCN is invalid")
 	}
 
 	// The remaining digits should be integers


### PR DESCRIPTION
Fixes Index out of range error in examples/credit-card-form when credit card number(CCN) is not provided.

To reproduce:

- Run examples/credit-card-form/main.go
- Do not type anything in "Card number"
- Press UP or DOWN keys on your keboard (or press TAB several times)

_ccnValidator_ will trigger and will attempt to read a symbol which is located at _len("")-1_, that will cause Index out of range error (because CCN is empty).