### PR TITLE
feat: add WithWindowSize option to set the initial window size

### DIFF
--- a/options.go
+++ b/options.go
@@ -295,3 +295,14 @@ func WithColorProfile(profile colorprofile.Profile) ProgramOption {
 		p.profile = profile
 	}
 }
+
+// WithWindowSize sets the initial size of the terminal window. This is useful
+// when you need to set the initial size of the terminal window, for example
+// during testing or when you want to run your program in a non-interactive
+// environment.
+func WithWindowSize(width, height int) ProgramOption {
+	return func(p *Program) {
+		p.width = width
+		p.height = height
+	}
+}

--- a/screen_test.go
+++ b/screen_test.go
@@ -94,10 +94,9 @@ func TestClearMsg(t *testing.T) {
 					"TERM=xterm-256color", // always use xterm and 256 colors for tests
 				}),
 				// Use ANSI256 to increase test coverage.
-				WithColorProfile(colorprofile.ANSI256))
-
-			// Set the initial window size for the program.
-			p.width, p.height = 80, 24
+				WithColorProfile(colorprofile.ANSI256),
+				// Set the initial window size for the program.
+				WithWindowSize(80, 24))
 
 			go p.Send(append(test.cmds, Quit))
 


### PR DESCRIPTION
This adds a new option to set the initial window size of the terminal window. This is useful in testing and required for teatest/v2 after the changes in the renderer. The cell-based cursed renderer heavily relies on the terminal size, and it's important to have a way to set the size manually for tests to run in a non-interactive environment.