### PR TITLE
fix: use safeWriter to guard writing to output

### DIFF
--- a/examples/go.mod
+++ b/examples/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymanbagabas/go-udiff v0.2.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/charmbracelet/x/ansi v0.2.3 // indirect
+	github.com/charmbracelet/x/ansi v0.3.0 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect
 	github.com/charmbracelet/x/windows v0.2.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -14,8 +14,6 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
-github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbles v0.20.1-0.20240910180436-8972b56c9dde h1:/u+F3xZsfJYhEQ3MjKvqiXb2Y6LV8/4YHAMICxjGVhY=
 github.com/charmbracelet/bubbles v0.20.1-0.20240910180436-8972b56c9dde/go.mod h1:M5Z4yZGaxq8TZoEY2rs529UxFTeZLnAhmAzqd2wd48M=
 github.com/charmbracelet/glamour v0.8.0 h1:tPrjL3aRcQbn++7t18wOpgLyl8wrOHUEDS7IZ68QtZs=
@@ -24,12 +22,10 @@ github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
 github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA/SsA3cjw=
 github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
-github.com/charmbracelet/x/ansi v0.2.3 h1:VfFN0NUpcjBRd4DnKfRaIRo53KRgey/nhOoEqosGDEY=
-github.com/charmbracelet/x/ansi v0.2.3/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
+github.com/charmbracelet/x/ansi v0.3.0 h1:CCsscv7vKC/DNYUYFQNNIOWzrpTUbLXL3d4fdFIQ0WE=
+github.com/charmbracelet/x/ansi v0.3.0/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b h1:MnAMdlwSltxJyULnrYbkZpp4k58Co7Tah3ciKhSNo0Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
-github.com/charmbracelet/x/exp/teatest v0.0.0-20240521184646-23081fb03b28 h1:sOWKNRjt8uOEVgPiJVIJCse1+mUDM2F/vYY6W0Go640=
-github.com/charmbracelet/x/exp/teatest v0.0.0-20240521184646-23081fb03b28/go.mod h1:l1w+LTJZCCozeGzMEWGxRw6Mo2DfcZUvupz8HGubdes=
 github.com/charmbracelet/x/exp/teatest v0.0.0-20240912153648-d6041061ead9 h1:2q41wBBupsw4GATbF/C3NZ3JtccZ/iYu7cL3doHOnuo=
 github.com/charmbracelet/x/exp/teatest v0.0.0-20240912153648-d6041061ead9/go.mod h1:WPIoTqLbtPGmiv83mabqvIYOrwa1vUZMdp3urF4gQrk=
 github.com/charmbracelet/x/term v0.2.0 h1:cNB9Ot9q8I711MyZ7myUR5HFWL/lc3OpU8jZ4hwm0x0=

--- a/exec.go
+++ b/exec.go
@@ -109,7 +109,7 @@ func (p *Program) exec(c ExecCommand, fn ExecCallback) {
 	}
 
 	c.SetStdin(p.input)
-	c.SetStdout(p.output)
+	c.SetStdout(p.output.Writer())
 	c.SetStderr(os.Stderr)
 
 	// Execute system command.

--- a/options.go
+++ b/options.go
@@ -29,7 +29,7 @@ func WithContext(ctx context.Context) ProgramOption {
 // won't need to use this.
 func WithOutput(output io.Writer) ProgramOption {
 	return func(p *Program) {
-		p.output = output
+		p.output = newSafeWriter(output)
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -11,7 +11,7 @@ func TestOptions(t *testing.T) {
 	t.Run("output", func(t *testing.T) {
 		var b bytes.Buffer
 		p := NewProgram(nil, WithOutput(&b))
-		if f, ok := p.output.(*os.File); ok {
+		if f, ok := p.output.Writer().(*os.File); ok {
 			t.Errorf("expected output to custom, got %v", f.Fd())
 		}
 	})

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -64,19 +64,18 @@ func (r *standardRenderer) setOutput(out io.Writer) {
 
 // close closes the renderer and flushes any remaining data.
 func (r *standardRenderer) close() (err error) {
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
-
-	r.execute(ansi.EraseEntireLine)
 	// Move the cursor back to the beginning of the line
-	r.execute("\r")
+	// NOTE: execute locks the mutex
+	r.execute(ansi.EraseEntireLine + "\r")
 
 	return
 }
 
 // execute writes the given sequence to the output.
 func (r *standardRenderer) execute(seq string) {
+	r.mtx.Lock()
 	_, _ = io.WriteString(r.out, seq)
+	r.mtx.Unlock()
 }
 
 // flush renders the buffer.
@@ -240,11 +239,7 @@ func (r *standardRenderer) reset() {
 }
 
 func (r *standardRenderer) clearScreen() {
-	r.mtx.Lock()
-	defer r.mtx.Unlock()
-
-	r.execute(ansi.EraseEntireDisplay)
-	r.execute(ansi.MoveCursorOrigin)
+	r.execute(ansi.EraseEntireDisplay + ansi.MoveCursorOrigin)
 
 	r.repaint()
 }

--- a/sync.go
+++ b/sync.go
@@ -1,0 +1,31 @@
+package tea
+
+import (
+	"io"
+	"sync"
+)
+
+// safeWriter is a thread-safe writer.
+type safeWriter struct {
+	w  io.Writer
+	mu sync.Mutex
+}
+
+var _ io.Writer = &safeWriter{}
+
+// newSafeWriter returns a new safeWriter.
+func newSafeWriter(w io.Writer) *safeWriter {
+	return &safeWriter{w: w}
+}
+
+// Writer returns the underlying writer.
+func (w *safeWriter) Writer() io.Writer {
+	return w.w
+}
+
+// Write writes to the underlying writer.
+func (w *safeWriter) Write(p []byte) (n int, err error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.w.Write(p)
+}

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -22,7 +22,7 @@ func (p *Program) initInput() (err error) {
 		}
 	}
 
-	if f, ok := p.output.(term.File); ok && term.IsTerminal(f.Fd()) {
+	if f, ok := p.output.Writer().(term.File); ok && term.IsTerminal(f.Fd()) {
 		p.ttyOutput = f
 	}
 

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -34,7 +34,7 @@ func (p *Program) initInput() (err error) {
 	}
 
 	// Save output screen buffer state and enable VT processing.
-	if f, ok := p.output.(term.File); ok && term.IsTerminal(f.Fd()) {
+	if f, ok := p.output.Writer().(term.File); ok && term.IsTerminal(f.Fd()) {
 		p.ttyOutput = f
 		p.previousOutputState, err = term.GetState(f.Fd())
 		if err != nil {


### PR DESCRIPTION
This implements a wrapper around p.output that locks the output on every write. We also need to redefine `channelHandlers` to be thread-safe since `p.Kill()` can be called from a different thread while the program is running.