### PR TITLE
feat: query the terminal version string and primary device attrs

### DIFF
--- a/da1.go
+++ b/da1.go
@@ -6,6 +6,17 @@ import "github.com/charmbracelet/x/ansi"
 // device attributes.
 type PrimaryDeviceAttributesMsg []uint
 
+// primaryDeviceAttrsMsg is an internal message that queries the terminal for
+// its primary device attributes (DA1).
+type primaryDeviceAttrsMsg struct{}
+
+// PrimaryDeviceAttributes is a command that queries the terminal for its
+// primary device attributes (DA1). This command is used to determine some of
+// the terminal capabilities.
+func PrimaryDeviceAttributes() Msg {
+	return primaryDeviceAttrsMsg{}
+}
+
 func parsePrimaryDevAttrs(csi *ansi.CsiSequence) Msg {
 	// Primary Device Attributes
 	da1 := make(PrimaryDeviceAttributesMsg, len(csi.Params))

--- a/tea.go
+++ b/tea.go
@@ -396,6 +396,12 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 				// NB: this blocks.
 				p.exec(msg.cmd, msg.fn)
 
+			case terminalVersion:
+				p.renderer.execute(ansi.RequestXTVersion)
+
+			case primaryDeviceAttrsMsg:
+				p.renderer.execute(ansi.RequestPrimaryDeviceAttributes)
+
 			case BatchMsg:
 				for _, cmd := range msg {
 					cmds <- cmd

--- a/xterm.go
+++ b/xterm.go
@@ -40,3 +40,16 @@ func parseXTermModifyOtherKeys(csi *ansi.CsiSequence) Msg {
 // See: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_
 // See: https://invisible-island.net/xterm/manpage/xterm.html#VT100-Widget-Resources:modifyOtherKeys
 type ModifyOtherKeysMsg uint8
+
+// TerminalVersionMsg is a message that represents the terminal version.
+type TerminalVersionMsg string
+
+// terminalVersion is an internal message that queries the terminal for its
+// version using XTVERSION.
+type terminalVersion struct{}
+
+// TerminalVersion is a command that queries the terminal for its version using
+// XTVERSION. Note that some terminals may not support this command.
+func TerminalVersion() Msg {
+	return terminalVersion{}
+}


### PR DESCRIPTION
This adds support for XTVERSION and DA1 querying.

XTVERSION responds with the version of the terminal (not supported by all terminals)

DA1 responds with some of the terminal capabilities