### PR TITLE
test: add negative test for TestTeaModel

### DIFF
--- a/tea_test.go
+++ b/tea_test.go
@@ -56,6 +56,17 @@ func TestTeaModel(t *testing.T) {
 	}
 }
 
+func TestTeaModelNoCustomInput(t *testing.T) {
+    var buf bytes.Buffer
+    var in bytes.Buffer
+    in.Write([]byte("q"))
+
+    p := NewProgram(&testModel{}, WithOutput(&buf))
+    if _, err := p.Run(); err == nil {
+        t.Fatal(err)
+    }
+}
+
 func TestTeaQuit(t *testing.T) {
 	var buf bytes.Buffer
 	var in bytes.Buffer


### PR DESCRIPTION
While experimenting with unit tests, I saw a large switch statement in the tea.go file with no coverage. Increased coverage by 1.4%.