### PR TITLE
Fix BatchMsg

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -475,7 +475,7 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 					if cmd == nil {
 						continue
 					}
-					go p.Send(cmd())
+					go func() { p.Send(cmd()) }()
 				}
 				continue
 


### PR DESCRIPTION
Without this change, `cmd()` is executed before the gorouting starts. This blocks the event loop.

With the change, `cmd()` now runs on the gorouting, so it doesn't block the event loop.

Here is a simple example that illustrates it:

```go
package main

import (
	"fmt"
	"time"

	"github.com/charmbracelet/bubbles/spinner"
	tea "github.com/charmbracelet/bubbletea"
)

type model struct {
	spinner spinner.Model
	message string
	loading bool
}

func initialModel() model {
	s := spinner.New()
	s.Spinner = spinner.MiniDot
	return model{
		spinner: s,
		message: "Waiting for async operation...",
		loading: true,
	}
}

func (m model) Init() tea.Cmd {
	return tea.Batch(performAsyncOperation(), m.spinner.Tick)
}

func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
	switch msg := msg.(type) {
	case resultMsg:
		m.loading = false
		m.message = msg.data
		return m, nil
	case tea.KeyMsg:
		if msg.String() == "q" || msg.String() == "esc" {
			return m, tea.Quit
		}
	}

	var cmd tea.Cmd
	if m.loading {
		m.spinner, cmd = m.spinner.Update(msg)
	}
	return m, cmd
}

func (m model) View() string {
	var s string
	if m.loading {
		s = m.spinner.View() + " "
	}
	return s + m.message + "\nPress 'q' or 'esc' to quit."
}

// resultMsg is a custom message type for our async operation's result
type resultMsg struct {
	data string
}

// performAsyncOperation is a function that simulates an async task
func performAsyncOperation() tea.Cmd {
	return func() tea.Msg {
		time.Sleep(4 * time.Second) // Simulate a long-running task
		return resultMsg{data: "Async operation completed!"}
	}
}

func main() {
	p := tea.NewProgram(initialModel())
	if _, err := p.Run(); err != nil {
		fmt.Printf("Error running program: %v\n", err)
	}
}
```

Before the change, the spinner wouldn't move until the async operation returned.
With the change, the spinner moves as expected.

### Describe your changes

### Related issue/discussion: <insert link>

### Checklist before requesting a review

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my code

### If this is a feature

- [ ] I have created a discussion
- [ ] A project maintainer has approved this feature request. Link to comment:
