### PR TITLE
feat!: v2: update module path to github.com/charmbracelet/bubbletea/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/charmbracelet/bubbletea
+module github.com/charmbracelet/bubbletea/v2
 
 go 1.18
 


### PR DESCRIPTION
We also need to do the same with bubbles. That's why the examples are failing