### PR TITLE
refactor: remove redundant nil check in `flush`

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -208,10 +208,8 @@ func (r *standardRenderer) flush() {
 
 	// Merge the set of lines we're skipping as a rendering optimization with
 	// the set of lines we've explicitly asked the renderer to ignore.
-	if r.ignoreLines != nil {
-		for k, v := range r.ignoreLines {
-			skipLines[k] = v
-		}
+	for k, v := range r.ignoreLines {
+		skipLines[k] = v
 	}
 
 	// Paint new lines


### PR DESCRIPTION
From the Go docs:

> "If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/zQyUnddPFbl