### PR TITLE
feat(ci): move from goveralls to codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,9 +20,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go test -race -covermode atomic -coverprofile=profile.cov ./...
-          go install github.com/mattn/goveralls@latest
-          goveralls -coverprofile=profile.cov -service=github
+          go test -race -covermode=atomic -coverprofile=coverage.txt ./...
+
+      - uses: codecov/codecov-action@v5
+        with:
+          file: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This commit moves the coverage reporting from goveralls to codecov and fixes broken coverage CI.