### PR TITLE
fix: race changing ignoreSignals

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package tea
 import (
 	"context"
 	"io"
+	"sync/atomic"
 
 	"github.com/muesli/termenv"
 )
@@ -76,7 +77,7 @@ func WithoutCatchPanics() ProgramOption {
 // This is mainly useful for testing.
 func WithoutSignals() ProgramOption {
 	return func(p *Program) {
-		p.ignoreSignals.Store(true)
+		atomic.StoreUint32(&p.ignoreSignals, 1)
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -76,7 +76,7 @@ func WithoutCatchPanics() ProgramOption {
 // This is mainly useful for testing.
 func WithoutSignals() ProgramOption {
 	return func(p *Program) {
-		p.ignoreSignals = true
+		p.ignoreSignals.Store(true)
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -2,6 +2,7 @@ package tea
 
 import (
 	"bytes"
+	"sync/atomic"
 	"testing"
 )
 
@@ -37,7 +38,7 @@ func TestOptions(t *testing.T) {
 
 	t.Run("without signals", func(t *testing.T) {
 		p := NewProgram(nil, WithoutSignals())
-		if !p.ignoreSignals.Load() {
+		if atomic.LoadUint32(&p.ignoreSignals) == 0 {
 			t.Errorf("ignore signals should have been set")
 		}
 	})

--- a/options_test.go
+++ b/options_test.go
@@ -37,7 +37,7 @@ func TestOptions(t *testing.T) {
 
 	t.Run("without signals", func(t *testing.T) {
 		p := NewProgram(nil, WithoutSignals())
-		if !p.ignoreSignals {
+		if !p.ignoreSignals.Load() {
 			t.Errorf("ignore signals should have been set")
 		}
 	})

--- a/tea.go
+++ b/tea.go
@@ -154,7 +154,7 @@ type Program struct {
 
 	// was the altscreen active before releasing the terminal?
 	altScreenWasActive bool
-	ignoreSignals      atomic.Bool
+	ignoreSignals      uint32
 
 	// Stores the original reference to stdin for cases where input is not a
 	// TTY on windows and we've automatically opened CONIN$ to receive input.
@@ -239,7 +239,7 @@ func (p *Program) handleSignals() chan struct{} {
 				return
 
 			case <-sig:
-				if !p.ignoreSignals.Load() {
+				if atomic.LoadUint32(&p.ignoreSignals) == 0 {
 					p.msgs <- QuitMsg{}
 					return
 				}
@@ -633,7 +633,7 @@ func (p *Program) shutdown(kill bool) {
 // ReleaseTerminal restores the original terminal state and cancels the input
 // reader. You can return control to the Program with RestoreTerminal.
 func (p *Program) ReleaseTerminal() error {
-	p.ignoreSignals.Store(true)
+	atomic.StoreUint32(&p.ignoreSignals, 1)
 	p.cancelReader.Cancel()
 	p.waitForReadLoop()
 
@@ -649,7 +649,7 @@ func (p *Program) ReleaseTerminal() error {
 // terminal to the former state when the program was running, and repaints.
 // Use it to reinitialize a Program after running ReleaseTerminal.
 func (p *Program) RestoreTerminal() error {
-	p.ignoreSignals.Store(false)
+	atomic.StoreUint32(&p.ignoreSignals, 0)
 
 	if err := p.initTerminal(); err != nil {
 		return err


### PR DESCRIPTION
multiple goroutines can try  to `ReleaseTerminal` (and/or `RestoreTerminal`) at the same time, causing a data race.