### PR TITLE
(v2) refactor: remove moving the cursor logic

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -15,44 +15,6 @@ const (
 	CursorBar
 )
 
-// setCursorStyle is an internal message that sets the cursor style. This matches the
-// ANSI escape sequence values for cursor styles. This includes:
-//
-//	0: Blinking block
-//	1: Blinking block (default)
-//	2: Steady block
-//	3: Blinking underline
-//	4: Steady underline
-//	5: Blinking bar (xterm)
-//	6: Steady bar (xterm)
-type setCursorStyle int
-
-// SetCursorStyle is a command that sets the terminal cursor style. Steady
-// determines if the cursor should blink or not.
-func SetCursorStyle(style CursorStyle, blink bool) Cmd {
-	// We're using the ANSI escape sequence values for cursor styles.
-	// We need to map both [style] and [steady] to the correct value.
-	style = (style * 2) + 1
-	if !blink {
-		style++
-	}
-	return func() Msg {
-		return setCursorStyle(style)
-	}
-}
-
-// setCursorPosMsg represents a message to set the cursor position.
-type setCursorPosMsg image.Point
-
-// SetCursorPosition sets the cursor position to the specified relative
-// coordinates. Using -1 for either x or y will not change the cursor position
-// for that axis.
-func SetCursorPosition(x, y int) Cmd {
-	return func() Msg {
-		return setCursorPosMsg{x, y}
-	}
-}
-
 // requestCursorPosMsg is a message that requests the cursor position.
 type requestCursorPosMsg struct{}
 

--- a/tea.go
+++ b/tea.go
@@ -474,9 +474,6 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 					}
 				}
 
-			case setCursorStyle:
-				p.execute(ansi.SetCursorStyle(int(msg)))
-
 			case modeReportMsg:
 				switch msg.Mode {
 				case ansi.GraphemeClusteringMode:
@@ -673,9 +670,6 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 
 			case RawMsg:
 				p.execute(fmt.Sprint(msg.Msg))
-
-			case setCursorPosMsg:
-				p.renderer.moveTo(msg.X, msg.Y)
 
 			case printLineMessage:
 				p.renderer.insertAbove(msg.messageBody)


### PR DESCRIPTION
This removes moving the cursor and setting the cursor style from the library until we have a better way to handle it.