### PR TITLE
fix: stop and drain timers

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -94,11 +94,16 @@ type sequenceMsg []Cmd
 //
 // Every is analogous to Tick in the Elm Architecture.
 func Every(duration time.Duration, fn func(time.Time) Msg) Cmd {
+	n := time.Now()
+	d := n.Truncate(duration).Add(duration).Sub(n)
+	t := time.NewTimer(d)
 	return func() Msg {
-		n := time.Now()
-		d := n.Truncate(duration).Add(duration).Sub(n)
-		t := time.NewTimer(d)
-		return fn(<-t.C)
+		ts := <-t.C
+		t.Stop()
+		for len(t.C) > 0 {
+			<-t.C
+		}
+		return fn(ts)
 	}
 }
 
@@ -141,9 +146,14 @@ func Every(duration time.Duration, fn func(time.Time) Msg) Cmd {
 //	    return m, nil
 //	}
 func Tick(d time.Duration, fn func(time.Time) Msg) Cmd {
+	t := time.NewTimer(d)
 	return func() Msg {
-		t := time.NewTimer(d)
-		return fn(<-t.C)
+		ts := <-t.C
+		t.Stop()
+		for len(t.C) > 0 {
+			<-t.C
+		}
+		return fn(ts)
 	}
 }
 


### PR DESCRIPTION
Stop the timers and drain them.

I got a situation in which this was causing a bubbletea app to use **A LOT** of ram.

Per my understanding, some timed commands were being fired twice sometimes... on most cases this might not be perceptible, but in this particular case, each of these commands generated another message, and the program went on double firing those too.