### PR TITLE
Windows: ensure output is UTF16 encoded when output is not a terminal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2
 	golang.org/x/sync v0.7.0
 	golang.org/x/sys v0.22.0
+	golang.org/x/text v0.6.0
 )
 
 require (
@@ -19,5 +20,4 @@ require (
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,5 +27,5 @@ golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
-golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+golang.org/x/text v0.6.0 h1:3XmdazWV+ubf7QgHSTWeykHOci5oeekaGJBLkrkaw4k=
+golang.org/x/text v0.6.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=

--- a/tea.go
+++ b/tea.go
@@ -506,16 +506,19 @@ func (p *Program) Run() (Model, error) {
 		}()
 	}
 
-	// If no renderer is set use the standard one.
-	if p.renderer == nil {
-		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor), p.fps)
-	}
-
 	// Check if output is a TTY before entering raw mode, hiding the cursor and
 	// so on.
 	if err := p.initTerminal(); err != nil {
 		return p.initialModel, err
 	}
+
+	// If no renderer is set use the standard one.
+	if p.renderer == nil {
+		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor), p.fps)
+	}
+
+	// Hide the cursor before running the program.
+	p.renderer.hideCursor()
 
 	// Honor program startup options.
 	if p.startupTitle != "" {

--- a/tty.go
+++ b/tty.go
@@ -26,8 +26,6 @@ func (p *Program) initTerminal() error {
 	if err := p.initInput(); err != nil {
 		return err
 	}
-
-	p.renderer.hideCursor()
 	return nil
 }
 

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/charmbracelet/x/term"
 	"golang.org/x/sys/windows"
+	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/transform"
 )
 
 func (p *Program) initInput() (err error) {
@@ -49,6 +51,11 @@ func (p *Program) initInput() (err error) {
 		if err := windows.SetConsoleMode(windows.Handle(p.ttyOutput.Fd()), mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING); err != nil {
 			return fmt.Errorf("error setting console mode: %w", err)
 		}
+	} else {
+		// If we're not running in a terminal, we need to encode output as UTF-16
+		// to avoid issues with Windows' default wide character encoding.
+		encoder := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder()
+		p.output = transform.NewWriter(p.output, encoder)
 	}
 
 	return


### PR DESCRIPTION
We need to transform the output from UTF8 to wide characters UTF16 for Windows to understand when output is not a terminal.