### PR TITLE
(v1-3/3) tea.go: fix panic handling race condition + wrongful nil returns despite errors (ctx, panic, ...)

### DIFF
--- a/options.go
+++ b/options.go
@@ -19,7 +19,7 @@ type ProgramOption func(*Program)
 // cancelled it will exit with an error ErrProgramKilled.
 func WithContext(ctx context.Context) ProgramOption {
 	return func(p *Program) {
-		p.ctx = ctx
+		p.externalCtx = ctx
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -2,6 +2,7 @@ package tea
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -48,6 +49,16 @@ func TestOptions(t *testing.T) {
 		p := NewProgram(nil, WithFilter(func(_ Model, msg Msg) Msg { return msg }))
 		if p.filter == nil {
 			t.Errorf("expected filter to be set")
+		}
+	})
+
+	t.Run("external context", func(t *testing.T) {
+		extCtx, extCancel := context.WithCancel(context.Background())
+		defer extCancel()
+
+		p := NewProgram(nil, WithContext(extCtx))
+		if p.externalCtx != extCtx || p.externalCtx == context.Background() {
+			t.Errorf("expected passed in external context, got default (nil)")
 		}
 	})
 

--- a/tea.go
+++ b/tea.go
@@ -790,7 +790,7 @@ func (p *Program) recoverFromPanic(r interface{}) {
 	case p.errs <- ErrProgramPanic:
 	default:
 	}
-	p.shutdown(true)
+	p.shutdown(true) // Ok to call here, p.Run() cannot do it anymore.
 	fmt.Printf("Caught panic:\n\n%s\n\nRestoring terminal...\n\n", r)
 	debug.PrintStack()
 }

--- a/tea_test.go
+++ b/tea_test.go
@@ -143,8 +143,16 @@ func TestTeaKill(t *testing.T) {
 		}
 	}()
 
-	if _, err := p.Run(); !errors.Is(err, ErrProgramKilled) {
+	_, err := p.Run()
+
+	if !errors.Is(err, ErrProgramKilled) {
 		t.Fatalf("Expected %v, got %v", ErrProgramKilled, err)
+	}
+
+	if errors.Is(err, context.Canceled) {
+		// The end user should not know about the program's internal context state.
+		// The program should only report external context cancellation as a context error.
+		t.Fatalf("Internal context cancellation was reported as context error!")
 	}
 }
 
@@ -165,8 +173,15 @@ func TestTeaContext(t *testing.T) {
 		}
 	}()
 
-	if _, err := p.Run(); !errors.Is(err, ErrProgramKilled) {
+	_, err := p.Run()
+
+	if !errors.Is(err, ErrProgramKilled) {
 		t.Fatalf("Expected %v, got %v", ErrProgramKilled, err)
+	}
+
+	if !errors.Is(err, context.Canceled) {
+		// The end user should know that their passed in context caused the kill.
+		t.Fatalf("Expected %v, got %v", context.Canceled, err)
 	}
 }
 


### PR DESCRIPTION
This is the last patch of my earlier investigations, thanks for bearing with me. 😎 

Note the CI pipeline will fail the PR's proposed changes on the current codebase (as of 28.03).
This is not because of the code itself, but the deadlock issues in the previous PRs not yet merged (see below).

## Issues

- **Panic recovery in goroutines ("Cmd"s) also caused the race conditions uncovered earlier.**
_**related to**:_ #1373 
This also stems from multiple calls to `p.shutdown()` despite it still being called at the end of `p.Run()`.
This was fixed by using a separate method for Goroutine panics, calling `p.cancel()` for natural teardown.

- **Recovered panics in the main thread would have `p.Run()` return `nil`, despite the program being killed.**
This was caused by `p.Run()` never reaching the point where it could return an error, when panicking.
This was fixed to return both `ErrProgramKilled` and `ErrProgramPanic` (newly introduced) as a wrapped error.

- **`p.Run()` would only return an error but not `ErrProgramKilled` on failure, despite the program being killed.**
This was fixed to return both `ErrProgramKilled` and the error as a wrapped error for better general check-ability.

- **A crashing `p.eventLoop()` may have returned `nil`, if it crashed before receiving from the error channel.**
This was fixed by giving the error channel a buffer of 1 and draining for scraps that error channel in `p.Run()`.

- **A cancelled context would not be returned as a context error, but merely as part of the error message.**
_**fixes**:_ #1212, 
builds on, enhances and _**closes**_ (as obsolete): #1306
This was fixed by returning `ErrProgramKilled` and `externalCtx.Err()` as a wrapped error (**see below**).

- **A cancelled internal context should not be returned back to the user as a context error.**
The user is not aware of the program's internal context, does not need to know about such internals.
It would be confusing to return a context error when the user has not explicitly provided such a context.
This was fixed separating `externalCtx` and `ctx`, with `ctx` being built from `externalCtx` or `context.Background()`.
A cancellation of the `externalCtx` would be reported as described above, the internal `ctx` only as `ErrProgramKilled`.

## Testing

- **Previously not existing test cases for panic handling were introduced.**
- **Existing `p.Kill()`- and context-related test cases were expanded to cover above nuances and changes.**

## Merge & CI
The CI pipeline will fail the PR's proposed changes on the current codebase (as of 28.03).
This is not because of the code, but the deadlock issues in the previous PRs not yet merged.

While the code in this PR is not dependent on them, the test cases suffer under these issues.
- #1372 
- #1373

**Testing the combined changes of all three PRs resulted in:**
- https://github.com/charmbracelet/bubbletea/pull/1376
```
Running all tests for 1000 times without result caching...
=========================
Test Summary
Successes: 1000
Failures:  0
=========================
```




