### PR TITLE
fix(examples): run filepicker on stdout (versus stderr)

### DIFF
--- a/examples/file-picker/main.go
+++ b/examples/file-picker/main.go
@@ -88,7 +88,7 @@ func main() {
 	m := model{
 		filepicker: fp,
 	}
-	tm, _ := tea.NewProgram(&m, tea.WithOutput(os.Stderr)).Run()
+	tm, _ := tea.NewProgram(&m).Run()
 	mm := tm.(model)
 	fmt.Println("\n  You selected: " + m.filepicker.Styles.Selected.Render(mm.selectedFile) + "\n")
 }


### PR DESCRIPTION
Fixes #852 

The cursor has trouble mapping to the correct location when using stderr. Using stdout is more reliable, and this example isn't taking advantage of stderr in any meaningful way over stdout, so it's probably better to show people a more common example.