### PR TITLE
chore(lint): wrap various TTY-related errors

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -2,6 +2,7 @@ package tea
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"time"
@@ -21,7 +22,7 @@ func (p *Program) initTerminal() error {
 	if p.console != nil {
 		err = p.console.SetRaw()
 		if err != nil {
-			return err
+			return fmt.Errorf("error entering raw mode: %w", err)
 		}
 	}
 
@@ -48,7 +49,7 @@ func (p *Program) restoreTerminalState() error {
 	if p.console != nil {
 		err := p.console.Reset()
 		if err != nil {
-			return err
+			return fmt.Errorf("error restoring terminal state: %w", err)
 		}
 	}
 
@@ -60,7 +61,7 @@ func (p *Program) initCancelReader() error {
 	var err error
 	p.cancelReader, err = cancelreader.NewReader(p.input)
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating cancelreader: %w", err)
 	}
 
 	p.readLoopDone = make(chan struct{})

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -4,6 +4,7 @@
 package tea
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/containerd/console"
@@ -28,7 +29,9 @@ func (p *Program) initInput() error {
 // program exits.
 func (p *Program) restoreInput() error {
 	if p.console != nil {
-		return p.console.Reset()
+		if err := p.console.Reset(); err != nil {
+			return fmt.Errorf("error restoring console: %w", err)
+		}
 	}
 	return nil
 }
@@ -36,7 +39,7 @@ func (p *Program) restoreInput() error {
 func openInputTTY() (*os.File, error) {
 	f, err := os.Open("/dev/tty")
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not open a new TTY: %w", err)
 	}
 	return f, nil
 }


### PR DESCRIPTION
Just soft linter stuff, though I could see this being helpful in development.