### PR TITLE
fix: renderer: keep a separate count of lines rendered in the alt screen 

### DIFF
--- a/screen_test.go
+++ b/screen_test.go
@@ -24,7 +24,7 @@ func TestClearMsg(t *testing.T) {
 		{
 			name:     "altscreen_autoexit",
 			cmds:     []Cmd{EnterAltScreen},
-			expected: "\x1b[?25l\x1b[?2004h\x1b[?1049h\x1b[2J\x1b[H\x1b[?25l\rsuccess\x1b[0K\r\n\x1b[0K\x1b[2;0H\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1049l\x1b[?25h",
+			expected: "\x1b[?25l\x1b[?2004h\x1b[?1049h\x1b[2J\x1b[H\x1b[?25l\x1b[H\rsuccess\x1b[0K\r\n\x1b[0K\x1b[2;0H\x1b[2K\r\x1b[?2004l\x1b[?25h\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?1049l\x1b[?25h",
 		},
 		{
 			name:     "mouse_cellmotion",

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -57,9 +57,6 @@ type standardRenderer struct {
 
 	// lines explicitly set not to render
 	ignoreLines map[int]struct{}
-
-	// lines rendered before entering alt screen mode
-	linesRenderedBeforeAltScreen int
 }
 
 // newRenderer creates a new renderer. Normally you'll want to initialize it
@@ -337,10 +334,6 @@ func (r *standardRenderer) enterAltScreen() {
 	r.altScreenActive = true
 	r.execute(ansi.EnableAltScreenBuffer)
 
-	// Save the current line count before entering the alternate screen mode.
-	// This allows us to compare and adjust the cursor position when exiting the alternate screen.
-	r.linesRenderedBeforeAltScreen = r.linesRendered
-
 	// Ensure that the terminal is cleared, even when it doesn't support
 	// alt screen (or alt screen support is disabled, like GNU screen by
 	// default).
@@ -372,18 +365,6 @@ func (r *standardRenderer) exitAltScreen() {
 
 	r.altScreenActive = false
 	r.execute(ansi.DisableAltScreenBuffer)
-
-	// Adjust cursor and screen
-	if r.linesRendered < r.linesRenderedBeforeAltScreen {
-		// If fewer lines were rendered in the alternate screen, move the cursor up
-		// to align with the previous normal screen position and clear any remaining lines.
-		r.execute(ansi.CursorUp(r.linesRenderedBeforeAltScreen - r.linesRendered))
-		r.execute(ansi.EraseScreenBelow)
-	} else if r.linesRendered > r.linesRenderedBeforeAltScreen && r.linesRenderedBeforeAltScreen > 0 {
-		// If more lines were rendered in the alternate screen, move the cursor down
-		// to align with the new position.
-		r.execute(ansi.CursorDown(r.linesRendered - r.linesRenderedBeforeAltScreen))
-	}
 
 	// cmd.exe and other terminals keep separate cursor states for the AltScreen
 	// and the main buffer. We have to explicitly reset the cursor visibility


### PR DESCRIPTION
We need to keep a separate count of lines rendered in the alt screen and
inline mode. This is because when we enter alt screen mode, the cursor
position is saved, and the alt screen is cleared. Now when we exit the
alt screen mode, the cursor position is restored so we don't need to
move the cursor to the beginning of the section that we rendered.

To fix this, we keep a separate count of lines rendered in the alt screen
mode and inline mode.

Related: https://github.com/charmbracelet/bubbletea/issues/1013
Fixes: https://github.com/charmbracelet/bubbletea/pull/1241
Fixes: https://github.com/charmbracelet/bubbletea/issues/1248


CC/ @unitsvc @semihbkgr 