### PR TITLE
fix: Disable window title when no TTY

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -220,7 +220,7 @@ func (p *Program) DisableMouseAllMotion() {
 //
 // Deprecated: Use the SetWindowTitle command instead.
 func (p *Program) SetWindowTitle(title string) {
-	if p.renderer != nil {
+	if p.renderer != nil && p.ttyOutput != nil {
 		p.renderer.setWindowTitle(title)
 	} else {
 		p.startupTitle = title


### PR DESCRIPTION
Because window title should obviously only be handled on a tty :)