### PR TITLE
feat: use go 1.21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,19 +31,16 @@ jobs:
         run: go test ./...
 
       - name: Build examples
-        if: ${{ matrix.go-version != '~1.21' }}
         run: |
           go mod tidy
           go build -v ./...
         working-directory: ./examples
 
       - name: Test examples
-        if: ${{ matrix.go-version != '~1.21' }}
         run: go test -v ./...
         working-directory: ./examples
 
       - name: Build tutorials
-        if: ${{ matrix.go-version != '~1.21' }}
         run: |
           go mod tidy
           go build -v ./...

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.18, ^1]
+        go-version: [~1.21, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -31,19 +31,19 @@ jobs:
         run: go test ./...
 
       - name: Build examples
-        if: ${{ matrix.go-version != '~1.18' }}
+        if: ${{ matrix.go-version != '~1.21' }}
         run: |
           go mod tidy
           go build -v ./...
         working-directory: ./examples
 
       - name: Test examples
-        if: ${{ matrix.go-version != '~1.18' }}
+        if: ${{ matrix.go-version != '~1.21' }}
         run: go test -v ./...
         working-directory: ./examples
 
       - name: Build tutorials
-        if: ${{ matrix.go-version != '~1.18' }}
+        if: ${{ matrix.go-version != '~1.21' }}
         run: |
           go mod tidy
           go build -v ./...

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,8 +2,6 @@ module examples
 
 go 1.21
 
-toolchain go1.22.5
-
 require (
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/bubbletea
 
-go 1.18
+go 1.21
 
 require (
 	github.com/charmbracelet/lipgloss v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,7 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/tutorials/go.mod
+++ b/tutorials/go.mod
@@ -1,6 +1,6 @@
 module tutorial
 
-go 1.18
+go 1.21
 
 require github.com/charmbracelet/bubbletea v0.25.0
 

--- a/tutorials/go.sum
+++ b/tutorials/go.sum
@@ -32,6 +32,7 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
+golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
 golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
- some dependency is already requiring it, as examples/go.mod was set to 1.21 already 
- builds were breaking because of it
- go 1.18 is really old, maybe its time to upgrade?