### PR TITLE
fix: we don't initialize the terminal when using a nilRenderer

### DIFF
--- a/tty.go
+++ b/tty.go
@@ -23,6 +23,11 @@ func (p *Program) suspend() {
 }
 
 func (p *Program) initTerminal() error {
+	if _, ok := p.renderer.(*nilRenderer); ok {
+		// No need to initialize the terminal if we're not rendering
+		return nil
+	}
+
 	if err := p.initInput(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Otherwise, a raw terminal will mess up the output. This is because a raw terminal disables termios OPOST mode which converts newlines to `\r\n` to reset the cursor to the beginning of the screen on new lines.

CC/ @cwarden

Fixes: https://github.com/charmbracelet/bubbletea/issues/1069