### PR TITLE
Compact sequences like batches

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -13,6 +13,27 @@ import (
 //		       return tea.Batch(someCommand, someOtherCommand)
 //	    }
 func Batch(cmds ...Cmd) Cmd {
+	return compactCmds[BatchMsg](cmds)
+}
+
+// BatchMsg is a message used to perform a bunch of commands concurrently with
+// no ordering guarantees. You can send a BatchMsg with Batch.
+type BatchMsg []Cmd
+
+// Sequence runs the given commands one at a time, in order. Contrast this with
+// Batch, which runs commands concurrently.
+func Sequence(cmds ...Cmd) Cmd {
+	return compactCmds[sequenceMsg](cmds)
+}
+
+// sequenceMsg is used internally to run the given commands in order.
+type sequenceMsg []Cmd
+
+// compactCmds ignores any nil commands in cmds, and returns the most direct
+// command possible. That is, considering the non-nil commands, if there are
+// none it returns nil, if there is exactly one it returns that command
+// directly, else it returns the non-nil commands as type T.
+func compactCmds[T ~[]Cmd](cmds []Cmd) Cmd {
 	var validCmds []Cmd //nolint:prealloc
 	for _, c := range cmds {
 		if c == nil {
@@ -27,25 +48,10 @@ func Batch(cmds ...Cmd) Cmd {
 		return validCmds[0]
 	default:
 		return func() Msg {
-			return BatchMsg(validCmds)
+			return T(validCmds)
 		}
 	}
 }
-
-// BatchMsg is a message used to perform a bunch of commands concurrently with
-// no ordering guarantees. You can send a BatchMsg with Batch.
-type BatchMsg []Cmd
-
-// Sequence runs the given commands one at a time, in order. Contrast this with
-// Batch, which runs commands concurrently.
-func Sequence(cmds ...Cmd) Cmd {
-	return func() Msg {
-		return sequenceMsg(cmds)
-	}
-}
-
-// sequenceMsg is used internally to run the given commands in order.
-type sequenceMsg []Cmd
 
 // Every is a command that ticks in sync with the system clock. So, if you
 // wanted to tick with the system clock every second, minute or hour you

--- a/commands_test.go
+++ b/commands_test.go
@@ -82,25 +82,33 @@ func TestSequentially(t *testing.T) {
 }
 
 func TestBatch(t *testing.T) {
+	testMultipleCommands[BatchMsg](t, Batch)
+}
+
+func TestSequence(t *testing.T) {
+	testMultipleCommands[sequenceMsg](t, Sequence)
+}
+
+func testMultipleCommands[T ~[]Cmd](t *testing.T, createFn func(cmd ...Cmd) Cmd) {
 	t.Run("nil cmd", func(t *testing.T) {
-		if b := Batch(nil); b != nil {
+		if b := createFn(nil); b != nil {
 			t.Fatalf("expected nil, got %+v", b)
 		}
 	})
 	t.Run("empty cmd", func(t *testing.T) {
-		if b := Batch(); b != nil {
+		if b := createFn(); b != nil {
 			t.Fatalf("expected nil, got %+v", b)
 		}
 	})
 	t.Run("single cmd", func(t *testing.T) {
-		b := Batch(Quit)()
+		b := createFn(Quit)()
 		if _, ok := b.(QuitMsg); !ok {
 			t.Fatalf("expected a QuitMsg, got %T", b)
 		}
 	})
 	t.Run("mixed nil cmds", func(t *testing.T) {
-		b := Batch(nil, Quit, nil, Quit, nil, nil)()
-		if l := len(b.(BatchMsg)); l != 2 {
+		b := createFn(nil, Quit, nil, Quit, nil, nil)()
+		if l := len(b.(T)); l != 2 {
 			t.Fatalf("expected a []Cmd with len 2, got %d", l)
 		}
 	})


### PR DESCRIPTION
This change makes `Sequence` behave like `Batch` in how it handles `nil` entries, preventing a possible infinite loop.

## Background

I stumbled across this discrepancy when I noticed a bubbletea program I had written had CPU usage over 100% all the time, when I would expect it near zero as a CLI simply waiting for input.

I created a [simplified repro](https://github.com/jdhenke/repro-bubbletea-sequence-bug/blob/main/main.go), and noticed that swapping in `tea.Batch` for `tea.Sequence` fixed the CPU usage, which was nice, but it seems like either one _should_ work.

Digging in, it looks like `Batch` already had logic to handle all nils in #217 and more recently to return the only non-nil entry directly if possible in #875. This change reuses the same logic (and tests) for `Sequence` as well now, which avoids creating this infinite loop when using `Sequence` :+1: 

## Demo of Fix

Here's a walk through showing the fix in action within a go workspace.

```
$ cat go.work
go 1.21

toolchain go1.21.1

use (
	./bubbletea
	./repro
)
```

Here's showing the CPU issue before:

<img width="937" alt="image" src="https://github.com/charmbracelet/bubbletea/assets/1418690/de13fa68-4f6f-4101-ac94-75589f548019">

<img width="937" alt="image" src="https://github.com/charmbracelet/bubbletea/assets/1418690/ea72d0ba-22e0-42ba-88ed-7f6209ac3ca4">

And here's showing it's fixed using this branch:

<img width="937" alt="image" src="https://github.com/charmbracelet/bubbletea/assets/1418690/7e52ed5f-50bc-4207-bacc-74cf372dedd0">


<img width="937" alt="image" src="https://github.com/charmbracelet/bubbletea/assets/1418690/a66e6ed6-df89-466f-8431-c05bce84157b">

----

Let me know your thoughts and if you need this PR adjusted in any way, cheers.