### PR TITLE
add copyloopvar linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable:
     - bodyclose
+    - copyloopvar
     - exhaustive
     - goconst
     - godot

--- a/key_sequences.go
+++ b/key_sequences.go
@@ -14,7 +14,6 @@ import (
 var extSequences = func() map[string]Key {
 	s := map[string]Key{}
 	for seq, key := range sequences {
-		key := key
 		s[seq] = key
 		if !key.Alt {
 			key.Alt = true


### PR DESCRIPTION
this commit adds the copyloopvar linter, so places where loop variables are copied are detected
