### PR TITLE
fix: reset renderer and cursor when releasing terminal

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -100,7 +100,7 @@ func (c *osExecCommand) SetStderr(w io.Writer) {
 
 // exec runs an ExecCommand and delivers the results to the program as a Msg.
 func (p *Program) exec(c ExecCommand, fn ExecCallback) {
-	if err := p.ReleaseTerminal(); err != nil {
+	if err := p.releaseTerminal(false); err != nil {
 		// If we can't release input, abort.
 		if fn != nil {
 			go p.Send(fn(err))

--- a/tea.go
+++ b/tea.go
@@ -1050,6 +1050,10 @@ func (p *Program) recoverFromPanic() {
 // ReleaseTerminal restores the original terminal state and cancels the input
 // reader. You can return control to the Program with RestoreTerminal.
 func (p *Program) ReleaseTerminal() error {
+	return p.releaseTerminal(false)
+}
+
+func (p *Program) releaseTerminal(reset bool) error {
 	atomic.StoreUint32(&p.ignoreSignals, 1)
 	if p.inputReader != nil {
 		p.inputReader.Cancel()
@@ -1059,6 +1063,9 @@ func (p *Program) ReleaseTerminal() error {
 
 	if p.renderer != nil {
 		p.stopRenderer(false)
+		if reset {
+			p.renderer.reset()
+		}
 	}
 
 	return p.restoreTerminalState()
@@ -1167,9 +1174,6 @@ func (p *Program) startRenderer() {
 	p.once = sync.Once{}
 
 	// Start the renderer.
-	if p.renderer != nil {
-		p.renderer.reset()
-	}
 	go func() {
 		for {
 			select {

--- a/tty.go
+++ b/tty.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (p *Program) suspend() {
-	if err := p.ReleaseTerminal(); err != nil {
+	if err := p.releaseTerminal(true); err != nil {
 		// If we can't release input, abort.
 		return
 	}


### PR DESCRIPTION
The cursed renderer moves the cursor between renders, which can cause issues when the terminal is released and restored. For instance, when we exec a command using tea.Exec, we want the cursor position to remain the same after the command finishes and goes back to the same position as before the command was executed.

With tea.Suspend on the other hand, we want to make sure we reset the cursor position because the program stops executing and is put to suspend. Resuming the program again initializes the renderer and its cursor position again from scratch as if it was a new program.

This wasn't an issue for the standard renderer because we always put the cursor at the lower left corner of the screen. Releasing and restoring the program wasn't an issue because the cursor was always at the same position.