### PR TITLE
fix(windows): Fix coninput not handling control sequences

### DIFF
--- a/key_windows.go
+++ b/key_windows.go
@@ -39,9 +39,19 @@ func readConInputs(ctx context.Context, msgsch chan<- Msg, con windows.Handle) e
 				}
 
 				for i := 0; i < int(e.RepeatCount); i++ {
+					eventKeyType := keyType(e)
+					var runes []rune
+
+					// Add the character only if the key type is an actual character and not a control sequence.
+					// This mimics the behavior in readAnsiInputs where the character is also removed.
+					// We don't need to handle KeySpace here. See the comment in keyType().
+					if eventKeyType == KeyRunes {
+						runes = []rune{e.Char}
+					}
+
 					msgs = append(msgs, KeyMsg{
-						Type:  keyType(e),
-						Runes: []rune{e.Char},
+						Type:  eventKeyType,
+						Runes: runes,
 						Alt:   e.ControlKeyState.Contains(coninput.LEFT_ALT_PRESSED | coninput.RIGHT_ALT_PRESSED),
 					})
 				}


### PR DESCRIPTION
#### This PR fixes an issue where pressing <kbd>Enter</kbd> or <kbd>Shift+Tab</kbd> would add a space to the input in `huh`'s input field on Windows.

Before, when emitting a key event containing a control sequence, the character would also be included.
The `textinput` bubble would see this as user input and sanitize it, converting `\r` to a space and appending it.

Even though this fixes the issue, the real problem lies in the fact that text input is accepted before (all) key binds are processed, presumably because it is assumed that control sequences don't contain any characters (which is the case on Unix, and with this PR now also on Windows). ~~This should be looked into in a separate issue in the `huh` repository.~~ https://github.com/charmbracelet/huh/pull/284

Thanks @robotastronaut for sharing their research in the Charm Discord server and for the [initial fix](https://github.com/charmbracelet/bubbletea/commit/ae18b80676e60b3a5a1eb4e7a6aab5795d4b4945).
In contrast to their fix, this should fully align with the key handling on Unix and fix other issues like <kbd>Shift+Tab</kbd> not working on Windows.