### PR TITLE
fix: renderer: use newline instead of cud1 to move cursor down

### DIFF
--- a/examples/simple/testdata/TestApp.golden
+++ b/examples/simple/testdata/TestApp.golden
@@ -2,4 +2,6 @@
 [K
 To quit sooner press ctrl-c, or press ctrl-z to suspend...[K
 [K[70D[3AHi. This program will exit in 9 seconds.[K
-[B[B[70D[2K[?2004l[?25h[?1002l[?1003l[?1006l
+
+
+[70D[2K[?2004l[?25h[?1002l[?1003l[?1006l

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -217,7 +217,7 @@ func (r *standardRenderer) flush() {
 		if _, ignore := r.ignoreLines[i]; ignore || canSkip {
 			// Unless this is the last line, move the cursor down.
 			if i < len(newLines)-1 {
-				buf.WriteString(ansi.CUD1)
+				buf.WriteByte('\n')
 			}
 			continue
 		}


### PR DESCRIPTION
Using cud1 (`\x1b[B`) won't scroll the terminal if the cursor is already at the bottom of the screen. Instead, use a newline character to move the cursor down and scroll the terminal if necessary.

Fixes: https://github.com/charmbracelet/bubbletea/issues/1322