### PR TITLE
feat: separate view in its own interface

### DIFF
--- a/cursor.go
+++ b/cursor.go
@@ -1,9 +1,7 @@
 package tea
 
-import "image"
-
 // Position represents a position in the terminal.
-type Position image.Point
+type Position struct{ X, Y int }
 
 // CursorPositionMsg is a message that represents the terminal cursor position.
 type CursorPositionMsg Position

--- a/examples/tui-daemon-combo/main.go
+++ b/examples/tui-daemon-combo/main.go
@@ -24,7 +24,6 @@ func main() {
 	var (
 		daemonMode bool
 		showHelp   bool
-		opts       []tea.ProgramOption
 	)
 
 	flag.BoolVar(&daemonMode, "d", false, "run as a daemon")
@@ -36,15 +35,18 @@ func main() {
 		os.Exit(0)
 	}
 
+	var model tea.Model
+	m := newModel()
 	if daemonMode || !isatty.IsTerminal(os.Stdout.Fd()) {
+		model = m
 		// If we're in daemon mode don't render the TUI
-		opts = []tea.ProgramOption{tea.WithoutRenderer()}
 	} else {
+		model = modelView{m}
 		// If we're in TUI mode, discard log output
 		log.SetOutput(io.Discard)
 	}
 
-	p := tea.NewProgram(newModel(), opts...)
+	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {
 		fmt.Println("Error starting Bubble Tea program:", err)
 		os.Exit(1)
@@ -102,7 +104,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 }
 
-func (m model) View() string {
+type modelView struct {
+	model
+}
+
+func (m modelView) View() string {
 	s := "\n" +
 		m.spinner.View() + " Doing some work...\n\n"
 

--- a/options.go
+++ b/options.go
@@ -168,20 +168,6 @@ func WithMouseAllMotion() ProgramOption {
 	}
 }
 
-// WithoutRenderer disables the renderer. When this is set output and log
-// statements will be plainly sent to stdout (or another output if one is set)
-// without any rendering and redrawing logic. In other words, printing and
-// logging will behave the same way it would in a non-TUI commandline tool.
-// This can be useful if you want to use the Bubble Tea framework for a non-TUI
-// application, or to provide an additional non-TUI mode to your Bubble Tea
-// programs. For example, your program could behave like a daemon if output is
-// not a TTY.
-func WithoutRenderer() ProgramOption {
-	return func(p *Program) {
-		p.renderer = &nilRenderer{}
-	}
-}
-
 // WithFilter supplies an event filter that will be invoked before Bubble Tea
 // processes a tea.Msg. The event filter can return any tea.Msg which will then
 // get handled by Bubble Tea instead of the original event. If the event filter

--- a/options_test.go
+++ b/options_test.go
@@ -27,16 +27,6 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("renderer", func(t *testing.T) {
-		p := NewProgram(nil, WithoutRenderer())
-		switch p.renderer.(type) {
-		case *nilRenderer:
-			return
-		default:
-			t.Errorf("expected renderer to be a nilRenderer, got %v", p.renderer)
-		}
-	})
-
 	t.Run("without signals", func(t *testing.T) {
 		p := NewProgram(nil, WithoutSignals())
 		if atomic.LoadUint32(&p.ignoreSignals) == 0 {

--- a/tty.go
+++ b/tty.go
@@ -26,7 +26,7 @@ func (p *Program) suspend() {
 }
 
 func (p *Program) initTerminal() error {
-	if _, ok := p.renderer.(*nilRenderer); ok {
+	if !hasView(p.initialModel) {
 		// No need to initialize the terminal if we're not rendering
 		return nil
 	}


### PR DESCRIPTION
This change separates the viw from the main model by introducing new interfaces `ViewModel` and `CursorModel`. The `ViewModel` interface provides a view method that returns the string to render, while the `CursorModel` interface provides a view method that returns the string to render and the cursor position.

If a program does not implement a view interface, the program won't render anything. This removes the need for the `WithoutRenderer` option.