### PR TITLE
docs(v2): update v2 table bubble example

### DIFF
--- a/examples/_1248/main.go
+++ b/examples/_1248/main.go
@@ -6,26 +6,16 @@ import (
 	"github.com/charmbracelet/lipgloss/v2"
 )
 
-var baseStyle = lipgloss.NewStyle().
-	BorderStyle(lipgloss.NormalBorder()).
-	BorderForeground(lipgloss.Color("240"))
-
 func NewTable() table.Model {
-	rows := []table.Row{
+	rows := [][]string{
 		{"1", "issue", "v1.2.3", "24/11/22", "EnterAltScreen"},
 	}
-	columns := []table.Column{
-		{Title: "ID", Width: 4},
-		{Title: "NAME", Width: 28},
-		{Title: "VERSION", Width: 18},
-		{Title: "DATE", Width: 15},
-		{Title: "REMARK", Width: 4},
-	}
+	headers := []string{"ID", "NAME", "VERSION", "DATE", "REMARK"}
 	t := table.New(
-		table.WithColumns(columns),
-		table.WithRows(rows),
+		table.WithHeaders(headers...),
+		table.WithRows(rows...),
 		table.WithFocused(true),
-		table.WithHeight(7),
+		table.WithHeight(10),
 	)
 	s := table.DefaultStyles()
 	s.Header = s.Header.
@@ -33,12 +23,8 @@ func NewTable() table.Model {
 		BorderForeground(lipgloss.Color("240")).
 		BorderBottom(true).
 		Bold(false)
-	s.Selected = s.Selected.
-		Foreground(lipgloss.Color("229")).
-		Background(lipgloss.Color("57")).
-		Bold(false)
 	t.SetStyles(s)
-	return t
+	return *t
 }
 
 type Model struct {
@@ -79,7 +65,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) View() string {
-	return baseStyle.Render(m.currentModel.View()) + "\n" + m.currentModel.HelpView() + "\n"
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.currentModel.View(),
+		m.currentModel.HelpView(),
+	)
 }
 
 func NewModel() (model Model, err error) {

--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -43,18 +43,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
-	return baseStyle.Render(m.table.View()) + "\n  " + m.table.HelpView() + "\n"
+	return lipgloss.JoinVertical(
+		lipgloss.Left,
+		m.table.View(),
+		m.table.HelpView(),
+	)
 }
 
 func main() {
-	columns := []table.Column{
-		{Title: "Rank", Width: 4},
-		{Title: "City", Width: 10},
-		{Title: "Country", Width: 10},
-		{Title: "Population", Width: 10},
-	}
+	headers := []string{"Rank", "City", "Country", "Population"}
 
-	rows := []table.Row{
+	rows := [][]string{
 		{"1", "Tokyo", "Japan", "37,274,000"},
 		{"2", "Delhi", "India", "32,065,760"},
 		{"3", "Shanghai", "China", "28,516,904"},
@@ -158,11 +157,18 @@ func main() {
 	}
 
 	t := table.New(
-		table.WithColumns(columns),
-		table.WithRows(rows),
+		table.WithHeaders(headers...),
+		table.WithRows(rows...),
 		table.WithFocused(true),
-		table.WithHeight(7),
+		table.WithHeight(20),
 	)
+
+	// This is another way to initialize the same table.
+	//	t := table.New().
+	//		SetHeaders(headers...).
+	//		SetRows(rows...).
+	//		SetFocused(true).
+	//		SetHeight(20)
 
 	s := table.DefaultStyles()
 	s.Header = s.Header.
@@ -170,13 +176,10 @@ func main() {
 		BorderForeground(lipgloss.Color("240")).
 		BorderBottom(true).
 		Bold(false)
-	s.Selected = s.Selected.
-		Foreground(lipgloss.Color("229")).
-		Background(lipgloss.Color("57")).
-		Bold(false)
+
 	t.SetStyles(s)
 
-	m := model{t}
+	m := model{*t}
 	if _, err := tea.NewProgram(m).Run(); err != nil {
 		fmt.Println("Error running program:", err)
 		os.Exit(1)

--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -176,6 +176,10 @@ func main() {
 		BorderForeground(lipgloss.Color("240")).
 		BorderBottom(true).
 		Bold(false)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("229")).
+		Background(lipgloss.Color("57")).
+		Bold(false)
 
 	t.SetStyles(s)
 


### PR DESCRIPTION
related:
https://github.com/charmbracelet/bubbles/pull/772
https://github.com/charmbracelet/lipgloss/pull/512

This includes a runnable example of the updated table bubble. You will need to replace the `bubbles` and `lipgloss` modules with the branches from the PRs listed above.

![image](https://github.com/user-attachments/assets/ac40cd8f-6eea-4b52-8ca8-605692e43797)
