### PR TITLE
chore: remove unused min/max func

### DIFF
--- a/examples/tabs/main.go
+++ b/examples/tabs/main.go
@@ -98,17 +98,3 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
- [ ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 
