### PR TITLE
feat!: make Init return the model

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -13,9 +13,9 @@ type testExecModel struct {
 	err error
 }
 
-func (m testExecModel) Init() Cmd {
+func (m *testExecModel) Init() (Model, Cmd) {
 	c := exec.Command(m.cmd) //nolint:gosec
-	return ExecProcess(c, func(err error) Msg {
+	return m, ExecProcess(c, func(err error) Msg {
 		return execFinishedMsg{err}
 	})
 }

--- a/tea.go
+++ b/tea.go
@@ -39,7 +39,7 @@ type Msg interface{}
 type Model interface {
 	// Init is the first function that will be called. It returns an optional
 	// initial command. To not perform an initial command return nil.
-	Init() Cmd
+	Init() (Model, Cmd)
 
 	// Update is called when a message is received. Use it to inspect messages
 	// and, in response, update the model and/or send a command.
@@ -762,7 +762,9 @@ func (p *Program) Run() (Model, error) {
 	p.startRenderer()
 
 	// Initialize the program.
-	if initCmd := model.Init(); initCmd != nil {
+	var initCmd Cmd
+	model, initCmd = model.Init()
+	if initCmd != nil {
 		ch := make(chan struct{})
 		handlers.add(ch)
 

--- a/tea_test.go
+++ b/tea_test.go
@@ -16,8 +16,8 @@ type testModel struct {
 	counter  atomic.Value
 }
 
-func (m testModel) Init() Cmd {
-	return nil
+func (m *testModel) Init() (Model, Cmd) {
+	return m, nil
 }
 
 func (m *testModel) Update(msg Msg) (Model, Cmd) {


### PR DESCRIPTION
This is a useful breaking change that makes `Init()` return the model used in the program. This makes it possible to do creative things in programs with multiple models where the program needs to change the main model.