### PR TITLE
docs: Add CHIP-8 to projects in the wild

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ For some Bubble Tea programs in production, see:
 * [chatgpt-cli](https://github.com/j178/chatgpt): a CLI for ChatGPT
 * [ChatGPTUI](https://github.com/dwisiswant0/chatgptui): a TUI for ChatGPT
 * [chezmoi](https://github.com/twpayne/chezmoi): securely manage your dotfiles across multiple machines
+* [chip-8](https://github.com/braheezy/chip-8): CHIP-8 interpreter
 * [chtop](https://github.com/chhetripradeep/chtop): monitor your ClickHouse node without leaving the terminal
 * [circumflex](https://github.com/bensadeh/circumflex): read Hacker News in the terminal
 * [clidle](https://github.com/ajeetdsouza/clidle): a Wordle clone


### PR DESCRIPTION
Hello! [My CHIP-8 project](https://github.com/braheezy/chip-8) now renders as a TUI using BubbleTea. I didn't any similar projects in the README so I thought it'd be neat to add mine. Thanks in advance!