### PR TITLE
feat: set the program environment variables

### DIFF
--- a/options.go
+++ b/options.go
@@ -49,6 +49,23 @@ func WithInputTTY() ProgramOption {
 	}
 }
 
+// WithEnvironment sets the environment variables that the program will use.
+// This useful when the program is running in a remote session (e.g. SSH) and
+// you want to pass the environment variables from the remote session to the
+// program.
+//
+// Example:
+//
+//	var sess ssh.Session // ssh.Session is a type from the github.com/charmbracelet/ssh package
+//	pty, _, _ := sess.Pty()
+//	environ := append(sess.Environ(), "TERM="+pty.Term)
+//	p := tea.NewProgram(model, tea.WithEnvironment(environ)
+func WithEnvironment(env []string) ProgramOption {
+	return func(p *Program) {
+		p.environ = env
+	}
+}
+
 // WithoutSignalHandler disables the signal handler that Bubble Tea sets up for
 // Programs. This is useful if you want to handle signals yourself.
 func WithoutSignalHandler() ProgramOption {

--- a/tea.go
+++ b/tea.go
@@ -151,6 +151,9 @@ type Program struct {
 	previousOutputState *term.State
 	renderer            renderer
 
+	// the environment variables for the program, defaults to os.Environ().
+	environ []string
+
 	// where to read inputs from, this will usually be os.Stdin.
 	input io.Reader
 	// ttyInput is null if input is not a TTY.
@@ -220,6 +223,11 @@ func NewProgram(model Model, opts ...ProgramOption) *Program {
 	// if no output was set, set it to stdout
 	if p.output == nil {
 		p.output = os.Stdout
+	}
+
+	// if no environment was set, set it to os.Environ()
+	if p.environ == nil {
+		p.environ = os.Environ()
 	}
 
 	return p


### PR DESCRIPTION
This adds the option to provide a custom set of environment variables to use in the Bubble Tea program. When running Bubble Tea in a remote session such as SSH, we need to be able to pass the SSH session's environment variables rather than the server ones.

```go
	// Add the TERM from the SSH session to the environment
	var sess ssh.Session // from the github.com/charmbracelet/ssh package
	pty, _, _ := sess.Pty()
	environ := append(sess.Environ(), "TERM="+pty.Term)
	p := tea.NewProgram(model{}, tea.WithEnvironmen(environ))
```

Now, the Bubble Tea program running for a remote session can determine the appropriate color profile from the session's environment variables instead of the _server's_ environment variables.

In most cases you'll only need this feature when using Bubble Tea in remote sessions.