### PR TITLE
Update documentation references from 'master' to 'main' branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ By the way, the non-annotated source code for this program is available
 [on GitHub][tut-source].
 
 [elm]: https://guide.elm-lang.org/architecture/
-[tut-source]: https://github.com/charmbracelet/bubbletea/tree/master/tutorials/basics
+[tut-source]: https://github.com/charmbracelet/bubbletea/tree/main/tutorials/basics
 
 ### Enough! Let's get to it.
 
@@ -257,8 +257,8 @@ look at the [Command Tutorial][cmd]. It's pretty simple.
 There are also several [Bubble Tea examples][examples] available and, of course,
 there are [Go Docs][docs].
 
-[cmd]: https://github.com/charmbracelet/bubbletea/tree/master/tutorials/commands/
-[examples]: https://github.com/charmbracelet/bubbletea/tree/master/examples
+[cmd]: https://github.com/charmbracelet/bubbletea/tree/main/tutorials/commands/
+[examples]: https://github.com/charmbracelet/bubbletea/tree/main/examples
 [docs]: https://pkg.go.dev/github.com/charmbracelet/bubbletea?tab=doc
 
 ## Debugging
@@ -385,7 +385,7 @@ of days past.
 
 ## License
 
-[MIT](https://github.com/charmbracelet/bubbletea/raw/master/LICENSE)
+[MIT](https://github.com/charmbracelet/bubbletea/raw/main/LICENSE)
 
 ---
 


### PR DESCRIPTION
This PR updates outdated references in the README.md file that pointed to the `master` branch, replacing them with references to the `main` branch. This ensures the documentation reflects the current branch naming convention and avoids confusion for new users.