### PR TITLE
feat: Wrap error returned from run with context error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/charmbracelet/bubbletea/v2
 
-go 1.18
+go 1.20
 
 require (
 	github.com/charmbracelet/colorprofile v0.1.3

--- a/tea.go
+++ b/tea.go
@@ -810,7 +810,7 @@ func (p *Program) Run() (Model, error) {
 	model, err := p.eventLoop(model, cmds)
 	killed := p.ctx.Err() != nil
 	if killed {
-		err = fmt.Errorf("%w: %s", ErrProgramKilled, p.ctx.Err())
+		err = fmt.Errorf("%w: %w", ErrProgramKilled, p.ctx.Err())
 	} else {
 		// Ensure we rendered the final state of the model.
 		p.renderer.render(model.View()) //nolint:errcheck

--- a/tea.go
+++ b/tea.go
@@ -810,7 +810,7 @@ func (p *Program) Run() (Model, error) {
 	model, err := p.eventLoop(model, cmds)
 	killed := p.ctx.Err() != nil
 	if killed {
-		err = fmt.Errorf("%w: %w", ErrProgramKilled, p.ctx.Err())
+		err = fmt.Errorf("%w: %w", ErrProgramKilled, context.Cause(p.ctx))
 	} else {
 		// Ensure we rendered the final state of the model.
 		p.renderer.render(model.View()) //nolint:errcheck

--- a/tea_test.go
+++ b/tea_test.go
@@ -160,8 +160,13 @@ func TestTeaContext(t *testing.T) {
 		}
 	}()
 
-	if _, err := p.Run(); !errors.Is(err, ErrProgramKilled) {
+	_, err := p.Run()
+	if !errors.Is(err, ErrProgramKilled) {
 		t.Fatalf("Expected %v, got %v", ErrProgramKilled, err)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Expected %v, got %v", context.Canceled, err)
 	}
 }
 

--- a/tutorials/go.mod
+++ b/tutorials/go.mod
@@ -1,6 +1,6 @@
 module tutorial
 
-go 1.18
+go 1.20
 
 require github.com/charmbracelet/bubbletea/v2 v2.0.0-20240918180721-14cb6b5de1d2
 


### PR DESCRIPTION
Fixes #1212 

Previous PR: #1215 

This change depends on features added in go 1.20, therefore the minimum version is bumped to that.;

This allows the error returned by `p.Run` to be checked for a context error.

For example, given this code:

```go
ctx := context.WithTimeout(context.Background, time.Second*5)
p := tea.NewProgram(model, tea.WithContext(ctx))
_, err := p.Run()
if errors.Is(err, context.DeadlineExceeded) {
  // Handle timeout
}
```

This change now allows this to work.

This opens up more possibilities, allowing a program to cancel a context, and look for the reason for the cancellation.

Using `context.Cause` to get the error further allows for even more precise handling, when a context is built with `context.WithCancelCause`, for example:

```go
ctx, cancel := context.WithCancelCause(context.Background())
ctx = context.WithTimeout(ctx, time.Second*5)
badThing := errors.New("a bad thing happened")

p := tea.NewProgram(model, tea.WithContext(ctx))
go func() {
  // do some stuff
  if badThingHappened {
    cancel(badThing)
  }
)()

_, err := p.Run()
switch {
case errors.Is(err, context.DeadlineExceeded):
  // Handle timeout
case errors.Is(err, badThing):
  // Handle bad thing
case err != nil:
  // Handle other errors
}
```