### PR TITLE
Deprecate high performance rendering feature and ANSI compressor

### DIFF
--- a/examples/pager/main.go
+++ b/examples/pager/main.go
@@ -13,14 +13,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// You generally won't need this unless you're processing stuff with
-// complicated ANSI escape sequences. Turn it on if you notice flickering.
-//
-// Also keep in mind that high performance rendering only works for programs
-// that use the full size of the terminal. We're enabling that below with
-// tea.EnterAltScreen().
-const useHighPerformanceRenderer = false
-
 var (
 	titleStyle = func() lipgloss.Style {
 		b := lipgloss.RoundedBorder()
@@ -70,26 +62,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// here.
 			m.viewport = viewport.New(msg.Width, msg.Height-verticalMarginHeight)
 			m.viewport.YPosition = headerHeight
-			m.viewport.HighPerformanceRendering = useHighPerformanceRenderer
 			m.viewport.SetContent(m.content)
 			m.ready = true
-
-			// This is only necessary for high performance rendering, which in
-			// most cases you won't need.
-			//
-			// Render the viewport one line below the header.
-			m.viewport.YPosition = headerHeight + 1
 		} else {
 			m.viewport.Width = msg.Width
 			m.viewport.Height = msg.Height - verticalMarginHeight
-		}
-
-		if useHighPerformanceRenderer {
-			// Render (or re-render) the whole viewport. Necessary both to
-			// initialize the viewport and when the window is resized.
-			//
-			// This is needed for high-performance rendering only.
-			cmds = append(cmds, viewport.Sync(m.viewport))
 		}
 	}
 

--- a/options.go
+++ b/options.go
@@ -185,6 +185,9 @@ func WithoutRenderer() ProgramOption {
 //
 // This feature is provisional, and may be changed or removed in a future version
 // of this package.
+//
+// Deprecated: this incurs a noticable performance hit. A future release will
+// optimize ANSI automatically without the performance penalty.
 func WithANSICompressor() ProgramOption {
 	return func(p *Program) {
 		p.startupOptions |= withANSICompressor

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -546,6 +546,9 @@ func (r *standardRenderer) clearIgnoredLines() {
 // use in high-performance rendering, such as a pager that could potentially
 // be rendering very complicated ansi. In cases where the content is simpler
 // standard Bubble Tea rendering should suffice.
+//
+// Deprecated: This option is deprecated and will be removed in a future
+// version of this package.
 func (r *standardRenderer) insertTop(lines []string, topBoundary, bottomBoundary int) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
@@ -573,6 +576,9 @@ func (r *standardRenderer) insertTop(lines []string, topBoundary, bottomBoundary
 // See note in insertTop() for caveats, how this function only makes sense for
 // full-window applications, and how it differs from the normal way we do
 // rendering in Bubble Tea.
+//
+// Deprecated: This option is deprecated and will be removed in a future
+// version of this package.
 func (r *standardRenderer) insertBottom(lines []string, topBoundary, bottomBoundary int) {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
@@ -657,6 +663,8 @@ type syncScrollAreaMsg struct {
 // should also be called on resize (WindowSizeMsg).
 //
 // For high-performance, scroll-based rendering only.
+//
+// Deprecated: This option will be removed in a future version of this package.
 func SyncScrollArea(lines []string, topBoundary int, bottomBoundary int) Cmd {
 	return func() Msg {
 		return syncScrollAreaMsg{
@@ -673,6 +681,8 @@ type clearScrollAreaMsg struct{}
 // those lines to the main rendering routine.
 //
 // For high-performance, scroll-based rendering only.
+//
+// Deprecated: This option will be removed in a future version of this package.
 func ClearScrollArea() Msg {
 	return clearScrollAreaMsg{}
 }
@@ -688,6 +698,8 @@ type scrollUpMsg struct {
 // from view.
 //
 // For high-performance, scroll-based rendering only.
+//
+// Deprecated: This option will be removed in a future version of this package.
 func ScrollUp(newLines []string, topBoundary, bottomBoundary int) Cmd {
 	return func() Msg {
 		return scrollUpMsg{
@@ -709,6 +721,8 @@ type scrollDownMsg struct {
 // disappear from view.
 //
 // For high-performance, scroll-based rendering only.
+//
+// Deprecated: This option will be removed in a future version of this package.
 func ScrollDown(newLines []string, topBoundary, bottomBoundary int) Cmd {
 	return func() Msg {
 		return scrollDownMsg{


### PR DESCRIPTION
These revisions deprecate the high performance rendering set of commands:

* `SyncScrollArea()`
* `ClearScrollArea()`
* `ScrollUp()`
* `ScrollDown()`

Performance rendering is very hard to implement, goes against Bubble Tea's Elm Architecture design patterns, and is very limited in that it can _only_ operate on the entire width of the terminal at once (so it won't work in, say, a viewport that spans half of the terminal width).

We’re also deprecating `WithANSICompressor()` as it has very noticeable performance costs which we believe outweigh the bandwidth benefits otherwise provided.