### PR TITLE
fix(examples): Fix bugs in package-manager

### DIFF
--- a/examples/package-manager/main.go
+++ b/examples/package-manager/main.go
@@ -58,20 +58,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		}
 	case installedPkgMsg:
+		pkg := m.packages[m.index]
 		if m.index >= len(m.packages)-1 {
 			// Everything's been installed. We're done!
 			m.done = true
-			return m, tea.Quit
+			return m, tea.Sequence(
+				tea.Printf("%s %s", checkMark, pkg), // print the last success message
+				tea.Quit,                            // exit the program
+			)
 		}
 
 		// Update progress bar
-		progressCmd := m.progress.SetPercent(float64(m.index) / float64(len(m.packages)-1))
-
 		m.index++
+		progressCmd := m.progress.SetPercent(float64(m.index) / float64(len(m.packages)))
+
 		return m, tea.Batch(
 			progressCmd,
-			tea.Printf("%s %s", checkMark, m.packages[m.index]), // print success message above our program
-			downloadAndInstall(m.packages[m.index]),             // download the next package
+			tea.Printf("%s %s", checkMark, pkg),     // print success message above our program
+			downloadAndInstall(m.packages[m.index]), // download the next package
 		)
 	case spinner.TickMsg:
 		var cmd tea.Cmd
@@ -95,7 +99,7 @@ func (m model) View() string {
 		return doneStyle.Render(fmt.Sprintf("Done! Installed %d packages.\n", n))
 	}
 
-	pkgCount := fmt.Sprintf(" %*d/%*d", w, m.index, w, n-1)
+	pkgCount := fmt.Sprintf(" %*d/%*d", w, m.index, w, n)
 
 	spin := m.spinner.View() + " "
 	prog := m.progress.View()


### PR DESCRIPTION
I fixed 3 bugs in the package-manager example (they are easier to spot when working with a small list of 4, for example):

1. The total packages count.
2. The progress bar percentage.
3. The final installed package in the output.

## Before
![before](https://github.com/charmbracelet/bubbletea/assets/5598975/c7405ab3-d8cc-4ff8-ae94-e37568bcae29)

## After
![after](https://github.com/charmbracelet/bubbletea/assets/5598975/475dc6b8-3a71-430d-ba3c-c210dde0f1b4)
