### PR TITLE
(v1-2/3) tea.go: teardown-related deadlock & race condition fixes

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -708,11 +708,11 @@ func (p *Program) Quit() {
 	p.Send(Quit())
 }
 
-// Kill stops the program immediately and restores the former terminal state.
+// Kill signals the program to stop immediately and restore the former terminal state.
 // The final render that you would normally see when quitting will be skipped.
 // [program.Run] returns a [ErrProgramKilled] error.
 func (p *Program) Kill() {
-	p.shutdown(true)
+	p.cancel()
 }
 
 // Wait waits/blocks until the underlying Program finished shutting down.
@@ -721,7 +721,11 @@ func (p *Program) Wait() {
 }
 
 // shutdown performs operations to free up resources and restore the terminal
-// to its original state.
+// to its original state. It is called once at the end of the program's lifetime.
+//
+// This method should not be called to signal the program to be killed/shutdown.
+// Doing so can lead to race conditions with the eventual call at the program's end.
+// As alternatives, the [Quit] or [Kill] convenience methods should be used instead.
 func (p *Program) shutdown(kill bool) {
 	p.cancel()
 

--- a/tea.go
+++ b/tea.go
@@ -519,7 +519,11 @@ func (p *Program) Run() (Model, error) {
 	p.handlers = channelHandlers{}
 	cmds := make(chan Cmd)
 	p.errs = make(chan error)
-	p.finished = make(chan struct{}, 1)
+
+	p.finished = make(chan struct{})
+	defer func() {
+		close(p.finished)
+	}()
 
 	defer p.cancel()
 
@@ -744,9 +748,6 @@ func (p *Program) shutdown(kill bool) {
 	}
 
 	_ = p.restoreTerminalState()
-	if !kill {
-		p.finished <- struct{}{}
-	}
 }
 
 // recoverFromPanic recovers from a panic, prints the stack trace, and restores

--- a/tea_test.go
+++ b/tea_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -113,8 +114,17 @@ func TestTeaWaitQuit(t *testing.T) {
 	}()
 
 	<-progStarted
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			p.Wait()
+			wg.Done()
+		}()
+	}
 	close(waitStarted)
-	p.Wait()
+	wg.Wait()
 
 	err := <-errChan
 	if err != nil {
@@ -154,8 +164,17 @@ func TestTeaWaitKill(t *testing.T) {
 	}()
 
 	<-progStarted
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			p.Wait()
+			wg.Done()
+		}()
+	}
 	close(waitStarted)
-	p.Wait()
+	wg.Wait()
 
 	err := <-errChan
 	if !errors.Is(err, ErrProgramKilled) {

--- a/tea_test.go
+++ b/tea_test.go
@@ -81,6 +81,88 @@ func TestTeaQuit(t *testing.T) {
 	}
 }
 
