### PR TITLE
fix: program renderer commands

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -151,6 +151,8 @@ type disableBracketedPasteMsg struct{}
 func (p *Program) EnterAltScreen() {
 	if p.renderer != nil {
 		p.renderer.enterAltScreen()
+	} else {
+		p.startupOptions |= withAltScreen
 	}
 }
 
@@ -160,6 +162,8 @@ func (p *Program) EnterAltScreen() {
 func (p *Program) ExitAltScreen() {
 	if p.renderer != nil {
 		p.renderer.exitAltScreen()
+	} else {
+		p.startupOptions &^= withAltScreen
 	}
 }
 
@@ -168,7 +172,11 @@ func (p *Program) ExitAltScreen() {
 //
 // Deprecated: Use the WithMouseCellMotion ProgramOption instead.
 func (p *Program) EnableMouseCellMotion() {
-	p.renderer.enableMouseCellMotion()
+	if p.renderer != nil {
+		p.renderer.enableMouseCellMotion()
+	} else {
+		p.startupOptions |= withMouseCellMotion
+	}
 }
 
 // DisableMouseCellMotion disables Mouse Cell Motion tracking. This will be
@@ -176,7 +184,11 @@ func (p *Program) EnableMouseCellMotion() {
 //
 // Deprecated: The mouse will automatically be disabled when the program exits.
 func (p *Program) DisableMouseCellMotion() {
-	p.renderer.disableMouseCellMotion()
+	if p.renderer != nil {
+		p.renderer.disableMouseCellMotion()
+	} else {
+		p.startupOptions &^= withMouseCellMotion
+	}
 }
 
 // EnableMouseAllMotion enables mouse click, release, wheel and motion events,
@@ -185,7 +197,11 @@ func (p *Program) DisableMouseCellMotion() {
 //
 // Deprecated: Use the WithMouseAllMotion ProgramOption instead.
 func (p *Program) EnableMouseAllMotion() {
-	p.renderer.enableMouseAllMotion()
+	if p.renderer != nil {
+		p.renderer.enableMouseAllMotion()
+	} else {
+		p.startupOptions |= withMouseAllMotion
+	}
 }
 
 // DisableMouseAllMotion disables All Motion mouse tracking. This will be
@@ -193,10 +209,20 @@ func (p *Program) EnableMouseAllMotion() {
 //
 // Deprecated: The mouse will automatically be disabled when the program exits.
 func (p *Program) DisableMouseAllMotion() {
-	p.renderer.disableMouseAllMotion()
+	if p.renderer != nil {
+		p.renderer.disableMouseAllMotion()
+	} else {
+		p.startupOptions &^= withMouseAllMotion
+	}
 }
 
 // SetWindowTitle sets the terminal window title.
+//
+// Deprecated: Use the SetWindowTitle command instead.
 func (p *Program) SetWindowTitle(title string) {
-	p.renderer.setWindowTitle(title)
+	if p.renderer != nil {
+		p.renderer.setWindowTitle(title)
+	} else {
+		p.startupTitle = title
+	}
 }

--- a/tea.go
+++ b/tea.go
@@ -131,6 +131,10 @@ type Program struct {
 	// treated as bits. These options can be set via various ProgramOptions.
 	startupOptions startupOptions
 
+	// startupTitle is the title that will be set on the terminal when the
+	// program starts.
+	startupTitle string
+
 	inputType inputType
 
 	ctx    context.Context
@@ -490,6 +494,9 @@ func (p *Program) Run() (Model, error) {
 	}
 
 	// Honor program startup options.
+	if p.startupTitle != "" {
+		p.renderer.setWindowTitle(p.startupTitle)
+	}
 	if p.startupOptions&withAltScreen != 0 {
 		p.renderer.enterAltScreen()
 	}


### PR DESCRIPTION
Using program commands like p.EnableMouseCellMotion and p.SetWindowTitle _before_ the program starts can panic the application since `renderer` hasn't been initialized yet. Use program options to enable and set these options if `renderer` is not initialized.

Fixes: https://github.com/charmbracelet/bubbletea/issues/1029