### PR TITLE
Introduce withRethrowPanics option

### DIFF
--- a/options.go
+++ b/options.go
@@ -73,6 +73,12 @@ func WithoutCatchPanics() ProgramOption {
 	}
 }
 
+func WithRethrowPanics() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withRethrowPanics
+	}
+}
+
 // WithoutSignals will ignore OS signals.
 // This is mainly useful for testing.
 func WithoutSignals() ProgramOption {

--- a/options_test.go
+++ b/options_test.go
@@ -89,6 +89,10 @@ func TestOptions(t *testing.T) {
 			exercise(t, WithoutCatchPanics(), withoutCatchPanics)
 		})
 
+		t.Run("with rethrow panics", func(t *testing.T) {
+			exercise(t, WithRethrowPanics(), withRethrowPanics)
+		})
+
 		t.Run("without signal handler", func(t *testing.T) {
 			exercise(t, WithoutSignalHandler(), withoutSignalHandler)
 		})

--- a/tea.go
+++ b/tea.go
@@ -99,6 +99,7 @@ const (
 	// recover from panics, print the stack trace, and disable raw mode. This
 	// feature is on by default.
 	withoutCatchPanics
+	withRethrowPanics
 )
 
 // handlers manages series of channels returned by various processes. It allows
@@ -474,6 +475,9 @@ func (p *Program) Run() (Model, error) {
 		defer func() {
 			if r := recover(); r != nil {
 				p.shutdown(true)
+				if p.startupOptions.has(withRethrowPanics) {
+					panic(r)
+				}
 				fmt.Printf("Caught panic:\n\n%s\n\nRestoring terminal...\n\n", r)
 				debug.PrintStack()
 				return


### PR DESCRIPTION
This option makes bubbletea silently recovers panics, shutdown itself, and rethrows panics for a possible handling at a higher/lower level.

In my use case, i would like to centralize the panics, not being "polluted" by terminal outputs. As the bubbletea `shutdown` method is not public, and is the only way to gracefully restore the terminal, the only way seems to add such an option.

Pleas note that i'm not fully satisfied by the option name `withRethrowPanics`, i'm totally open to suggestions :)