### PR TITLE
chore(docs): remove the tea.EnterAltScreen from Init

### DIFF
--- a/examples/fullscreen/main.go
+++ b/examples/fullscreen/main.go
@@ -23,7 +23,7 @@ func main() {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(tick(), tea.EnterAltScreen)
+	return tick()
 }
 
 func (m model) Update(message tea.Msg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
The docs say you shouldn't do this - https://github.com/charmbracelet/bubbletea/blob/8f3464a75600e991bbce22229d6e5b99975416f0/screen.go#L29 - and it works just fine with it removed.

Removing it will make sure that people who are new don't go down the wrong path looking at this example.