### PR TITLE
fix: wait for goland terminal size

### DIFF
--- a/signals_unix.go
+++ b/signals_unix.go
@@ -28,6 +28,6 @@ func (p *Program) listenForResize(done chan struct{}) {
 		case <-sig:
 		}
 
-		p.checkResize()
+		p.checkResize(false)
 	}
 }

--- a/tea.go
+++ b/tea.go
@@ -247,7 +247,7 @@ func (p *Program) handleResize() chan struct{} {
 
 	if p.ttyOutput != nil {
 		// Get the initial terminal size and send it to the program.
-		go p.checkResize()
+		go p.checkResize(true)
 
 		// Listen for window resizes.
 		go p.listenForResize(ch)
@@ -686,7 +686,7 @@ func (p *Program) RestoreTerminal() error {
 	// process was at the foreground, in which case we may not have received
 	// SIGWINCH. Detect any size change now and propagate the new size as
 	// needed.
-	go p.checkResize()
+	go p.checkResize(false)
 
 	return nil
 }


### PR DESCRIPTION
The embedded terminal of JetBrains products (JediTerm) such as Goland have a serious bug :(

At the startup, It waits for approx. 400ms before answering *real* window sizes... As a matter of consequence, in many situations, the first `WindowSizeMsg` received by models is width=0 and height=0

This pr tries to mitigate this issue by repeating nth requests during an arbitrary delay of 600ms on the first call.

- Fix https://github.com/charmbracelet/huh/issues/204
- Address https://github.com/charmbracelet/huh/discussions/157

Please, let me know if you know or find any other link referencing this issue ❤️ 