### PR TITLE
Add support for z/OS

### DIFF
--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix || zos
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix zos
 
 package tea
 

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix || zos
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix zos
 
 package tea
 


### PR DESCRIPTION
Hello Charm team,

I work on the Go compiler for z/OS and would love to have bubbletea programs work out of the box on our platform.

There are two dependencies that also need z/OS support for perfect out of the box support, but I've opened PRs for both of them ([termenv](https://github.com/muesli/termenv/pull/165) & [clipboard](https://github.com/muesli/termenv/pull/165))

As for bubbletea, the build and all tests are passing on z/OS after the addition of these tags.