### PR TITLE
feat(ci): use meta lint-sync workflow to sync linter config

### DIFF
--- a/.github/workflows/lint-sync.yml
+++ b/.github/workflows/lint-sync.yml
@@ -1,0 +1,14 @@
+name: lint-sync
+on:
+  schedule:
+    # every Sunday at midnight
+    - cron: "0 0 * * 0"
+  workflow_dispatch: # allows manual triggering
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lint:
+    uses: charmbracelet/meta/.github/workflows/lint-sync.yml@main


### PR DESCRIPTION
This adds a new workflow that runs manually or every week to sync the linter configuration from the meta repo. It will simply open a PR with the changes, which can be reviewed and merged as needed.