### PR TITLE
chore: correct DisableBracketedPaste behavior in comment

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -131,7 +131,7 @@ func EnableBracketedPaste() Msg {
 type enableBracketedPasteMsg struct{}
 
 // DisableBracketedPaste is a special command that tells the Bubble Tea program
-// to accept bracketed paste input.
+// to stop processing bracketed paste input.
 //
 // Note that bracketed paste will be automatically disabled when the
 // program quits.


### PR DESCRIPTION
### Describe your changes

Thanks for the wonderful documentation. That was a pleasure to read on the subway. Just wanted to point out there's an error in the DisableBracketedPaste comment. I've reviewed all the PRs and confirmed there are no duplicates. Maybe?

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code