### PR TITLE
feat: Wrap error returned from run with context error

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -595,7 +595,7 @@ func (p *Program) Run() (Model, error) {
 	model, err := p.eventLoop(model, cmds)
 	killed := p.ctx.Err() != nil
 	if killed {
-		err = fmt.Errorf("%w: %w", ErrProgramKilled, context.Cause(p.ctx))
+		err = fmt.Errorf("%w: %w", ErrProgramKilled, p.ctx.Err())
 	} else {
 		// Ensure we rendered the final state of the model.
 		p.renderer.write(model.View())

--- a/tea.go
+++ b/tea.go
@@ -595,7 +595,7 @@ func (p *Program) Run() (Model, error) {
 	model, err := p.eventLoop(model, cmds)
 	killed := p.ctx.Err() != nil
 	if killed {
-		err = fmt.Errorf("%w: %s", ErrProgramKilled, p.ctx.Err())
+		err = fmt.Errorf("%w: %w", ErrProgramKilled, p.ctx.Err())
 	} else {
 		// Ensure we rendered the final state of the model.
 		p.renderer.write(model.View())

--- a/tea.go
+++ b/tea.go
@@ -595,6 +595,7 @@ func (p *Program) Run() (Model, error) {
 	model, err := p.eventLoop(model, cmds)
 	killed := p.ctx.Err() != nil
 	if killed {
+		// TODO: change p.ctx.Err() to context.Cause(p.ctx) on upgrade to go 1.20 to take into account context.WithCancelCause
 		err = fmt.Errorf("%w: %w", ErrProgramKilled, p.ctx.Err())
 	} else {
 		// Ensure we rendered the final state of the model.

--- a/tea.go
+++ b/tea.go
@@ -595,7 +595,7 @@ func (p *Program) Run() (Model, error) {
 	model, err := p.eventLoop(model, cmds)
 	killed := p.ctx.Err() != nil
 	if killed {
-		err = fmt.Errorf("%w: %w", ErrProgramKilled, p.ctx.Err())
+		err = fmt.Errorf("%w: %w", ErrProgramKilled, context.Cause(p.ctx))
 	} else {
 		// Ensure we rendered the final state of the model.
 		p.renderer.write(model.View())

--- a/tea_test.go
+++ b/tea_test.go
@@ -160,8 +160,13 @@ func TestTeaContext(t *testing.T) {
 		}
 	}()
 
-	if _, err := p.Run(); !errors.Is(err, ErrProgramKilled) {
+	_, err := p.Run()
+	if !errors.Is(err, ErrProgramKilled) {
 		t.Fatalf("Expected %v, got %v", ErrProgramKilled, err)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected %v, got %v", context.Canceled, err)
 	}
 }
 


### PR DESCRIPTION
Fixes #1212 

This change allows the error returned by `p.Run` to be checked for a context error.

For example, given this code:

```go
ctx := context.WithDeadline(context.Background, time.Second*5)
p := tea.NewProgram(model, tea.WithContext(ctx))
_, err := p.Run()
if errors.Is(err, context.DeadlineExceeded) {
  // Handle timeout
}
```

This change now allows this to work.

This opens up more possibilities, allowing a program to cancel a context, and look for the reason for the cancellation.
