### PR TITLE
feat(SIGINT): better handle interrupts

### DIFF
--- a/examples/suspend/main.go
+++ b/examples/suspend/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -23,9 +24,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "q", "ctrl+c", "esc":
+		case "q", "esc":
 			m.quitting = true
 			return m, tea.Quit
+		case "ctrl+c":
+			m.quitting = true
+			return m, tea.Interrupt
 		case "ctrl+z":
 			m.suspending = true
 			return m, tea.Suspend
@@ -39,12 +43,15 @@ func (m model) View() string {
 		return ""
 	}
 
-	return "\nPress ctrl-z to suspend, or ctrl+c to exit\n"
+	return "\nPress ctrl-z to suspend, ctrl+c to interrupt, q, or esc to exit\n"
 }
 
 func main() {
 	if _, err := tea.NewProgram(model{}).Run(); err != nil {
 		fmt.Println("Error running program:", err)
+		if errors.Is(err, tea.ErrInterrupted) {
+			os.Exit(130)
+		}
 		os.Exit(1)
 	}
 }

--- a/options.go
+++ b/options.go
@@ -186,7 +186,7 @@ func WithoutRenderer() ProgramOption {
 // This feature is provisional, and may be changed or removed in a future version
 // of this package.
 //
-// Deprecated: this incurs a noticable performance hit. A future release will
+// Deprecated: this incurs a noticeable performance hit. A future release will
 // optimize ANSI automatically without the performance penalty.
 func WithANSICompressor() ProgramOption {
 	return func(p *Program) {


### PR DESCRIPTION
This PR introduces `Interrupt()`, `InterruptMsg{}`, and `ErrInterrupted`.

Users can still handle "ctrl+c" as before, but instead of return `tea.Quit`, they can return `tea.Interrupt`.

Later on, they can check if `errors.Is(err, tea.ErrInterrupted)`, and `os.Exit(130)` if they want to exit with a different code.