### PR TITLE
V2 viewable

### DIFF
--- a/examples/textinput/main.go
+++ b/examples/textinput/main.go
@@ -70,7 +70,9 @@ func (m model) View() tea.View {
 		str += "\n"
 	}
 
-	return tea.NewView(str).Cursor(c)
+	v := tea.NewView(str)
+	v.SetCursor(c)
+	return v
 }
 
 func (m model) headerView() string { return "What’s your favorite Pokémon?\n" }

--- a/examples/textinput/main.go
+++ b/examples/textinput/main.go
@@ -59,19 +59,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
-func (m model) View() (string, *tea.Cursor) {
+func (m model) View() tea.View {
 	var c *tea.Cursor
 	if !m.textInput.VirtualCursor() {
 		c = m.textInput.Cursor()
 		c.Y += lipgloss.Height(m.headerView())
 	}
-
 	str := lipgloss.JoinVertical(lipgloss.Top, m.headerView(), m.textInput.View(), m.footerView())
 	if m.quitting {
 		str += "\n"
 	}
 
-	return str, c
+	return tea.NewView(str).Cursor(c)
 }
 
 func (m model) headerView() string { return "What’s your favorite Pokémon?\n" }

--- a/tea.go
+++ b/tea.go
@@ -118,22 +118,35 @@ func NewView(body string) View {
 	return View{body: body}
 }
 
-// Cursor renders a cursor. If nil, the cursor will be hidden. Use [NewCursor]
-// to create a cursor for a given position with default styles.
-func (v View) Cursor(c *Cursor) View {
-	v.cursor = c
-	return v
+// String returns the main body of the view, without additional metadata like
+// the cursor.
+func (v View) String() string {
+	return v.body
 }
 
-// BackgroundColor sets the background color of the terminal window. If nil,
+// SetCursor renders a cursor. If nil, the cursor will be hidden. Use [NewCursor]
+// to create a cursor for a given position with default styles.
+func (v *View) SetCursor(c *Cursor) {
+	v.cursor = c
+}
+
+// Cursor returns the cursor of the view. If the view does not have a
+// cursor, it returns nil.
+func (v View) Cursor() *Cursor {
+	return v.cursor
+}
+
+// SetBackgroundColor sets the background color of the terminal window. If nil,
 // the background color will be removed.
-func (v View) BackgroundColor(c color.Color) View {
+func (v *View) SetBackgroundColor(c color.Color) {
+	// We record whether the background color was set or not rather than
+	// accepting a pointer value for better Lip Gloss compatibility, since Lip
+	// Gloss does not use pointers for colors in lipgloss.Color().
 	v.bgColorSet = true
 	v.bgColor = &c
-	return v
 }
 
-func (v View) getBackgroundColor() *color.Color {
+func (v View) BackgroundColor() *color.Color {
 	if v.bgColorSet {
 		return v.bgColor
 	}

--- a/tea.go
+++ b/tea.go
@@ -146,6 +146,8 @@ func (v *View) SetBackgroundColor(c color.Color) {
 	v.bgColor = &c
 }
 
+// BackgroundColor returns the background color of the view. If the view does
+// not have a background color, it returns nil.
 func (v View) BackgroundColor() *color.Color {
 	if v.bgColorSet {
 		return v.bgColor

--- a/tea.go
+++ b/tea.go
@@ -106,10 +106,9 @@ type CursorModel interface {
 
 // View represents a view in a program.
 type View struct {
-	body       string
-	cursor     *Cursor
-	bgColor    *color.Color
-	bgColorSet bool
+	body    string
+	cursor  *Cursor
+	bgColor color.Color
 }
 
 // NewView is a helper function to create a new view. It takes a string,
@@ -139,20 +138,13 @@ func (v View) Cursor() *Cursor {
 // SetBackgroundColor sets the background color of the terminal window. If nil,
 // the background color will be removed.
 func (v *View) SetBackgroundColor(c color.Color) {
-	// We record whether the background color was set or not rather than
-	// accepting a pointer value for better Lip Gloss compatibility, since Lip
-	// Gloss does not use pointers for colors in lipgloss.Color().
-	v.bgColorSet = true
-	v.bgColor = &c
+	v.bgColor = c
 }
 
 // BackgroundColor returns the background color of the view. If the view does
 // not have a background color, it returns nil.
-func (v View) BackgroundColor() *color.Color {
-	if v.bgColorSet {
-		return v.bgColor
-	}
-	return nil
+func (v View) BackgroundColor() color.Color {
+	return v.bgColor
 }
 
 // Viewable is an optional interface that can be implemented by the main model
@@ -847,11 +839,13 @@ func (p *Program) render(model Model) {
 
 		// Set or clear the background color.
 		c := model.View().bgColor
-		if c != nil {
-			p.execute(ansi.SetBackgroundColor(*c))
-			p.setBg = *c
-		} else {
-			p.execute(ansi.ResetBackgroundColor)
+		if c != p.setBg {
+			if c != nil {
+				p.execute(ansi.SetBackgroundColor(c))
+			} else {
+				p.execute(ansi.ResetBackgroundColor)
+			}
+			p.setBg = c
 		}
 	case ViewModel:
 		view = model.View()


### PR DESCRIPTION
This replaces `CursorView` (and potentially `ViewModel`) with a simpler, more extensible API.

```go
type Viewable interface {
    View() View
}
```

In practice, it looks like:

```go
// A simple case where the view is just a string.
func (m Model) View() tea.View {
    // ...
    return tea.NewView(str)
}

// A more complex case where the view is a string with
// cursor and background color metadata.
func (m Model) View() tea.View {
    // ...
    v := tea.NewView(str)
    v.SetCursor(cur)
    v.SetBackgroundColor(c)
    return v
}
```

Properties like the cursor and background color are optional, and `View` could be extended down the road to include other metadata, like `lipgloss.Canvas`. Note that the background color _should_ be attached to the view to avoid race conditions like we saw with `tea.SetCursorPosition`.

It would be my suggestion _not_ to merge `Viewable` with `Model` in order to eventually support view alternatives like the following:

```go
func (m Model) View(b *screen.Buffer)
```