### PR TITLE
Ensure nils are removed from sequences

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -81,6 +81,31 @@ func TestSequentially(t *testing.T) {
 	}
 }
 
+func TestSequence(t *testing.T) {
+	t.Run("nil cmd", func(t *testing.T) {
+		if b := Sequence(nil); b != nil {
+			t.Fatalf("expected nil, got %+v", b)
+		}
+	})
+	t.Run("empty cmd", func(t *testing.T) {
+		if b := Sequence(); b != nil {
+			t.Fatalf("expected nil, got %+v", b)
+		}
+	})
+	t.Run("single cmd", func(t *testing.T) {
+		b := Sequence(Quit)()
+		if _, ok := b.(QuitMsg); !ok {
+			t.Fatalf("expected a QuitMsg, got %T", b)
+		}
+	})
+	t.Run("mixed nil cmds", func(t *testing.T) {
+		b := Sequence(nil, Quit, nil, Quit, nil, nil)()
+		if l := len(b.(sequenceMsg)); l != 2 {
+			t.Fatalf("expected a []Cmd with len 2, got %d", l)
+		}
+	})
+}
+
 func TestBatch(t *testing.T) {
 	t.Run("nil cmd", func(t *testing.T) {
 		if b := Batch(nil); b != nil {


### PR DESCRIPTION
When a sequence is used, nils trigger a go routine in `tea.go` here:
```
case sequenceMsg:
  go func() {
    // Execute commands one at a time, in order.
    for _, cmd := range msg {
      if cmd == nil {
        continue
      }
      //...
    }
  }()
```
Even though the go routine is short-lived, this can cause a significant performance hit to the runtime. The Batch mechanism eliminates nils before they are processed. This change replicates that behaviour in `sequenceMsg`.