### PR TITLE
(v2) feat: add WithRequestBackground option to query terminal background c…

### DIFF
--- a/options.go
+++ b/options.go
@@ -268,3 +268,14 @@ func WithGraphemeClustering() ProgramOption {
 		p.startupOptions |= withGraphemeClustering
 	}
 }
+
+// WithRequestBackground starts the program with a request to query the
+// background color of the terminal.
+//
+// This is useful if you want to know the background color of the terminal. The
+// background color will be sent to your program as a [BackgroundMsg].
+func WithRequestBackground() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withRequestBackgroundColor
+	}
+}

--- a/tea.go
+++ b/tea.go
@@ -104,6 +104,7 @@ const (
 	withReportFocus
 	withKeyboardEnhancements
 	withGraphemeClustering
+	withRequestBackgroundColor
 )
 
 // channelHandlers manages the series of channels returned by various processes.
@@ -767,6 +768,9 @@ func (p *Program) Run() (Model, error) {
 			p.execute(ansi.PushKittyKeyboard(p.keyboard.kittyFlags))
 			p.execute(ansi.RequestKittyKeyboard)
 		}
+	}
+	if p.startupOptions.has(withRequestBackgroundColor) {
+		p.execute(ansi.RequestBackgroundColor)
 	}
 
 	// Start the renderer.


### PR DESCRIPTION
…olor

This commit adds a new option to the program, `WithRequestBackground`, which will send a request to the terminal to query the background color of the terminal.