### PR TITLE
fix: restore terminal during Program.Kill()

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -666,9 +666,10 @@ func (p *Program) Quit() {
 
 // Kill stops the program immediately and restores the former terminal state.
 // The final render that you would normally see when quitting will be skipped.
-// [program.Run] returns a [ErrProgramKilled] error.
+// [Program.Run] returns a [ErrProgramKilled] error.
 func (p *Program) Kill() {
 	p.cancel()
+	p.shutdown(true)
 }
 
 // Wait waits/blocks until the underlying Program finished shutting down.


### PR DESCRIPTION
Prior to this `Program.Kill()` would shutdown the program but not restore the terminal state. Addresses an issue we found in in #1127.

Thanks to @aymanbagabas who paired with me on this one!