### PR TITLE
fix: handle Kitty keyboard protocol extensions to legacy sequences

### DIFF
--- a/key_test.go
+++ b/key_test.go
@@ -135,6 +135,18 @@ func TestParseSequence(t *testing.T) {
 			[]Msg{KeyPressMsg{Mod: ModShift | ModAlt, Code: KeyDown}},
 		},
 		seqTest{
+			[]byte("\x1b[1;4:1B"),
+			[]Msg{KeyPressMsg{Mod: ModShift | ModAlt, Code: KeyDown}},
+		},
+		seqTest{
+			[]byte("\x1b[1;4:2B"),
+			[]Msg{KeyPressMsg{Mod: ModShift | ModAlt, Code: KeyDown, IsRepeat: true}},
+		},
+		seqTest{
+			[]byte("\x1b[1;4:3B"),
+			[]Msg{KeyReleaseMsg{Mod: ModShift | ModAlt, Code: KeyDown}},
+		},
+		seqTest{
 			[]byte("\x1b[8~"),
 			[]Msg{KeyPressMsg{Code: KeyEnd}},
 		},

--- a/kitty.go
+++ b/kitty.go
@@ -321,3 +321,20 @@ func parseKittyKeyboard(csi *ansi.CsiSequence) Msg {
 
 	return KeyPressMsg(key)
 }
+
+// parseKittyKeyboardExt parses a Kitty Keyboard Protocol sequence extensions
+// for non CSI u sequences. This includes things like CSI A, SS3 A and others,
+// and CSI ~.
+func parseKittyKeyboardExt(csi *ansi.CsiSequence, k KeyPressMsg) Msg {
+	// Handle Kitty keyboard protocol
+	if csi.HasMore(1) {
+		switch csi.Param(2) {
+		case 1:
+		case 2:
+			k.IsRepeat = true
+		case 3:
+			return KeyReleaseMsg(k)
+		}
+	}
+	return k
+}


### PR DESCRIPTION
Kitty Keyboard protocol extension also applies to legacy CSI A, CSI B, and others, and CSI ~