+func TestTeaWaitQuit(t *testing.T) {
+	var buf bytes.Buffer
+	var in bytes.Buffer
+
+	progStarted := make(chan struct{})
+	waitStarted := make(chan struct{})
+	errChan := make(chan error, 1)
+
+	m := &testModel{}
+	p := NewProgram(m, WithInput(&in), WithOutput(&buf))
+
+	go func() {
+		_, err := p.Run()
+		errChan <- err
+	}()
+
+	go func() {
+		for {
+			time.Sleep(time.Millisecond)
+			if m.executed.Load() != nil {
+				close(progStarted)
+
+				<-waitStarted
+				time.Sleep(50 * time.Millisecond)
+				p.Quit()
+
+				return
+			}
+		}
+	}()
+
+	<-progStarted
+	close(waitStarted)
+	p.Wait()
+
+	err := <-errChan
+	if err != nil {
+		t.Fatalf("Expected nil, got %v", err)
+	}
+}
+
+func TestTeaWaitKill(t *testing.T) {
+	var buf bytes.Buffer
+	var in bytes.Buffer
+
+	progStarted := make(chan struct{})
+	waitStarted := make(chan struct{})
+	errChan := make(chan error, 1)
+
+	m := &testModel{}
+	p := NewProgram(m, WithInput(&in), WithOutput(&buf))
+
+	go func() {
+		_, err := p.Run()
+		errChan <- err
+	}()
+
+	go func() {
+		for {
+			time.Sleep(time.Millisecond)
+			if m.executed.Load() != nil {
+				close(progStarted)
+
+				<-waitStarted
+				time.Sleep(50 * time.Millisecond)
+				p.Kill()
+
+				return
+			}
+		}
+	}()
+
+	<-progStarted
+	close(waitStarted)
+	p.Wait()
+
+	err := <-errChan
+	if !errors.Is(err, ErrProgramKilled) {
+		t.Fatalf("Expected %v, got %v", ErrProgramKilled, err)
+	}
+}
+
 func TestTeaWithFilter(t *testing.T) {
 	testTeaWithFilter(t, 0)
 	testTeaWithFilter(t, 1)


### PR DESCRIPTION
## Overview

**The PR addresses and resolves three possible deadlocks and a multitude of race conditions:**

- `p.Wait()` deadlocking (externally) after the program aborts/is killed.
_The proposed change also factors in program abort/kill and reports such completions too._

- multiple `p.Wait()` deadlocking (externally) as the `p.finished` channel was not closed.
_The proposed change closes the respective channel before program exit, releasing such waiting functions._

- `p.shutdown()` deadlocking (internally) on multiple executions due to `p.finished` buffer constraints
_The proposed change does not send into the completion channel, but rather closes it, to signal all waiting functions._

- `p.Kill()` race conditions and points of failure calling `p.shutdown()` again, despite it being called at program end.
_The proposed change cancels the program's context instead, untying `p.Kill()` from program state and allowing the natural program teardown eventually resulting in `p.shutdown()` as needed. `p.Kill()` is now idempotent, safe and versatile._

## Specifics of occasional test failures regarding `p.shutdown()` and `p.Wait()`:

The failed test helped uncover multiple deadlock situations that the initial code (if clause) was probably put in place to treat symptomatically (causing deadlocks on its own in the process, albeit external ones). `p.shutdown()` may get called multiple times throughout the code, in the (_sometimes failing, sometimes not - depending on the race condition's timing_) test's case once by our explicit `p.Kill()` call and then upon exit of the `p.eventLoop()` another time. This resulted in sending to the `p.finished` channel twice despite it only having a buffer of one. 

To mitigate this problem, the logic of reporting completion through that channel was moved closer to the actual end of the program using a logically placed `defer` call right after the channel's establishment (for logic and readability).

The code was also refactored to closing the `p.finished` channel on teardown, instead of sending into it, to allow unblocking of multiple blocked `p.Wait()` calls instead of just one and having the rest deadlock (just one value being drained).

## Specifics of occasional (older and new) test failures regarding `p.Kill()`:

First off, we're lucky this happened exactly here - because it doesn't always:
```
Running all tests for 1000 times without result caching...
=========================
Test Summary
Successes: 830
Failures:  170
=========================
```

**You may have seen this in other commits and considered it an occasional blip of the CI:**
https://github.com/charmbracelet/bubbletea/actions/runs/13250713846/job/36987719494
https://github.com/charmbracelet/bubbletea/actions/runs/13796125964/job/38588086635
https://github.com/charmbracelet/bubbletea/actions/runs/13268485968/job/37041941350

But, at present there's a myriad of race conditions (seen in these test failures) and possible pitfalls associated with calling `p.Kill()` either too soon or too late. This is with the program not having fully initialised yet or another shutdown already being in progress from inside the program. It all stems from directly calling `p.shutdown(true)` inside of `p.Kill()`:

https://github.com/charmbracelet/bubbletea/blob/6a1ebaa0ea00f482b7e1b9d3c47c3eb978e70fe9/tea.go#L710-L712

This call makes no sense, because at the end of the natural program flow (either natural or accelerated by a quit/kill) it always gets called anyway - shutdown function then runs doubly, waits doubly, attempts to restore the terminal doubly, you get the idea.

https://github.com/charmbracelet/bubbletea/blob/6a1ebaa0ea00f482b7e1b9d3c47c3eb978e70fe9/tea.go#L658

Ideally a user should never need to care about when it is safe to call `p.Kill()`, it should just ensure the program is aware it needs to tear down fast and do that. Since the program is already (internal) context aware, it is safer to just cancel that context inside `p.Kill()` and let the program tear down itself - always eventually ending in the needed `p.shutdown()` at the end of `p.Run()`.

```
func (p *Program) Kill() {
	p.cancel()
}
```

**This change makes the `p.Kill()` function versatile, idempotent and not tied to the program's state.**
Plus, it also eliminates all race conditions, double executions and related points of failure - which I think is sweet. 😎 

## Testing the proposed changes
```
Running all tests for 1000 times without result caching...
=========================
Test Summary
Successes: 1000
Failures:  0
=========================
```