### PR TITLE
(v2) tea.go: deadlock/error return fixes, additional tests (targeted at v2)

### DIFF
--- a/options.go
+++ b/options.go
@@ -21,7 +21,7 @@ type ProgramOption func(*Program)
 // cancelled it will exit with an error ErrProgramKilled.
 func WithContext(ctx context.Context) ProgramOption {
 	return func(p *Program) {
-		p.ctx = ctx
+		p.externalCtx = ctx
 	}
 }
 

--- a/options_test.go
+++ b/options_test.go
@@ -2,6 +2,7 @@ package tea
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -38,6 +39,16 @@ func TestOptions(t *testing.T) {
 		p := NewProgram(nil, WithFilter(func(_ Model, msg Msg) Msg { return msg }))
 		if p.filter == nil {
 			t.Errorf("expected filter to be set")
+		}
+	})
+
+	t.Run("external context", func(t *testing.T) {
+		extCtx, extCancel := context.WithCancel(context.Background())
+		defer extCancel()
+
+		p := NewProgram(nil, WithContext(extCtx))
+		if p.externalCtx != extCtx || p.externalCtx == context.Background() {
+			t.Errorf("expected passed in external context, got default")
 		}
 	})
 


### PR DESCRIPTION
This PR contains the v2-targeted and v2-applicable portions of the following v1-targeted fixes:
- #1376 
- #1372 
- #1373 
- #1375

Meaning it fixes all above issues in v2, the bugs that are not already resolved otherwise in v2.
Issues are related to deadlocks and wrongful nil returns on error, PR adds a couple of tests as well.