### PR TITLE
fix: protect output buffer with mutex

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -416,6 +416,8 @@ type Program struct {
 	useHardTabs bool
 	// whether to use backspace to optimize cursor movements
 	useBackspace bool
+
+	mu sync.Mutex
 }
 
 // Quit is a special command that tells the Bubble Tea program to exit.
@@ -1248,11 +1250,16 @@ func (p *Program) Wait() {
 
 // execute writes the given sequence to the program output.
 func (p *Program) execute(seq string) {
+	p.mu.Lock()
 	_, _ = p.outputBuf.WriteString(seq)
+	p.mu.Unlock()
 }
 
 // flush flushes the output buffer to the program output.
 func (p *Program) flush() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	if p.outputBuf.Len() == 0 {
 		return nil
 	}


### PR DESCRIPTION
When using multiple goroutines to send messages to a Bubble Tea program, there can be concurrent writes to the output buffer, leading race conditions. This commit adds a mutex to the Program struct to ensure that writes to the output buffer are thread-safe.
