### PR TITLE
(v2) feat: add experimental features

### DIFF
--- a/options.go
+++ b/options.go
@@ -268,3 +268,24 @@ func WithoutGraphemeClustering() ProgramOption {
 		p.startupOptions |= withoutGraphemeClustering
 	}
 }
+
+// experimentalOptions are experimental features that are not yet stable. These
+// features may change or be removed in future versions.
+type experimentalOptions []string
+
+// has returns true if the experimental option is enabled.
+func (e experimentalOptions) has(option string) bool {
+	for _, o := range e {
+		if o == option {
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	// experimentalCellbuf is an experimental feature that enables a cell buffer
+	// for the renderer. This can be useful for rendering performance and
+	// efficiency.
+	experimentalCellbuf = "cellbuf"
+)

--- a/tea.go
+++ b/tea.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -212,6 +213,9 @@ type Program struct {
 
 	// tracer is used to trace the program's output and input.
 	tracer tracer
+
+	// exp stores program experimental features.
+	exp experimentalOptions
 }
 
 // Quit is a special command that tells the Bubble Tea program to exit.
@@ -246,6 +250,7 @@ func NewProgram(model Model, opts ...ProgramOption) *Program {
 		msgs:         make(chan Msg),
 		rendererDone: make(chan struct{}),
 		modes:        make(map[string]bool),
+		exp:          experimentalOptions{},
 	}
 
 	// Apply all options to the program.
@@ -296,6 +301,12 @@ func NewProgram(model Model, opts ...ProgramOption) *Program {
 
 	if p.tracer.mask&traceOutput != 0 {
 		p.output.trace = true
+	}
+
+	// Experimental features. Right now, we only have one experimental feature
+	// to use the new cell buffer as a default renderer.
+	if exp := p.getenv("TEA_EXPERIMENTAL"); exp != "" {
+		p.exp = strings.Split(exp, ",")
 	}
 
 	return p
@@ -683,8 +694,11 @@ func (p *Program) Run() (Model, error) {
 	var output io.Writer
 	output = p.output
 	if p.renderer == nil {
-		// p.renderer = newStandardRenderer()
-		p.renderer = newCellRenderer()
+		if p.exp.has(experimentalCellbuf) {
+			p.renderer = newCellRenderer()
+		} else {
+			p.renderer = newStandardRenderer()
+		}
 	}
 
 	// Set the renderer output.


### PR DESCRIPTION
Right now, we only have one experimental feature to use the new cell buffer as a default renderer. Use `TEA_EXPERIMENTAL=cellbuf` environment variable to enable the use of the cell buffer as the default renderer.