### PR TITLE
Fix: Windows: first character input lost on successive programs

### DIFF
--- a/inputreader_windows.go
+++ b/inputreader_windows.go
@@ -67,6 +67,8 @@ func newInputReader(r io.Reader, enableMouse bool) (cancelreader.CancelReader, e
 func (r *conInputReader) Cancel() bool {
 	r.setCanceled()
 
+	// Warning: These cancel methods do not reliably work on console input
+	// 			and should not be counted on.
 	return windows.CancelIoEx(r.conin, nil) == nil || windows.CancelIo(r.conin) == nil
 }
 

--- a/key_windows.go
+++ b/key_windows.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/erikgeiser/coninput"
 	localereader "github.com/mattn/go-localereader"
@@ -25,14 +26,10 @@ func readConInputs(ctx context.Context, msgsch chan<- Msg, con *conInputReader) 
 	var ps coninput.ButtonState                 // keep track of previous mouse state
 	var ws coninput.WindowBufferSizeEventRecord // keep track of the last window size event
 	for {
-		events, err := coninput.ReadNConsoleInputs(con.conin, 16)
+		events, err := peekAndReadConsInput(con)
 		if err != nil {
-			if con.isCanceled() {
-				return cancelreader.ErrCanceled
-			}
-			return fmt.Errorf("read coninput events: %w", err)
+			return err
 		}
-
 		for _, event := range events {
 			var msgs []Msg
 			switch e := event.Unwrap().(type) {
@@ -91,6 +88,42 @@ func readConInputs(ctx context.Context, msgsch chan<- Msg, con *conInputReader) 
 				}
 			}
 		}
+	}
+}
+
+// Peek for new input in a tight loop and then read the input.
+// windows.CancelIo* does not work reliably so peek first and only use the data if
+// the console input is not cancelled.
+func peekAndReadConsInput(con *conInputReader) ([]coninput.InputRecord, error) {
+	events, err := peekConsInput(con)
+	if err != nil {
+		return events, err
+	}
+	events, err = coninput.ReadNConsoleInputs(con.conin, uint32(len(events)))
+	if con.isCanceled() {
+		return events, cancelreader.ErrCanceled
+	}
+	if err != nil {
+		return events, fmt.Errorf("read coninput events: %w", err)
+	}
+	return events, nil
+}
+
+// Keeps peeking until there is data or the input is cancelled.
+func peekConsInput(con *conInputReader) ([]coninput.InputRecord, error) {
+	for {
+		events, err := coninput.PeekNConsoleInputs(con.conin, 16)
+		if con.isCanceled() {
+			return events, cancelreader.ErrCanceled
+		}
+		if err != nil {
+			return events, fmt.Errorf("peek coninput events: %w", err)
+		}
+		if len(events) > 0 {
+			return events, nil
+		}
+		// Sleep for a bit to avoid busy waiting.
+		time.Sleep(16 * time.Millisecond)
 	}
 }
 

--- a/key_windows.go
+++ b/key_windows.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/erikgeiser/coninput"
@@ -99,7 +100,12 @@ func peekAndReadConsInput(con *conInputReader) ([]coninput.InputRecord, error) {
 	if err != nil {
 		return events, err
 	}
-	events, err = coninput.ReadNConsoleInputs(con.conin, uint32(len(events)))
+	numEvents := len(events)
+	// Check to satisfy lint G115.
+	if numEvents < 0 || numEvents > math.MaxUint32 {
+		panic("cannot convert numEvents " + fmt.Sprint(numEvents) + " to uint32")
+	}
+	events, err = coninput.ReadNConsoleInputs(con.conin, uint32(numEvents))
 	if con.isCanceled() {
 		return events, cancelreader.ErrCanceled
 	}


### PR DESCRIPTION
Explanation here: https://github.com/charmbracelet/bubbletea/issues/1167#issuecomment-2728251993

Note: I don't think it is possible to unit test this in a meaningful way because to reproduce the issue requires using console input, but please correct me if I'm wrong.

<!-- 

#### Testing

<img src="XXXCOPYURLXXX" alt="" width="300"/> 

<video src="XXXCOPYURLXXX" alt="" width="300"/>

| Before | After |
| ------------- | ------------- |
| <img src="XXXCOPYURLXXX" alt="" width="300"/> | <img src="XXXCOPYURLXXX" alt="" width="300"/> |


| Before | After |
| ------------- | ------------- |
| <video src="XXXCOPYURLXXX" alt="" width="300"/> | <video src="XXXCOPYURLXXX" alt="" width="300"/> |

<details>
  <summary>Detailed Section (click me)</summary>
  
</details>

-->

#### Issue: https://github.com/charmbracelet/bubbletea/issues/1167
