### PR TITLE
(v2) feat: support setting cursor position

### DIFF
--- a/cell_renderer.go
+++ b/cell_renderer.go
@@ -263,6 +263,7 @@ func (c *cellRenderer) update(msg Msg) {
 
 	case clearScreenMsg:
 		io.WriteString(c.out, ansi.EraseEntireScreen+ansi.CursorOrigin) //nolint:errcheck
+		c.repaint()
 
 	case repaintMsg:
 		c.repaint()

--- a/cursor.go
+++ b/cursor.go
@@ -1,5 +1,7 @@
 package tea
 
+import "image"
+
 // CursorPositionMsg is a message that represents the terminal cursor position.
 type CursorPositionMsg struct {
 	// Row is the row number.
@@ -42,5 +44,17 @@ func SetCursorStyle(style CursorStyle, steady bool) Cmd {
 	}
 	return func() Msg {
 		return setCursorStyle(style)
+	}
+}
+
+// setCursorPosMsg represents a message to set the cursor position.
+type setCursorPosMsg image.Point
+
+// SetCursorPosition sets the cursor position to the specified relative
+// coordinates. Using -1 for either x or y will not change the cursor position
+// for that axis.
+func SetCursorPosition(x, y int) Cmd {
+	return func() Msg {
+		return setCursorPosMsg{x, y}
 	}
 }

--- a/cursor.go
+++ b/cursor.go
@@ -3,13 +3,7 @@ package tea
 import "image"
 
 // CursorPositionMsg is a message that represents the terminal cursor position.
-type CursorPositionMsg struct {
-	// Row is the row number.
-	Row int
-
-	// Column is the column number.
-	Column int
-}
+type CursorPositionMsg image.Point
 
 // CursorStyle is a style that represents the terminal cursor.
 type CursorStyle int

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aymanbagabas/go-udiff v0.2.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/charmbracelet/x/ansi v0.4.0 // indirect
-	github.com/charmbracelet/x/cellbuf v0.0.0-20241015153255-110a4e49aee6 // indirect
+	github.com/charmbracelet/x/cellbuf v0.0.1 // indirect
 	github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b // indirect
 	github.com/charmbracelet/x/term v0.2.0 // indirect
 	github.com/charmbracelet/x/wcwidth v0.0.0-20241011142426-46044092ad91 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -24,8 +24,8 @@ github.com/charmbracelet/lipgloss v0.13.0 h1:4X3PPeoWEDCMvzDvGmTajSyYPcZM4+y8sCA
 github.com/charmbracelet/lipgloss v0.13.0/go.mod h1:nw4zy0SBX/F/eAO1cWdcvy6qnkDUxr8Lw7dvFrAIbbY=
 github.com/charmbracelet/x/ansi v0.4.0 h1:NqwHA4B23VwsDn4H3VcNX1W1tOmgnvY1NDx5tOXdnOU=
 github.com/charmbracelet/x/ansi v0.4.0/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoCBjs7dGWp4Ktw=
-github.com/charmbracelet/x/cellbuf v0.0.0-20241015153255-110a4e49aee6 h1:z6Jq8MwJxOqzNSLEyAfRrHvUGFU7SgTFgZrqFHAJIu4=
-github.com/charmbracelet/x/cellbuf v0.0.0-20241015153255-110a4e49aee6/go.mod h1:mFpvlGowTd0Fiv4TdoKyGZaZdigSUHtBJralbADonwE=
+github.com/charmbracelet/x/cellbuf v0.0.1 h1:us+C8dDO1NzO+2I8WItenR6V/oBZr7oVmhU4n3mi4Yg=
+github.com/charmbracelet/x/cellbuf v0.0.1/go.mod h1:mFpvlGowTd0Fiv4TdoKyGZaZdigSUHtBJralbADonwE=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b h1:MnAMdlwSltxJyULnrYbkZpp4k58Co7Tah3ciKhSNo0Q=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/exp/teatest/v2 v2.0.0-20241016014612-3b4d04043233 h1:2bTR/MtnJuq9RrCZSPwCOO34YSDByKL6nzXQMnsKK6U=

--- a/key_test.go
+++ b/key_test.go
@@ -64,7 +64,7 @@ func buildBaseSeqTests() []seqTest {
 		// position report having the same sequence. See [parseCsi] for more
 		// information.
 		if f3CurPosRegexp.MatchString(seq) {
-			st.msgs = []Msg{k, CursorPositionMsg{Row: 1, Column: int(key.Mod) + 1}}
+			st.msgs = []Msg{k, CursorPositionMsg{Y: 0, X: int(key.Mod)}}
 		}
 		td = append(td, st)
 	}

--- a/parse.go
+++ b/parse.go
@@ -256,7 +256,7 @@ func parseCsi(b []byte) (int, Msg) {
 		// This report may return a third parameter representing the page
 		// number, but we don't really need it.
 		if paramsLen >= 2 && csi.Param(0) != -1 && csi.Param(1) != -1 {
-			return i, CursorPositionMsg{Row: csi.Param(0), Column: csi.Param(1)}
+			return i, CursorPositionMsg{Y: csi.Param(0) - 1, X: csi.Param(1) - 1}
 		}
 	case 'm' | '<'<<parser.MarkerShift, 'M' | '<'<<parser.MarkerShift:
 		// Handle SGR mouse
@@ -275,7 +275,7 @@ func parseCsi(b []byte) (int, Msg) {
 	case 'R':
 		// Cursor position report OR modified F3
 		if paramsLen == 2 && csi.Param(0) != -1 && csi.Param(1) != -1 {
-			m := CursorPositionMsg{Row: csi.Param(0), Column: csi.Param(1)}
+			m := CursorPositionMsg{Y: csi.Param(0) - 1, X: csi.Param(1) - 1}
 			if csi.Param(0) == 1 && csi.Param(1)-1 <= int(ModMeta|ModShift|ModAlt|ModCtrl) {
 				// XXX: We cannot differentiate between cursor position report and
 				// CSI 1 ; <mod> R (which is modified F3) when the cursor is at the


### PR DESCRIPTION
You can now set the cursor position in Bubble Tea cell renderer.

```go
// func SetCursorPosition(x, y int) Cmd
// In your Update
func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
  // ...
  return m, tea.SetCursorPosition(0, 3) // set the cursor position to the beginning of the 4th line
}
```

Fixes: https://github.com/charmbracelet/bubbletea/issues/918
Fixes: https://github.com/charmbracelet/bubbletea/issues/874