### PR TITLE
feat: expose the renderer interface

### DIFF
--- a/examples/simple/testdata/TestApp.golden
+++ b/examples/simple/testdata/TestApp.golden
@@ -2,4 +2,4 @@
 
 To quit sooner press ctrl-c, or press ctrl-z to suspend...
 [70D[A[A[A[70D[2KHi. This program will exit in 9 seconds.
-[B[B[70D[2K[?2004l[?25h[?1002l[?1003l[?1006l
+[B[B[70D[2K[?2004l[?25h

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -17,3 +17,5 @@ func (nilRenderer) CursorVisibility() bool          { return false }
 func (nilRenderer) ShowCursor()                     {}
 func (nilRenderer) HideCursor()                     {}
 func (nilRenderer) Execute(string)                  {}
+func (nilRenderer) InsertAbove(string) error        { return nil }
+func (nilRenderer) Resize(int, int)                 {}

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -26,26 +26,14 @@ func (NilRenderer) Repaint() {}
 // ClearScreen implements the Renderer interface.
 func (NilRenderer) ClearScreen() {}
 
-// AltScreen implements the Renderer interface.
-func (NilRenderer) AltScreen() bool { return false }
-
-// EnterAltScreen implements the Renderer interface.
-func (NilRenderer) EnterAltScreen() {}
-
-// ExitAltScreen implements the Renderer interface.
-func (NilRenderer) ExitAltScreen() {}
-
-// CursorVisibility implements the Renderer interface.
-func (NilRenderer) CursorVisibility() bool { return false }
-
-// ShowCursor implements the Renderer interface.
-func (NilRenderer) ShowCursor() {}
-
-// HideCursor implements the Renderer interface.
-func (NilRenderer) HideCursor() {}
-
 // InsertAbove implements the Renderer interface.
 func (NilRenderer) InsertAbove(string) error { return nil }
 
 // Resize implements the Renderer interface.
 func (NilRenderer) Resize(int, int) {}
+
+// SetMode implements the Renderer interface.
+func (NilRenderer) SetMode(int, bool) {}
+
+// Mode implements the Renderer interface.
+func (NilRenderer) Mode(int) bool { return false }

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -2,23 +2,25 @@ package tea
 
 import "io"
 
-type nilRenderer struct{}
+// NilRenderer is a no-op renderer. It implements the Renderer interface but
+// doesn't render anything to the terminal.
+type NilRenderer struct{}
 
-var _ Renderer = nilRenderer{}
+var _ Renderer = NilRenderer{}
 
-func (nilRenderer) SetOutput(io.Writer)             {}
-func (nilRenderer) Flush() error                    { return nil }
-func (nilRenderer) Close() error                    { return nil }
-func (nilRenderer) Write([]byte) (int, error)       { return 0, nil }
-func (nilRenderer) WriteString(string) (int, error) { return 0, nil }
-func (nilRenderer) Repaint()                        {}
-func (nilRenderer) ClearScreen()                    {}
-func (nilRenderer) AltScreen() bool                 { return false }
-func (nilRenderer) EnterAltScreen()                 {}
-func (nilRenderer) ExitAltScreen()                  {}
-func (nilRenderer) CursorVisibility() bool          { return false }
-func (nilRenderer) ShowCursor()                     {}
-func (nilRenderer) HideCursor()                     {}
-func (nilRenderer) Execute(string)                  {}
-func (nilRenderer) InsertAbove(string) error        { return nil }
-func (nilRenderer) Resize(int, int)                 {}
+func (NilRenderer) SetOutput(io.Writer)             {}
+func (NilRenderer) Flush() error                    { return nil }
+func (NilRenderer) Close() error                    { return nil }
+func (NilRenderer) Write([]byte) (int, error)       { return 0, nil }
+func (NilRenderer) WriteString(string) (int, error) { return 0, nil }
+func (NilRenderer) Repaint()                        {}
+func (NilRenderer) ClearScreen()                    {}
+func (NilRenderer) AltScreen() bool                 { return false }
+func (NilRenderer) EnterAltScreen()                 {}
+func (NilRenderer) ExitAltScreen()                  {}
+func (NilRenderer) CursorVisibility() bool          { return false }
+func (NilRenderer) ShowCursor()                     {}
+func (NilRenderer) HideCursor()                     {}
+func (NilRenderer) Execute(string)                  {}
+func (NilRenderer) InsertAbove(string) error        { return nil }
+func (NilRenderer) Resize(int, int)                 {}

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -8,19 +8,44 @@ type NilRenderer struct{}
 
 var _ Renderer = NilRenderer{}
 
-func (NilRenderer) SetOutput(io.Writer)             {}
-func (NilRenderer) Flush() error                    { return nil }
-func (NilRenderer) Close() error                    { return nil }
-func (NilRenderer) Write([]byte) (int, error)       { return 0, nil }
-func (NilRenderer) WriteString(string) (int, error) { return 0, nil }
-func (NilRenderer) Repaint()                        {}
-func (NilRenderer) ClearScreen()                    {}
-func (NilRenderer) AltScreen() bool                 { return false }
-func (NilRenderer) EnterAltScreen()                 {}
-func (NilRenderer) ExitAltScreen()                  {}
-func (NilRenderer) CursorVisibility() bool          { return false }
-func (NilRenderer) ShowCursor()                     {}
-func (NilRenderer) HideCursor()                     {}
-func (NilRenderer) Execute(string)                  {}
-func (NilRenderer) InsertAbove(string) error        { return nil }
-func (NilRenderer) Resize(int, int)                 {}
+// SetOutput implements the Renderer interface.
+func (NilRenderer) SetOutput(io.Writer) {}
+
+// Flush implements the Renderer interface.
+func (NilRenderer) Flush() error { return nil }
+
+// Close implements the Renderer interface.
+func (NilRenderer) Close() error { return nil }
+
+// Render implements the Renderer interface.
+func (NilRenderer) Render(string) error { return nil }
+
+// Repaint implements the Renderer interface.
+func (NilRenderer) Repaint() {}
+
+// ClearScreen implements the Renderer interface.
+func (NilRenderer) ClearScreen() {}
+
+// AltScreen implements the Renderer interface.
+func (NilRenderer) AltScreen() bool { return false }
+
+// EnterAltScreen implements the Renderer interface.
+func (NilRenderer) EnterAltScreen() {}
+
+// ExitAltScreen implements the Renderer interface.
+func (NilRenderer) ExitAltScreen() {}
+
+// CursorVisibility implements the Renderer interface.
+func (NilRenderer) CursorVisibility() bool { return false }
+
+// ShowCursor implements the Renderer interface.
+func (NilRenderer) ShowCursor() {}
+
+// HideCursor implements the Renderer interface.
+func (NilRenderer) HideCursor() {}
+
+// InsertAbove implements the Renderer interface.
+func (NilRenderer) InsertAbove(string) error { return nil }
+
+// Resize implements the Renderer interface.
+func (NilRenderer) Resize(int, int) {}

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -18,7 +18,7 @@ func (NilRenderer) Flush() error { return nil }
 func (NilRenderer) Close() error { return nil }
 
 // Render implements the Renderer interface.
-func (NilRenderer) Render(string) error { return nil }
+func (NilRenderer) Render(string) {}
 
 // Repaint implements the Renderer interface.
 func (NilRenderer) Repaint() {}

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -2,15 +2,18 @@ package tea
 
 type nilRenderer struct{}
 
-func (nilRenderer) start()          {}
-func (nilRenderer) stop()           {}
-func (nilRenderer) kill()           {}
-func (nilRenderer) write(string)    {}
-func (nilRenderer) repaint()        {}
-func (nilRenderer) clearScreen()    {}
-func (nilRenderer) altScreen() bool { return false }
-func (nilRenderer) enterAltScreen() {}
-func (nilRenderer) exitAltScreen()  {}
-func (nilRenderer) showCursor()     {}
-func (nilRenderer) hideCursor()     {}
-func (nilRenderer) execute(string)  {}
+var _ Renderer = nilRenderer{}
+
+func (nilRenderer) Flush() error                    { return nil }
+func (nilRenderer) Close() error                    { return nil }
+func (nilRenderer) Write([]byte) (int, error)       { return 0, nil }
+func (nilRenderer) WriteString(string) (int, error) { return 0, nil }
+func (nilRenderer) Repaint()                        {}
+func (nilRenderer) ClearScreen()                    {}
+func (nilRenderer) AltScreen() bool                 { return false }
+func (nilRenderer) EnterAltScreen()                 {}
+func (nilRenderer) ExitAltScreen()                  {}
+func (nilRenderer) CursorVisibility() bool          { return false }
+func (nilRenderer) ShowCursor()                     {}
+func (nilRenderer) HideCursor()                     {}
+func (nilRenderer) Execute(string)                  {}

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -1,9 +1,12 @@
 package tea
 
+import "io"
+
 type nilRenderer struct{}
 
 var _ Renderer = nilRenderer{}
 
+func (nilRenderer) SetOutput(io.Writer)             {}
 func (nilRenderer) Flush() error                    { return nil }
 func (nilRenderer) Close() error                    { return nil }
 func (nilRenderer) Write([]byte) (int, error)       { return 0, nil }

--- a/nil_renderer_test.go
+++ b/nil_renderer_test.go
@@ -5,12 +5,12 @@ import "testing"
 func TestNilRenderer(t *testing.T) {
 	r := NilRenderer{}
 	r.Repaint()
-	r.EnterAltScreen()
-	if r.AltScreen() {
+	r.SetMode(altScreenMode, true)
+	if r.Mode(altScreenMode) {
 		t.Errorf("altScreen should always return false")
 	}
-	r.ExitAltScreen()
+	r.SetMode(altScreenMode, false)
 	r.ClearScreen()
-	r.ShowCursor()
-	r.HideCursor()
+	r.SetMode(hideCursor, false)
+	r.SetMode(hideCursor, true)
 }

--- a/nil_renderer_test.go
+++ b/nil_renderer_test.go
@@ -4,18 +4,13 @@ import "testing"
 
 func TestNilRenderer(t *testing.T) {
 	r := nilRenderer{}
-	r.start()
-	r.stop()
-	r.kill()
-	r.write("a")
-	r.repaint()
-	r.enterAltScreen()
-	if r.altScreen() {
+	r.Repaint()
+	r.EnterAltScreen()
+	if r.AltScreen() {
 		t.Errorf("altScreen should always return false")
 	}
-	r.exitAltScreen()
-	r.clearScreen()
-	r.showCursor()
-	r.hideCursor()
-	r.execute("")
+	r.ExitAltScreen()
+	r.ClearScreen()
+	r.ShowCursor()
+	r.HideCursor()
 }

--- a/nil_renderer_test.go
+++ b/nil_renderer_test.go
@@ -3,7 +3,7 @@ package tea
 import "testing"
 
 func TestNilRenderer(t *testing.T) {
-	r := nilRenderer{}
+	r := NilRenderer{}
 	r.Repaint()
 	r.EnterAltScreen()
 	if r.AltScreen() {

--- a/options.go
+++ b/options.go
@@ -168,6 +168,14 @@ func WithMouseAllMotion() ProgramOption {
 	}
 }
 
+// WithRenderer sets a custom renderer. This is useful if you want to use a
+// custom renderer to process the output of the program differently.
+func WithRenderer(renderer Renderer) ProgramOption {
+	return func(p *Program) {
+		p.renderer = renderer
+	}
+}
+
 // WithoutRenderer disables the renderer. When this is set output and log
 // statements will be plainly sent to stdout (or another output if one is set)
 // without any rendering and redrawing logic. In other words, printing and
@@ -176,6 +184,9 @@ func WithMouseAllMotion() ProgramOption {
 // application, or to provide an additional non-TUI mode to your Bubble Tea
 // programs. For example, your program could behave like a daemon if output is
 // not a TTY.
+//
+// Deprecated: This option is deprecated and will be removed in a future
+// version of this package.
 func WithoutRenderer() ProgramOption {
 	return func(p *Program) {
 		p.renderer = &nilRenderer{}

--- a/options.go
+++ b/options.go
@@ -186,10 +186,10 @@ func WithRenderer(renderer Renderer) ProgramOption {
 // not a TTY.
 //
 // Deprecated: This option is deprecated and will be removed in a future
-// version of this package.
+// version of this package. Use [NilRenderer] with [WithRenderer] instead.
 func WithoutRenderer() ProgramOption {
 	return func(p *Program) {
-		p.renderer = &nilRenderer{}
+		p.renderer = &NilRenderer{}
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -30,7 +30,7 @@ func TestOptions(t *testing.T) {
 	t.Run("renderer", func(t *testing.T) {
 		p := NewProgram(nil, WithoutRenderer())
 		switch p.renderer.(type) {
-		case *nilRenderer:
+		case *NilRenderer:
 			return
 		default:
 			t.Errorf("expected renderer to be a nilRenderer, got %v", p.renderer)

--- a/renderer.go
+++ b/renderer.go
@@ -8,7 +8,7 @@ type Renderer interface {
 	Close() error
 
 	// Render renders a frame to the output.
-	Render(string) error
+	Render(string)
 
 	// SetOutput sets the output for the renderer.
 	SetOutput(io.Writer)

--- a/renderer.go
+++ b/renderer.go
@@ -16,6 +16,13 @@ type Renderer interface {
 	// Flush flushes the renderer's buffer to the output.
 	Flush() error
 
+	// InsertAbove inserts lines above the current frame. This only works in
+	// inline mode.
+	InsertAbove(string) error
+
+	// Resize sets the size of the terminal.
+	Resize(w int, h int)
+
 	// Request a full re-render. Note that this will not trigger a render
 	// immediately. Rather, this method causes the next render to be a full
 	// Repaint. Because of this, it's safe to call this method multiple times

--- a/renderer.go
+++ b/renderer.go
@@ -7,13 +7,8 @@ type Renderer interface {
 	// Close closes the renderer and flushes any remaining data.
 	Close() error
 
-	// Write a frame to the renderer. The renderer can write this data to
-	// output at its discretion.
-	Write([]byte) (int, error)
-
-	// WriteString a frame to the renderer. The renderer can WriteString this
-	// data to output at its discretion.
-	WriteString(string) (int, error)
+	// Render renders a frame to the output.
+	Render(string) error
 
 	// SetOutput sets the output for the renderer.
 	SetOutput(io.Writer)
@@ -50,9 +45,6 @@ type Renderer interface {
 	ShowCursor()
 	// Hide the cursor.
 	HideCursor()
-
-	// Execute writes a sequence to the underlying output.
-	Execute(string)
 }
 
 // repaintMsg forces a full repaint.

--- a/renderer.go
+++ b/renderer.go
@@ -1,5 +1,7 @@
 package tea
 
+import "io"
+
 // Renderer is the interface for Bubble Tea renderers.
 type Renderer interface {
 	// Close closes the renderer and flushes any remaining data.
@@ -12,6 +14,9 @@ type Renderer interface {
 	// WriteString a frame to the renderer. The renderer can WriteString this
 	// data to output at its discretion.
 	WriteString(string) (int, error)
+
+	// SetOutput sets the output for the renderer.
+	SetOutput(io.Writer)
 
 	// Flush flushes the renderer's buffer to the output.
 	Flush() error

--- a/renderer.go
+++ b/renderer.go
@@ -1,43 +1,46 @@
 package tea
 
-// renderer is the interface for Bubble Tea renderers.
-type renderer interface {
-	// Start the renderer.
-	start()
-
-	// Stop the renderer, but render the final frame in the buffer, if any.
-	stop()
-
-	// Stop the renderer without doing any final rendering.
-	kill()
+// Renderer is the interface for Bubble Tea renderers.
+type Renderer interface {
+	// Close closes the renderer and flushes any remaining data.
+	Close() error
 
 	// Write a frame to the renderer. The renderer can write this data to
 	// output at its discretion.
-	write(string)
+	Write([]byte) (int, error)
+
+	// WriteString a frame to the renderer. The renderer can WriteString this
+	// data to output at its discretion.
+	WriteString(string) (int, error)
+
+	// Flush flushes the renderer's buffer to the output.
+	Flush() error
 
 	// Request a full re-render. Note that this will not trigger a render
 	// immediately. Rather, this method causes the next render to be a full
-	// repaint. Because of this, it's safe to call this method multiple times
+	// Repaint. Because of this, it's safe to call this method multiple times
 	// in succession.
-	repaint()
+	Repaint()
 
-	// Clears the terminal.
-	clearScreen()
+	// ClearScreen clear the terminal screen.
+	ClearScreen()
 
 	// Whether or not the alternate screen buffer is enabled.
-	altScreen() bool
+	AltScreen() bool
 	// Enable the alternate screen buffer.
-	enterAltScreen()
+	EnterAltScreen()
 	// Disable the alternate screen buffer.
-	exitAltScreen()
+	ExitAltScreen()
 
+	// CursorVisibility returns whether the cursor is visible.
+	CursorVisibility() bool
 	// Show the cursor.
-	showCursor()
+	ShowCursor()
 	// Hide the cursor.
-	hideCursor()
+	HideCursor()
 
-	// execute writes a sequence to the terminal.
-	execute(string)
+	// Execute writes a sequence to the underlying output.
+	Execute(string)
 }
 
 // repaintMsg forces a full repaint.

--- a/renderer.go
+++ b/renderer.go
@@ -34,14 +34,15 @@ type Renderer interface {
 	// `CSI H`.
 	ClearScreen()
 
-	// SetMode sets a terminal mode on/off. The mode argument is an int
-	// consisting of the mode identifier.
-	// For example, to set alt-screen mode, you would call SetMode(1049, true).
+	// SetMode toggles a terminal mode such as bracketed paste, the altscreen,
+	// and so on.
+	//
+	// The mode argument is an int consisting of the mode identifier. For
+	// example, to set alt-screen mode, you would call SetMode(1049, true).
 	SetMode(mode int, on bool)
 
-	// Mode returns whether the render has a mode enabled.
-	// For example, to check if alt-screen mode is enabled, you would call
-	// Mode(1049).
+	// Mode returns whether the render has a mode enabled. For example, to
+	// check if alt-screen mode is enabled, you would call Mode(1049).
 	Mode(mode int) bool
 }
 

--- a/renderer.go
+++ b/renderer.go
@@ -29,23 +29,27 @@ type Renderer interface {
 	// in succession.
 	Repaint()
 
-	// ClearScreen clear the terminal screen.
+	// ClearScreen clear the terminal screen. This should always have the same
+	// behavior as the "clear" command which is equivalent to `CSI 2 J` and
+	// `CSI H`.
 	ClearScreen()
 
-	// Whether or not the alternate screen buffer is enabled.
-	AltScreen() bool
-	// Enable the alternate screen buffer.
-	EnterAltScreen()
-	// Disable the alternate screen buffer.
-	ExitAltScreen()
+	// SetMode sets a terminal mode on/off. The mode argument is an int
+	// consisting of the mode identifier.
+	// For example, to set alt-screen mode, you would call SetMode(1049, true).
+	SetMode(mode int, on bool)
 
-	// CursorVisibility returns whether the cursor is visible.
-	CursorVisibility() bool
-	// Show the cursor.
-	ShowCursor()
-	// Hide the cursor.
-	HideCursor()
+	// Mode returns whether the render has a mode enabled.
+	// For example, to check if alt-screen mode is enabled, you would call
+	// Mode(1049).
+	Mode(mode int) bool
 }
 
 // repaintMsg forces a full repaint.
 type repaintMsg struct{}
+
+// Terminal modes used by SetMode and Mode in Bubble Tea.
+const (
+	altScreenMode = 1049
+	hideCursor    = 25
+)

--- a/screen.go
+++ b/screen.go
@@ -168,7 +168,7 @@ func DisabledReportFocus() Msg { return disableReportFocusMsg{} }
 // Deprecated: Use the WithAltScreen ProgramOption instead.
 func (p *Program) EnterAltScreen() {
 	if p.renderer != nil {
-		p.renderer.EnterAltScreen()
+		p.renderer.SetMode(altScreenMode, true)
 	} else {
 		p.startupOptions |= withAltScreen
 	}
@@ -179,7 +179,7 @@ func (p *Program) EnterAltScreen() {
 // Deprecated: The altscreen will exited automatically when the program exits.
 func (p *Program) ExitAltScreen() {
 	if p.renderer != nil {
-		p.renderer.ExitAltScreen()
+		p.renderer.SetMode(altScreenMode, false)
 	} else {
 		p.startupOptions &^= withAltScreen
 	}

--- a/screen.go
+++ b/screen.go
@@ -190,11 +190,7 @@ func (p *Program) ExitAltScreen() {
 //
 // Deprecated: Use the WithMouseCellMotion ProgramOption instead.
 func (p *Program) EnableMouseCellMotion() {
-	if p.renderer != nil {
-		p.renderer.Execute(ansi.EnableMouseCellMotion)
-	} else {
-		p.startupOptions |= withMouseCellMotion
-	}
+	p.execute(ansi.EnableMouseCellMotion)
 }
 
 // DisableMouseCellMotion disables Mouse Cell Motion tracking. This will be
@@ -202,11 +198,7 @@ func (p *Program) EnableMouseCellMotion() {
 //
 // Deprecated: The mouse will automatically be disabled when the program exits.
 func (p *Program) DisableMouseCellMotion() {
-	if p.renderer != nil {
-		p.renderer.Execute(ansi.DisableMouseCellMotion)
-	} else {
-		p.startupOptions &^= withMouseCellMotion
-	}
+	p.execute(ansi.DisableMouseCellMotion)
 }
 
 // EnableMouseAllMotion enables mouse click, release, wheel and motion events,
@@ -215,11 +207,7 @@ func (p *Program) DisableMouseCellMotion() {
 //
 // Deprecated: Use the WithMouseAllMotion ProgramOption instead.
 func (p *Program) EnableMouseAllMotion() {
-	if p.renderer != nil {
-		p.renderer.Execute(ansi.EnableMouseAllMotion)
-	} else {
-		p.startupOptions |= withMouseAllMotion
-	}
+	p.execute(ansi.EnableMouseAllMotion)
 }
 
 // DisableMouseAllMotion disables All Motion mouse tracking. This will be
@@ -227,20 +215,12 @@ func (p *Program) EnableMouseAllMotion() {
 //
 // Deprecated: The mouse will automatically be disabled when the program exits.
 func (p *Program) DisableMouseAllMotion() {
-	if p.renderer != nil {
-		p.renderer.Execute(ansi.DisableMouseAllMotion)
-	} else {
-		p.startupOptions &^= withMouseAllMotion
-	}
+	p.execute(ansi.DisableMouseAllMotion)
 }
 
 // SetWindowTitle sets the terminal window title.
 //
 // Deprecated: Use the SetWindowTitle command instead.
 func (p *Program) SetWindowTitle(title string) {
-	if p.renderer != nil {
-		p.renderer.Execute(ansi.SetWindowTitle(title))
-	} else {
-		p.startupTitle = title
-	}
+	p.execute(ansi.SetWindowTitle(title))
 }

--- a/screen.go
+++ b/screen.go
@@ -168,7 +168,7 @@ func DisabledReportFocus() Msg { return disableReportFocusMsg{} }
 // Deprecated: Use the WithAltScreen ProgramOption instead.
 func (p *Program) EnterAltScreen() {
 	if p.renderer != nil {
-		p.renderer.enterAltScreen()
+		p.renderer.EnterAltScreen()
 	} else {
 		p.startupOptions |= withAltScreen
 	}
@@ -179,7 +179,7 @@ func (p *Program) EnterAltScreen() {
 // Deprecated: The altscreen will exited automatically when the program exits.
 func (p *Program) ExitAltScreen() {
 	if p.renderer != nil {
-		p.renderer.exitAltScreen()
+		p.renderer.ExitAltScreen()
 	} else {
 		p.startupOptions &^= withAltScreen
 	}
@@ -191,7 +191,7 @@ func (p *Program) ExitAltScreen() {
 // Deprecated: Use the WithMouseCellMotion ProgramOption instead.
 func (p *Program) EnableMouseCellMotion() {
 	if p.renderer != nil {
-		p.renderer.execute(ansi.EnableMouseCellMotion)
+		p.renderer.Execute(ansi.EnableMouseCellMotion)
 	} else {
 		p.startupOptions |= withMouseCellMotion
 	}
@@ -203,7 +203,7 @@ func (p *Program) EnableMouseCellMotion() {
 // Deprecated: The mouse will automatically be disabled when the program exits.
 func (p *Program) DisableMouseCellMotion() {
 	if p.renderer != nil {
-		p.renderer.execute(ansi.DisableMouseCellMotion)
+		p.renderer.Execute(ansi.DisableMouseCellMotion)
 	} else {
 		p.startupOptions &^= withMouseCellMotion
 	}
@@ -216,7 +216,7 @@ func (p *Program) DisableMouseCellMotion() {
 // Deprecated: Use the WithMouseAllMotion ProgramOption instead.
 func (p *Program) EnableMouseAllMotion() {
 	if p.renderer != nil {
-		p.renderer.execute(ansi.EnableMouseAllMotion)
+		p.renderer.Execute(ansi.EnableMouseAllMotion)
 	} else {
 		p.startupOptions |= withMouseAllMotion
 	}
@@ -228,7 +228,7 @@ func (p *Program) EnableMouseAllMotion() {
 // Deprecated: The mouse will automatically be disabled when the program exits.
 func (p *Program) DisableMouseAllMotion() {
 	if p.renderer != nil {
-		p.renderer.execute(ansi.DisableMouseAllMotion)
+		p.renderer.Execute(ansi.DisableMouseAllMotion)
 	} else {
 		p.startupOptions &^= withMouseAllMotion
 	}
@@ -239,7 +239,7 @@ func (p *Program) DisableMouseAllMotion() {
 // Deprecated: Use the SetWindowTitle command instead.
 func (p *Program) SetWindowTitle(title string) {
 	if p.renderer != nil {
-		p.renderer.execute(ansi.SetWindowTitle(title))
+		p.renderer.Execute(ansi.SetWindowTitle(title))
 	} else {
 		p.startupTitle = title
 	}

--- a/screen_test.go
+++ b/screen_test.go
@@ -45,12 +45,12 @@ func TestClearMsg(t *testing.T) {
 		{
 			name:     "cursor_hide",
 			cmds:     []Cmd{HideCursor},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?25l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
+			expected: "\x1b[?25l\x1b[?2004h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "cursor_hideshow",
 			cmds:     []Cmd{HideCursor, ShowCursor},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?25l\x1b[?25h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?25h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l",
 		},
 		{
 			name:     "bp_stop_start",

--- a/screen_test.go
+++ b/screen_test.go
@@ -15,17 +15,17 @@ func TestClearMsg(t *testing.T) {
 		{
 			name:     "clear_screen",
 			cmds:     []Cmd{ClearScreen},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[2J\x1b[1;1H\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[2J\x1b[1;1H\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "altscreen",
 			cmds:     []Cmd{EnterAltScreen, ExitAltScreen},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?1049h\x1b[2J\x1b[1;1H\x1b[?25l\x1b[?1049l\x1b[?25l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?1049h\x1b[2J\x1b[1;1H\x1b[?25l\x1b[?1049l\x1b[?25l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "altscreen_autoexit",
 			cmds:     []Cmd{EnterAltScreen},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?1049h\x1b[2J\x1b[1;1H\x1b[?25l\rsuccess\r\n\x1b[2;0H\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1049l\x1b[?25h",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?1049h\x1b[2J\x1b[1;1H\x1b[?25l\rsuccess\r\n\x1b[2;0H\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1049l\x1b[?25h",
 		},
 		{
 			name:     "mouse_cellmotion",
@@ -40,42 +40,42 @@ func TestClearMsg(t *testing.T) {
 		{
 			name:     "mouse_disable",
 			cmds:     []Cmd{EnableMouseAllMotion, DisableMouse},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?1003h\x1b[?1006h\x1b[?1002l\x1b[?1003l\x1b[?1006l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?1003h\x1b[?1006h\x1b[?1002l\x1b[?1003l\x1b[?1006l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "cursor_hide",
 			cmds:     []Cmd{HideCursor},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?25l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?25l\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "cursor_hideshow",
 			cmds:     []Cmd{HideCursor, ShowCursor},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?25l\x1b[?25h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?25l\x1b[?25h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "bp_stop_start",
 			cmds:     []Cmd{DisableBracketedPaste, EnableBracketedPaste},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?2004l\x1b[?2004h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?2004l\x1b[?2004h\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "read_set_clipboard",
 			cmds:     []Cmd{ReadClipboard, SetClipboard("success")},
-			expected: "\x1b[?25l\x1b[?2004h\x1b]52;c;?\a\x1b]52;c;c3VjY2Vzcw==\a\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b]52;c;?\a\x1b]52;c;c3VjY2Vzcw==\a\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "bg_fg_cur_color",
 			cmds:     []Cmd{ForegroundColor, BackgroundColor, CursorColor},
-			expected: "\x1b[?25l\x1b[?2004h\x1b]10;?\a\x1b]11;?\a\x1b]12;?\a\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b]10;?\a\x1b]11;?\a\x1b]12;?\a\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "bg_set_color",
 			cmds:     []Cmd{SetBackgroundColor(color.RGBA{255, 255, 255, 255})},
-			expected: "\x1b[?25l\x1b[?2004h\x1b]11;#ffffff\a\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l",
+			expected: "\x1b[?25l\x1b[?2004h\x1b]11;#ffffff\a\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h",
 		},
 		{
 			name:     "kitty_start",
 			cmds:     []Cmd{disableKittyKeyboard, enableKittyKeyboard(3)},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[>u\x1b[>3u\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[>0u",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[>u\x1b[>3u\rsuccess\r\n\x1b[D\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[>0u",
 		},
 	}
 

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -443,13 +443,6 @@ func (r *standardRenderer) handleMessages(msg Msg) {
 		r.Repaint()
 		r.mtx.Unlock()
 
-	case WindowSizeMsg:
-		r.mtx.Lock()
-		r.width = msg.Width
-		r.height = msg.Height
-		r.Repaint()
-		r.mtx.Unlock()
-
 	case clearScrollAreaMsg:
 		r.clearIgnoredLines()
 
@@ -476,15 +469,32 @@ func (r *standardRenderer) handleMessages(msg Msg) {
 	case scrollDownMsg:
 		r.insertBottom(msg.lines, msg.topBoundary, msg.bottomBoundary)
 
-	case printLineMessage:
-		if !r.altScreenActive {
-			lines := strings.Split(msg.messageBody, "\n")
-			r.mtx.Lock()
-			r.queuedMessageLines = append(r.queuedMessageLines, lines...)
-			r.Repaint()
-			r.mtx.Unlock()
-		}
 	}
+}
+
+// Resize sets the size of the terminal.
+func (r *standardRenderer) Resize(w int, h int) {
+	r.mtx.Lock()
+	r.width = w
+	r.height = h
+	r.Repaint()
+	r.mtx.Unlock()
+}
+
+// InsertAbove inserts lines above the current frame. This only works in
+// inline mode.
+func (r *standardRenderer) InsertAbove(s string) error {
+	if r.altScreenActive {
+		return nil
+	}
+
+	lines := strings.Split(s, "\n")
+	r.mtx.Lock()
+	r.queuedMessageLines = append(r.queuedMessageLines, lines...)
+	r.Repaint()
+	r.mtx.Unlock()
+
+	return nil
 }
 
 // HIGH-PERFORMANCE RENDERING STUFF

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -213,7 +213,7 @@ func (r *standardRenderer) Flush() (err error) {
 
 // Render renders the frame to the internal buffer. The buffer will be
 // outputted via the ticker which calls flush().
-func (r *standardRenderer) Render(s string) error {
+func (r *standardRenderer) Render(s string) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 	r.buf.Reset()
@@ -226,8 +226,7 @@ func (r *standardRenderer) Render(s string) error {
 		s = " "
 	}
 
-	_, err := r.buf.WriteString(s)
-	return err
+	_, _ = r.buf.WriteString(s)
 }
 
 // Repaint forces a full repaint.
@@ -454,7 +453,6 @@ func (r *standardRenderer) handleMessages(msg Msg) {
 
 	case scrollDownMsg:
 		r.insertBottom(msg.lines, msg.topBoundary, msg.bottomBoundary)
-
 	}
 }
 

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -47,9 +47,8 @@ type standardRenderer struct {
 
 // NewStandardRenderer creates a new renderer. Normally you'll want to initialize it
 // with os.Stdout as the first argument.
-func NewStandardRenderer(out io.Writer) Renderer {
+func NewStandardRenderer() Renderer {
 	r := &standardRenderer{
-		out:                out,
 		mtx:                &sync.Mutex{},
 		queuedMessageLines: []string{},
 	}

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -56,6 +56,13 @@ func NewStandardRenderer(out io.Writer) Renderer {
 	return r
 }
 
+// SetOutput sets the output for the renderer.
+func (r *standardRenderer) SetOutput(out io.Writer) {
+	r.mtx.Lock()
+	r.out = out
+	r.mtx.Unlock()
+}
+
 // Close closes the renderer and flushes any remaining data.
 func (r *standardRenderer) Close() (err error) {
 	r.mtx.Lock()

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/x/ansi"
-	"github.com/muesli/ansi/compressor"
 )
 
 const (
@@ -31,7 +30,6 @@ type standardRenderer struct {
 	queuedMessageLines []string
 	lastRender         string
 	linesRendered      int
-	useANSICompressor  bool
 
 	// cursor visibility state
 	cursorHidden bool
@@ -47,17 +45,13 @@ type standardRenderer struct {
 	ignoreLines map[int]struct{}
 }
 
-// newRenderer creates a new renderer. Normally you'll want to initialize it
+// NewStandardRenderer creates a new renderer. Normally you'll want to initialize it
 // with os.Stdout as the first argument.
-func newRenderer(out io.Writer, useANSICompressor bool) Renderer {
+func NewStandardRenderer(out io.Writer) Renderer {
 	r := &standardRenderer{
 		out:                out,
 		mtx:                &sync.Mutex{},
-		useANSICompressor:  useANSICompressor,
 		queuedMessageLines: []string{},
-	}
-	if r.useANSICompressor {
-		r.out = &compressor.Writer{Forward: out}
 	}
 	return r
 }

--- a/tea.go
+++ b/tea.go
@@ -474,7 +474,7 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 				p.renderer.Execute(ansi.RequestKittyKeyboard)
 
 			case modifyOtherKeys:
-				p.renderer.execute(ansi.RequestModifyOtherKeys)
+				p.renderer.Execute(ansi.RequestModifyOtherKeys)
 
 			case setModifyOtherKeysMsg:
 				p.modifyOtherKeys = int(msg)
@@ -642,17 +642,17 @@ func (p *Program) Run() (Model, error) {
 	}
 
 	// If no renderer is set use the standard one.
+	output := p.output
 	if p.renderer == nil {
-		output := p.output
+		// TODO(v2): remove the ANSI compressor
 		if p.startupOptions.has(withANSICompressor) {
 			output = &compressor.Writer{Forward: output}
 		}
-		p.renderer = NewStandardRenderer(output)
-	} else {
-		// Ensure the renderer has the correct output.
-		p.renderer.SetOutput(p.output)
+		p.renderer = NewStandardRenderer()
 	}
 
+	// Set the renderer output.
+	p.renderer.SetOutput(output)
 	if p.ttyOutput != nil {
 		// Set the initial size of the terminal.
 		w, h, err := term.GetSize(p.ttyOutput.Fd())

--- a/tea.go
+++ b/tea.go
@@ -648,6 +648,9 @@ func (p *Program) Run() (Model, error) {
 			output = &compressor.Writer{Forward: output}
 		}
 		p.renderer = NewStandardRenderer(output)
+	} else {
+		// Ensure the renderer has the correct output.
+		p.renderer.SetOutput(p.output)
 	}
 
 	if p.ttyOutput != nil {

--- a/tea.go
+++ b/tea.go
@@ -551,6 +551,13 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 
 			case windowSizeMsg:
 				go p.checkResize()
+
+			case WindowSizeMsg:
+				p.renderer.Resize(msg.Width, msg.Height)
+
+			case printLineMessage:
+				p.renderer.InsertAbove(msg.messageBody)
+
 			}
 
 			// Process internal messages for the renderer.

--- a/tea.go
+++ b/tea.go
@@ -349,9 +349,9 @@ func (p *Program) handleCommands(cmds chan Cmd) chan struct{} {
 }
 
 func (p *Program) disableMouse() {
-	p.renderer.Execute(ansi.DisableMouseCellMotion)
-	p.renderer.Execute(ansi.DisableMouseAllMotion)
-	p.renderer.Execute(ansi.DisableMouseSgrExt)
+	p.execute(ansi.DisableMouseCellMotion)
+	p.execute(ansi.DisableMouseAllMotion)
+	p.execute(ansi.DisableMouseSgrExt)
 }
 
 // eventLoop is the central message loop. It receives and handles the default
@@ -396,12 +396,12 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			case enableMouseCellMotionMsg, enableMouseAllMotionMsg:
 				switch msg.(type) {
 				case enableMouseCellMotionMsg:
-					p.renderer.Execute(ansi.EnableMouseCellMotion)
+					p.execute(ansi.EnableMouseCellMotion)
 				case enableMouseAllMotionMsg:
-					p.renderer.Execute(ansi.EnableMouseAllMotion)
+					p.execute(ansi.EnableMouseAllMotion)
 				}
 				// mouse mode (1006) is a no-op if the terminal doesn't support it.
-				p.renderer.Execute(ansi.EnableMouseSgrExt)
+				p.execute(ansi.EnableMouseSgrExt)
 
 			case disableMouseMsg:
 				p.disableMouse()
@@ -413,54 +413,54 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 				p.renderer.HideCursor()
 
 			case enableBracketedPasteMsg:
-				p.renderer.Execute(ansi.EnableBracketedPaste)
+				p.execute(ansi.EnableBracketedPaste)
 				p.bpActive = true
 
 			case disableBracketedPasteMsg:
-				p.renderer.Execute(ansi.DisableBracketedPaste)
+				p.execute(ansi.DisableBracketedPaste)
 				p.bpActive = false
 
 			case enableReportFocusMsg:
-				p.renderer.Execute(ansi.EnableReportFocus)
+				p.execute(ansi.EnableReportFocus)
 
 			case disableReportFocusMsg:
-				p.renderer.Execute(ansi.DisableReportFocus)
+				p.execute(ansi.DisableReportFocus)
 
 			case readClipboardMsg:
-				p.renderer.Execute(ansi.RequestSystemClipboard)
+				p.execute(ansi.RequestSystemClipboard)
 
 			case setClipboardMsg:
-				p.renderer.Execute(ansi.SetSystemClipboard(string(msg)))
+				p.execute(ansi.SetSystemClipboard(string(msg)))
 
 			case readPrimaryClipboardMsg:
-				p.renderer.Execute(ansi.RequestPrimaryClipboard)
+				p.execute(ansi.RequestPrimaryClipboard)
 
 			case setPrimaryClipboardMsg:
-				p.renderer.Execute(ansi.SetPrimaryClipboard(string(msg)))
+				p.execute(ansi.SetPrimaryClipboard(string(msg)))
 
 			case setBackgroundColorMsg:
 				if msg.Color != nil {
-					p.renderer.Execute(ansi.SetBackgroundColor(msg.Color))
+					p.execute(ansi.SetBackgroundColor(msg.Color))
 				}
 
 			case setForegroundColorMsg:
 				if msg.Color != nil {
-					p.renderer.Execute(ansi.SetForegroundColor(msg.Color))
+					p.execute(ansi.SetForegroundColor(msg.Color))
 				}
 
 			case setCursorColorMsg:
 				if msg.Color != nil {
-					p.renderer.Execute(ansi.SetCursorColor(msg.Color))
+					p.execute(ansi.SetCursorColor(msg.Color))
 				}
 
 			case backgroundColorMsg:
-				p.renderer.Execute(ansi.RequestBackgroundColor)
+				p.execute(ansi.RequestBackgroundColor)
 
 			case foregroundColorMsg:
-				p.renderer.Execute(ansi.RequestForegroundColor)
+				p.execute(ansi.RequestForegroundColor)
 
 			case cursorColorMsg:
-				p.renderer.Execute(ansi.RequestCursorColor)
+				p.execute(ansi.RequestCursorColor)
 
 			case _KittyKeyboardMsg:
 				// Store the kitty flags whenever they are queried.
@@ -468,17 +468,17 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 
 			case setKittyKeyboardFlagsMsg:
 				p.kittyFlags = int(msg)
-				p.renderer.Execute(ansi.PushKittyKeyboard(p.kittyFlags))
+				p.execute(ansi.PushKittyKeyboard(p.kittyFlags))
 
 			case kittyKeyboardMsg:
-				p.renderer.Execute(ansi.RequestKittyKeyboard)
+				p.execute(ansi.RequestKittyKeyboard)
 
 			case modifyOtherKeys:
-				p.renderer.Execute(ansi.RequestModifyOtherKeys)
+				p.execute(ansi.RequestModifyOtherKeys)
 
 			case setModifyOtherKeysMsg:
 				p.modifyOtherKeys = int(msg)
-				p.renderer.Execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
+				p.execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
 
 			case setEnhancedKeyboardMsg:
 				if bool(msg) {
@@ -488,15 +488,15 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 					p.kittyFlags = 0
 					p.modifyOtherKeys = 0
 				}
-				p.renderer.Execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
-				p.renderer.Execute(ansi.PushKittyKeyboard(p.kittyFlags))
+				p.execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
+				p.execute(ansi.PushKittyKeyboard(p.kittyFlags))
 
 			case enableWin32InputMsg:
-				p.renderer.Execute(ansi.EnableWin32Input)
+				p.execute(ansi.EnableWin32Input)
 				p.win32Input = true
 
 			case disableWin32InputMsg:
-				p.renderer.Execute(ansi.DisableWin32Input)
+				p.execute(ansi.DisableWin32Input)
 				p.win32Input = false
 
 			case execMsg:
@@ -504,10 +504,10 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 				p.exec(msg.cmd, msg.fn)
 
 			case terminalVersion:
-				p.renderer.Execute(ansi.RequestXTVersion)
+				p.execute(ansi.RequestXTVersion)
 
 			case primaryDeviceAttrsMsg:
-				p.renderer.Execute(ansi.RequestPrimaryDeviceAttributes)
+				p.execute(ansi.RequestPrimaryDeviceAttributes)
 
 			case BatchMsg:
 				for _, cmd := range msg {
@@ -562,9 +562,9 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			}
 
 			var cmd Cmd
-			model, cmd = model.Update(msg)       // run update
-			cmds <- cmd                          // process command (if any)
-			p.renderer.WriteString(model.View()) //nolint:errcheck // send view to renderer
+			model, cmd = model.Update(msg)  // run update
+			cmds <- cmd                     // process command (if any)
+			p.renderer.Render(model.View()) //nolint:errcheck // send view to renderer
 		}
 	}
 }
@@ -682,34 +682,34 @@ func (p *Program) Run() (Model, error) {
 
 	// Honor program startup options.
 	if p.startupTitle != "" {
-		p.renderer.Execute(ansi.SetWindowTitle(p.startupTitle))
+		p.execute(ansi.SetWindowTitle(p.startupTitle))
 	}
 	if p.startupOptions&withAltScreen != 0 {
 		p.renderer.EnterAltScreen()
 	}
 	if p.startupOptions&withoutBracketedPaste == 0 {
-		p.renderer.Execute(ansi.EnableBracketedPaste)
+		p.execute(ansi.EnableBracketedPaste)
 		p.bpActive = true
 	}
 	if p.startupOptions&withMouseCellMotion != 0 {
-		p.renderer.Execute(ansi.EnableMouseCellMotion)
-		p.renderer.Execute(ansi.EnableMouseSgrExt)
+		p.execute(ansi.EnableMouseCellMotion)
+		p.execute(ansi.EnableMouseSgrExt)
 	} else if p.startupOptions&withMouseAllMotion != 0 {
-		p.renderer.Execute(ansi.EnableMouseAllMotion)
-		p.renderer.Execute(ansi.EnableMouseSgrExt)
+		p.execute(ansi.EnableMouseAllMotion)
+		p.execute(ansi.EnableMouseSgrExt)
 	}
 	if p.startupOptions&withModifyOtherKeys != 0 {
-		p.renderer.Execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
+		p.execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
 	}
 	if p.startupOptions&withKittyKeyboard != 0 {
-		p.renderer.Execute(ansi.PushKittyKeyboard(p.kittyFlags))
+		p.execute(ansi.PushKittyKeyboard(p.kittyFlags))
 	}
 
 	if p.startupOptions&withReportFocus != 0 {
-		p.renderer.Execute(ansi.EnableReportFocus)
+		p.execute(ansi.EnableReportFocus)
 	}
 	if p.startupOptions&withWindowsInputMode != 0 {
-		p.renderer.Execute(ansi.EnableWin32Input)
+		p.execute(ansi.EnableWin32Input)
 	}
 
 	// Start the renderer.
@@ -731,7 +731,7 @@ func (p *Program) Run() (Model, error) {
 	}
 
 	// Render the initial view.
-	p.renderer.WriteString(model.View()) //nolint:errcheck
+	p.renderer.Render(model.View()) //nolint:errcheck
 
 	// Handle resize events.
 	handlers.add(p.handleResize())
@@ -746,7 +746,7 @@ func (p *Program) Run() (Model, error) {
 		err = fmt.Errorf("%w: %s", ErrProgramKilled, p.ctx.Err())
 	} else {
 		// Ensure we rendered the final state of the model.
-		p.renderer.WriteString(model.View()) //nolint:errcheck
+		p.renderer.Render(model.View()) //nolint:errcheck
 	}
 
 	// Tear down.
@@ -826,6 +826,11 @@ func (p *Program) Wait() {
 	<-p.finished
 }
 
+// execute writes the given sequence to the program output.
+func (p *Program) execute(seq string) {
+	io.WriteString(p.output, seq) //nolint:errcheck
+}
+
 // shutdown performs operations to free up resources and restore the terminal
 // to its original state.
 func (p *Program) shutdown(kill bool) {
@@ -876,13 +881,13 @@ func (p *Program) RestoreTerminal() error {
 	if p.renderer != nil {
 		p.startRenderer()
 		p.renderer.HideCursor()
-		p.renderer.Execute(ansi.EnableBracketedPaste)
+		p.execute(ansi.EnableBracketedPaste)
 		p.bpActive = true
 		if p.modifyOtherKeys != 0 {
-			p.renderer.Execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
+			p.execute(ansi.ModifyOtherKeys(p.modifyOtherKeys))
 		}
 		if p.kittyFlags != 0 {
-			p.renderer.Execute(ansi.PushKittyKeyboard(p.kittyFlags))
+			p.execute(ansi.PushKittyKeyboard(p.kittyFlags))
 		}
 	}
 

--- a/tty.go
+++ b/tty.go
@@ -33,19 +33,19 @@ func (p *Program) initTerminal() error {
 // Bubble Tea program.
 func (p *Program) restoreTerminalState() error {
 	if p.renderer != nil {
-		p.renderer.execute(ansi.DisableBracketedPaste)
+		p.renderer.Execute(ansi.DisableBracketedPaste)
 		p.bpActive = false
-		p.renderer.showCursor()
+		p.renderer.ShowCursor()
 		p.disableMouse()
 		if p.modifyOtherKeys != 0 {
-			p.renderer.execute(ansi.DisableModifyOtherKeys)
+			p.renderer.Execute(ansi.DisableModifyOtherKeys)
 		}
 		if p.kittyFlags != 0 {
-			p.renderer.execute(ansi.DisableKittyKeyboard)
+			p.renderer.Execute(ansi.DisableKittyKeyboard)
 		}
 
-		if p.renderer.altScreen() {
-			p.renderer.exitAltScreen()
+		if p.renderer.AltScreen() {
+			p.renderer.ExitAltScreen()
 
 			// give the terminal a moment to catch up
 			time.Sleep(time.Millisecond * 10) //nolint:gomnd

--- a/tty.go
+++ b/tty.go
@@ -32,18 +32,29 @@ func (p *Program) initTerminal() error {
 // restoreTerminalState restores the terminal to the state prior to running the
 // Bubble Tea program.
 func (p *Program) restoreTerminalState() error {
-	if p.renderer != nil {
+	if p.bpActive {
 		p.execute(ansi.DisableBracketedPaste)
-		p.bpActive = false
-		p.renderer.ShowCursor()
-		p.disableMouse()
-		if p.modifyOtherKeys != 0 {
-			p.execute(ansi.DisableModifyOtherKeys)
+	}
+	if p.renderer != nil {
+		if !p.cursorHidden {
+			p.renderer.ShowCursor()
 		}
-		if p.kittyFlags != 0 {
-			p.execute(ansi.DisableKittyKeyboard)
-		}
+	}
 
+	if p.mouseEnabled {
+		p.disableMouse()
+	}
+	if p.modifyOtherKeys != 0 {
+		p.execute(ansi.DisableModifyOtherKeys)
+	}
+	if p.kittyFlags != 0 {
+		p.execute(ansi.DisableKittyKeyboard)
+	}
+	if p.reportFocus {
+		p.execute(ansi.DisableReportFocus)
+	}
+
+	if p.renderer != nil {
 		if p.renderer.AltScreen() {
 			p.renderer.ExitAltScreen()
 

--- a/tty.go
+++ b/tty.go
@@ -37,7 +37,7 @@ func (p *Program) restoreTerminalState() error {
 	}
 	if p.renderer != nil {
 		if !p.cursorHidden {
-			p.renderer.ShowCursor()
+			p.renderer.SetMode(hideCursor, false)
 		}
 	}
 
@@ -55,8 +55,8 @@ func (p *Program) restoreTerminalState() error {
 	}
 
 	if p.renderer != nil {
-		if p.renderer.AltScreen() {
-			p.renderer.ExitAltScreen()
+		if p.renderer.Mode(altScreenMode) {
+			p.renderer.SetMode(altScreenMode, false)
 
 			// give the terminal a moment to catch up
 			time.Sleep(time.Millisecond * 10) //nolint:gomnd

--- a/tty.go
+++ b/tty.go
@@ -33,15 +33,15 @@ func (p *Program) initTerminal() error {
 // Bubble Tea program.
 func (p *Program) restoreTerminalState() error {
 	if p.renderer != nil {
-		p.renderer.Execute(ansi.DisableBracketedPaste)
+		p.execute(ansi.DisableBracketedPaste)
 		p.bpActive = false
 		p.renderer.ShowCursor()
 		p.disableMouse()
 		if p.modifyOtherKeys != 0 {
-			p.renderer.Execute(ansi.DisableModifyOtherKeys)
+			p.execute(ansi.DisableModifyOtherKeys)
 		}
 		if p.kittyFlags != 0 {
-			p.renderer.Execute(ansi.DisableKittyKeyboard)
+			p.execute(ansi.DisableKittyKeyboard)
 		}
 
 		if p.renderer.AltScreen() {


### PR DESCRIPTION
This adds the ability to use a custom renderer using a modified version of the existing `renderer` interface. This also keeps track of enabled capabilities and ensure they are turned off on program exit. It only turns off enabled capabilities rather.

The new API looks like:

```go
// Renderer is the interface for Bubble Tea renderers.
type Renderer interface {
	// Close closes the renderer and flushes any remaining data.
	Close() error

	// Render renders a frame to the output.
	Render(string) error

	// SetOutput sets the output for the renderer.
	SetOutput(io.Writer)

	// Flush flushes the renderer's buffer to the output.
	Flush() error

	// InsertAbove inserts lines above the current frame. This only works in
	// inline mode.
	InsertAbove(string) error

	// Resize sets the size of the terminal.
	Resize(w int, h int)

	// Request a full re-render. Note that this will not trigger a render
	// immediately. Rather, this method causes the next render to be a full
	// Repaint. Because of this, it's safe to call this method multiple times
	// in succession.
	Repaint()

	// ClearScreen clear the terminal screen. This should always have the same
	// behavior as the "clear" command which is equivalent to `CSI 2 J` and
	// `CSI H`.
	ClearScreen()

	// SetMode sets a terminal mode on/off. The mode argument is an int
	// consisting of the mode identifier.
	// For example, to set alt-screen mode, you would call SetMode(1049, true).
	SetMode(mode int, on bool)

	// Mode returns whether the render has a mode enabled.
	// For example, to check if alt-screen mode is enabled, you would call
	// Mode(1049).
	Mode(mode int) bool
}
```

--- 

This also introduces some performance gains by not writing unnecessary sequences on enable/disable terminal modes. For example, we always hide the cursor when the program runs, it doesn't make sense to write the sequence again when the model sends a `HideCursor` command, we already know it's hidden. Don't _always_ disable mouse if it wasn't enabled in the first place.