### PR TITLE
chore: don't shadow 'handler' type

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -100,18 +100,19 @@ const (
 	withoutCatchPanics
 )
 
-// handlers manages series of channels returned by various processes. It allows
-// us to wait for those processes to terminate before exiting the program.
-type handlers []chan struct{}
+// channelHandlers manages the series of channels returned by various processes.
+// It allows us to wait for those processes to terminate before exiting the
+// program.
+type channelHandlers []chan struct{}
 
 // Adds a channel to the list of handlers. We wait for all handlers to terminate
 // gracefully on shutdown.
-func (h *handlers) add(ch chan struct{}) {
+func (h *channelHandlers) add(ch chan struct{}) {
 	*h = append(*h, ch)
 }
 
 // shutdown waits for all handlers to terminate.
-func (h handlers) shutdown() {
+func (h channelHandlers) shutdown() {
 	var wg sync.WaitGroup
 	for _, ch := range h {
 		wg.Add(1)
@@ -406,7 +407,7 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 // terminated by either [Program.Quit], [Program.Kill], or its signal handler.
 // Returns the final model.
 func (p *Program) Run() (Model, error) {
-	handlers := handlers{}
+	handlers := channelHandlers{}
 	cmds := make(chan Cmd)
 	p.errs = make(chan error)
 	p.finished = make(chan struct{}, 1)


### PR DESCRIPTION
Not really much of a danger, but probably helpful to make the `handler` type name more explicit.