### PR TITLE
docs(examples): auto-wrap text in pager example

### DIFF
--- a/examples/pager/artichoke.md
+++ b/examples/pager/artichoke.md
@@ -1,15 +1,10 @@
-Glow
-====
+# Glow
 
 A casual introduction. 你好世界!
 
 ## Let’s talk about artichokes
 
-The _artichoke_ is mentioned as a garden plant in the 8th century BC by Homer
-**and** Hesiod. The naturally occurring variant of the artichoke, the cardoon,
-which is native to the Mediterranean area, also has records of use as a food
-among the ancient Greeks and Romans. Pliny the Elder mentioned growing of
-_carduus_ in Carthage and Cordoba.
+The _artichoke_ is mentioned as a garden plant in the 8th century BC by Homer **and** Hesiod. The naturally occurring variant of the artichoke, the cardoon, which is native to the Mediterranean area, also has records of use as a food among the ancient Greeks and Romans. Pliny the Elder mentioned growing of _carduus_ in Carthage and Cordoba.
 
 > He holds him with a skinny hand,
 > ‘There was a ship,’ quoth he.
@@ -25,28 +20,27 @@ _carduus_ in Carthage and Cordoba.
 1. Carrots
 1. Celery
 1. Tacos
-    * Soft
-    * Hard
+   - Soft
+   - Hard
 1. Cucumber
 
 ## Things to eat today
 
-* [x] Carrots
-* [x] Ramen
-* [ ] Currywurst
+- [x] Carrots
+- [x] Ramen
+- [ ] Currywurst
 
 ### Power levels of the aforementioned foods
 
 | Name       | Power | Comment          |
-| ---        | ---   | ---              |
+| ---------- | ----- | ---------------- |
 | Carrots    | 9001  | It’s over 9000?! |
 | Ramen      | 9002  | Also over 9000?! |
 | Currywurst | 10000 | What?!           |
 
 ## Currying Artichokes
 
-Here’s a bit of code in [Haskell](https://haskell.org), because we are fancy.
-Remember that to compile Haskell you’ll need `ghc`.
+Here’s a bit of code in [Haskell](https://haskell.org), because we are fancy. Remember that to compile Haskell you’ll need `ghc`.
 
 ```haskell
 module Main where
@@ -63,6 +57,6 @@ main =
     map hello [ "artichoke", "alcachofa" ] & intercalculate "\n" & putStrLn
 ```
 
-***
+---
 
 _Alcachofa_, if you were wondering, is artichoke in Spanish.

--- a/examples/pager/main.go
+++ b/examples/pager/main.go
@@ -62,8 +62,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// here.
 			m.viewport = viewport.New(msg.Width, msg.Height-verticalMarginHeight)
 			m.viewport.YPosition = headerHeight
-			m.viewport.SetContent(m.content)
 			m.ready = true
+
+			// Wrap content, if necessary.
+			c := lipgloss.NewStyle().Width(m.viewport.Width).Render(m.content)
+			m.viewport.SetContent(c)
 		} else {
 			m.viewport.Width = msg.Width
 			m.viewport.Height = msg.Height - verticalMarginHeight


### PR DESCRIPTION
This revision adds automatic word wrapping to the pager example.

In particular, it exists to illustrate how to work around wrapping issues discussed in https://github.com/charmbracelet/bubbles/pull/578.