### PR TITLE
feat: properly call nested sequenceMsg and batchMsg

### DIFF
--- a/examples/sequence/main.go
+++ b/examples/sequence/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -14,13 +15,37 @@ type model struct{}
 func (m model) Init() tea.Cmd {
 	return tea.Sequence(
 		tea.Batch(
-			tea.Println("A"),
-			tea.Println("B"),
-			tea.Println("C"),
+			tea.Sequence(
+				SleepPrintln("1-1-1", 1000),
+				SleepPrintln("1-1-2", 1000),
+			),
+			tea.Batch(
+				SleepPrintln("1-2-1", 1500),
+				SleepPrintln("1-2-2", 1250),
+			),
 		),
-		tea.Println("Z"),
+		tea.Println("2"),
+		tea.Sequence(
+			tea.Batch(
+				SleepPrintln("3-1-1", 500),
+				SleepPrintln("3-1-2", 1000),
+			),
+			tea.Sequence(
+				SleepPrintln("3-2-1", 750),
+				SleepPrintln("3-2-2", 500),
+			),
+		),
 		tea.Quit,
 	)
+}
+
+// print string after stopping for a certain period of time
+func SleepPrintln(s string, milisecond int) tea.Cmd {
+	printCmd := tea.Println(s)
+	return func() tea.Msg {
+		time.Sleep(time.Duration(milisecond) * time.Millisecond)
+		return printCmd()
+	}
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {

--- a/tea.go
+++ b/tea.go
@@ -355,13 +355,12 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 				p.exec(msg.cmd, msg.fn)
 
 			case BatchMsg:
-				for _, cmd := range msg {
-					cmds <- cmd
-				}
+				go p.execBatchMsg(msg)
 				continue
 
 			case sequenceMsg:
 				go p.execSequenceMsg(msg)
+				continue
 			}
 
 			// Process internal messages for the renderer.
@@ -396,7 +395,7 @@ func (p *Program) execSequenceMsg(msg sequenceMsg) {
 }
 
 func (p *Program) execBatchMsg(msg BatchMsg) {
-
+	// Execute commands one at a time.
 	g, _ := errgroup.WithContext(p.ctx)
 	for _, cmd := range msg {
 		cmd := cmd


### PR DESCRIPTION
# what this PR does
fix problems described in #847 

# problems
I have to check...
- method name: execSequenceMsg and execBatchMsg are good names for these methods?
- bugs: Does this change make other problems?
- optimization: Is there any performance problems when I handle nested messages with recursive functions?
