### PR TITLE
Send event on SIGHUP

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -1,5 +1,10 @@
 package tea
 
+// HangupMsg is used to report a terminal hangup. Note that Windows does not
+// have support for reporting when hangups occur as it does not support the
+// SIGHUP signal.
+type HangupMsg struct {}
+
 // WindowSizeMsg is used to report the terminal size. It's sent to Update once
 // initially and then on every terminal resize. Note that Windows does not
 // have support for reporting when resizes occur as it does not support the

--- a/screen.go
+++ b/screen.go
@@ -3,7 +3,7 @@ package tea
 // HangupMsg is used to report a terminal hangup. Note that Windows does not
 // have support for reporting when hangups occur as it does not support the
 // SIGHUP signal.
-type HangupMsg struct {}
+type HangupMsg struct{}
 
 // WindowSizeMsg is used to report the terminal size. It's sent to Update once
 // initially and then on every terminal resize. Note that Windows does not

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -38,9 +38,9 @@ func (p *Program) listen(done chan struct{}, sig syscall.Signal, f func()) {
 
 	for {
 		select {
-			case <-p.ctx.Done():
+		case <-p.ctx.Done():
 			return
-			case <-c:
+		case <-c:
 		}
 
 		f()

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -9,25 +9,40 @@ import (
 	"syscall"
 )
 
+// listenForHangup sends a message when the terminal is closed.
+// Argument output should be the file descriptor for the terminal; usually
+// os.Stdout.
+func (p *Program) listenForHangup(done chan struct{}) {
+	p.listen(done, syscall.SIGHUP, p.sendHangupMsg)
+}
+
+func (p *Program) sendHangupMsg() {
+	p.Send(HangupMsg{})
+}
+
 // listenForResize sends messages (or errors) when the terminal resizes.
 // Argument output should be the file descriptor for the terminal; usually
 // os.Stdout.
 func (p *Program) listenForResize(done chan struct{}) {
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGWINCH)
+	p.listen(done, syscall.SIGWINCH, p.checkResize)
+}
+
+func (p *Program) listen(done chan struct{}, sig syscall.Signal, f func()) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, sig)
 
 	defer func() {
-		signal.Stop(sig)
+		signal.Stop(c)
 		close(done)
 	}()
 
 	for {
 		select {
-		case <-p.ctx.Done():
+			case <-p.ctx.Done():
 			return
-		case <-sig:
+			case <-c:
 		}
 
-		p.checkResize()
+		f()
 	}
 }

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -3,6 +3,12 @@
 
 package tea
 
+// listenForHangup is not available on windows because windows does not
+// implement syscall.SIGHUP.
+func (p *Program) listenForHangup(done chan struct{}) {
+	close(done)
+}
+
 // listenForResize is not available on windows because windows does not
 // implement syscall.SIGWINCH.
 func (p *Program) listenForResize(done chan struct{}) {

--- a/tea.go
+++ b/tea.go
@@ -249,6 +249,15 @@ func (p *Program) handleSignals() chan struct{} {
 	return ch
 }
 
+// handleHangup handles terminal hangup events.
+func (p *Program) handleHangup() chan struct{} {
+	ch := make(chan struct{})
+
+	go p.listenForHangup(ch)
+
+	return ch
+}
+
 // handleResize handles terminal resize events.
 func (p *Program) handleResize() chan struct{} {
 	ch := make(chan struct{})
@@ -518,7 +527,8 @@ func (p *Program) Run() (Model, error) {
 		}
 	}
 
-	// Handle resize events.
+	// Handle signal-based events.
+	handlers.add(p.handleHangup())
 	handlers.add(p.handleResize())
 
 	// Process commands.


### PR DESCRIPTION
Listening for the SIGHUP syscall is needed for https://github.com/charmbracelet/glow/issues/524.
Implementation is based on the existing SIGWINCH listener.