### PR TITLE
(v2) Fix textinputs example

### DIFF
--- a/examples/textinputs/main.go
+++ b/examples/textinputs/main.go
@@ -70,7 +70,7 @@ func (m model) Init() (tea.Model, tea.Cmd) {
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	case tea.KeyMsg:
+	case tea.KeyPressMsg:
 		switch msg.String() {
 		case "ctrl+c", "esc":
 			return m, tea.Quit


### PR DESCRIPTION
## **Fix summary:**
This should fix the textinputs example, as the code is using KeyMsg. KeyMsg seems to have an issue with the v2 alpha where it appears that both KeyPressMsg and KeyReleaseMsg may be unintentionally being called sequentionally within `KeyMsg`. Just using one or the other should solve the issue for this (or at least be a temporary workaround). This issue also likely exists within other examples and may Need to be looked at separately.


## **Specific Details on the Issue Noticed**

**Specs/OS Information**
- Windows 11 Home 10.0.22631
- VSCode Powershell Instance 1.20.11781.0 (this is technical just an integrated vscode instance)
- VSCode Git bash instance 5.2.26(1)-release 
- Windows Terminal 1.20.11781.0 (this is also technically a powershell instance I believe)
- Running a standard querty keyboard layout
    - Result of `(Get-Culture).KeyboardLayoutID` in powershell: `1033`
    - Output from System Information related to Keyboard layout: ![image](https://github.com/user-attachments/assets/a3e7d269-9d73-49b3-9660-263971a13e8a)

**Context**
During the process of developing a client side, terminal implementation of a game client in bubbletea, I happened to notice that after migrating from v1/main release to `v.2.0.0` that my nested models and general input were now skipping/taking two inputs:

(I could only cycle between `Email` and `Submit` in this  photo)
![image](https://github.com/user-attachments/assets/18c8f6db-25f5-48f1-8fa5-ed6a3fffdcc4)

After fiddling with this for a **_while_** (And nearly giving up), I tried a couple of other terminals. I noticed that in Windows Terminal, that there was a slight delay in between key presses that looked very deterministic as to _when_ I pressed the key. Then I briefly recalled this section in the v2 alpha release notes (https://github.com/charmbracelet/bubbletea/releases/tag/v2.0.0-alpha.1):
![image](https://github.com/user-attachments/assets/bf47293e-eb25-454f-acbe-322795f85efa)

My theory then became that at least on 1 complete keyboard press (at least within my environment), that because it's matching on both possible instances (and that people are slow in comparison to an action that's being performed); that within `Update`,   `KeyMsg` was matching on both possible inputs (as was noted) and running each time a full key stroke is hit.  I assume this functionality was not intended, and that `KeyPress` was met as an _**Either Or**_ operation and not an _**Either AND**_. That, or there has to be something within the Runtime that is triggering both events to catch on `KeyPress`, causing this weird loop of Update being called twice.


This makes the fix (at least workaround) relatively simple in that you either need to use `KeyPressMsg` or `KeyReleaseMsg` instead of switching on `KeyMsg`.


There is also a separate bug that was noticed was that these weird escape characters seemed to appear when running the standalone windows terminal (I can also write this up as a separate bug if needed)
Standalone Windows Terminal:
![image](https://github.com/user-attachments/assets/208fbdc3-1377-48f9-9e7d-1fad59e3342e)
changed spots on subsequent attempts:
![image](https://github.com/user-attachments/assets/1642f21f-1b17-4463-ab64-86e8e2011499)



I can open up a separate issue(s) for deeper investigation into both of these problems/bugs if needed as well. 