### PR TITLE
Ensure rendering before exec

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -99,7 +99,9 @@ func (c *osExecCommand) SetStderr(w io.Writer) {
 }
 
 // exec runs an ExecCommand and delivers the results to the program as a Msg.
-func (p *Program) exec(c ExecCommand, fn ExecCallback) {
+func (p *Program) exec(model Model, c ExecCommand, fn ExecCallback) {
+	p.renderer.write(model.View()) // ensure the view is rendered one last time before we run the command.
+
 	if err := p.ReleaseTerminal(); err != nil {
 		// If we can't release input, abort.
 		if fn != nil {

--- a/tea.go
+++ b/tea.go
@@ -469,7 +469,7 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 
 			case execMsg:
 				// NB: this blocks.
-				p.exec(msg.cmd, msg.fn)
+				p.exec(model, msg.cmd, msg.fn)
 
 			case BatchMsg:
 				for _, cmd := range msg {


### PR DESCRIPTION
### Describe your changes
I'm building an application that has a pretty strict requirement that the view has been rendered before diving into exec

### Checklist before requesting a review

- [x] I have read `CONTRIBUTING.md`
- [x] I have performed a self-review of my code
