### PR TITLE
(v2) fix: windows: ensure the input buffer is empty

### DIFF
--- a/cancelreader_windows.go
+++ b/cancelreader_windows.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	xwindows "github.com/charmbracelet/x/windows"
 	"github.com/muesli/cancelreader"
 	"golang.org/x/sys/windows"
 )
@@ -44,6 +45,11 @@ func newCancelreader(r io.Reader) (cancelreader.CancelReader, error) {
 
 	conin, err := windows.GetStdHandle(windows.STD_INPUT_HANDLE)
 	if err != nil {
+		return fallback(r)
+	}
+
+	// Discard any pending input events.
+	if err := xwindows.FlushConsoleInputBuffer(conin); err != nil {
 		return fallback(r)
 	}
 


### PR DESCRIPTION
Before initializing the input reader, we need to ensure that the console input buffer is empty, otherwise, we can get dangling events from previous sessions.

Fixes: https://github.com/charmbracelet/bubbletea/issues/1167
Supersedes: https://github.com/charmbracelet/bubbletea/pull/1180

CC/ @denish3436