### PR TITLE
(v2) feat: add environ type and EnvMsg message

### DIFF
--- a/environ.go
+++ b/environ.go
@@ -1,6 +1,12 @@
 package tea
 
-import "strings"
+import (
+	"strings"
+)
+
+// environ is a slice of strings that represents the environment variables of
+// the program.
+type environ []string
 
 // getenv is a function that returns the value of the environment variable named
 // by the key. If the variable is not present in the environment, the value
@@ -8,11 +14,47 @@ import "strings"
 // This function traverses the environment variables in reverse order, so that
 // the last value set for the key is the one returned.
 func (p *Program) getenv(key string) (v string) {
-	for i := len(p.environ) - 1; i >= 0; i-- {
-		if strings.HasPrefix(p.environ[i], key+"=") {
-			v = strings.TrimPrefix(p.environ[i], key+"=")
+	return p.environ.Getenv(key)
+}
+
+// Getenv returns the value of the environment variable named by the key. If
+// the variable is not present in the environment, the value returned will be
+// the empty string.
+func (p environ) Getenv(key string) (v string) {
+	v, _ = p.LookupEnv(key)
+	return
+}
+
+// LookupEnv retrieves the value of the environment variable named by the key.
+// If the variable is present in the environment the value (which may be empty)
+// is returned and the boolean is true. Otherwise the returned value will be
+// empty and the boolean will be false.
+func (p environ) LookupEnv(key string) (s string, v bool) {
+	for i := len(p) - 1; i >= 0; i-- {
+		if strings.HasPrefix(p[i], key+"=") {
+			s = strings.TrimPrefix(p[i], key+"=")
+			v = true
 			break
 		}
 	}
 	return
+}
+
+// EnvMsg is a message that represents the environment variables of the
+// program. This message is sent to the program when it starts.
+type EnvMsg environ
+
+// Getenv returns the value of the environment variable named by the key. If
+// the variable is not present in the environment, the value returned will be
+// the empty string.
+func (msg EnvMsg) Getenv(key string) (v string) {
+	return environ(msg).Getenv(key)
+}
+
+// LookupEnv retrieves the value of the environment variable named by the key.
+// If the variable is present in the environment the value (which may be empty)
+// is returned and the boolean is true. Otherwise the returned value will be
+// empty and the boolean will be false.
+func (msg EnvMsg) LookupEnv(key string) (s string, v bool) {
+	return environ(msg).LookupEnv(key)
 }

--- a/tea.go
+++ b/tea.go
@@ -188,7 +188,7 @@ type Program struct {
 	renderer            renderer
 
 	// the environment variables for the program, defaults to os.Environ().
-	environ []string
+	environ environ
 
 	// where to read inputs from, this will usually be os.Stdin.
 	input io.Reader
@@ -779,6 +779,9 @@ func (p *Program) Run() (Model, error) {
 	// Send the initial size to the program.
 	go p.Send(resizeMsg)
 	p.renderer.resize(resizeMsg.Width, resizeMsg.Height)
+
+	// Send the environment variables used by the program.
+	go p.Send(EnvMsg(p.environ))
 
 	// Init the input reader and initial model.
 	model := p.initialModel


### PR DESCRIPTION
Send the environment variables used by the program to the program when it starts. This is done by sending an `EnvMsg` message to the program. Programs that need to access the environment variables can use this message type to get the values of the environment variables.

This is useful when programs targeting remote sessions need to access environment variables that are set by the user or the shell.

Example:

```go
type model struct {
  term string
}

func (m model) Init() (tea.Model, tea.Cmd) {
  return m, nil
}

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
  switch msg := msg.(type) {
  case tea.EnvMsg:
    m.term = msg.Getenv("TERM")
  }

  return m, nil
}

func (m model) View() string {
  return "We're running $TERM=" + m.term
}
```