### PR TITLE
feat: add option WithoutSkipRenderIdenticalLines, closes #1501

### DIFF
--- a/options.go
+++ b/options.go
@@ -194,6 +194,18 @@ func WithANSICompressor() ProgramOption {
 	}
 }
 
+// WithoutSkipRenderIdenticalLines disables an optimisation of the standard renderer
+// where it will skip writing a line to the screen,
+// if the same line written on the last render is identical.
+// The optimisation is usually without consequences, but can be unwanted if an ANSI coloring tag
+// is added on both sides of the unchanged line. If the line is not rewritten
+// (even though identical) it will not be colored in some terminals
+func WithoutSkipRenderIdenticalLines() ProgramOption {
+	return func(p *Program) {
+		p.startupOptions |= withoutSkipRenderIdenticalLines
+	}
+}
+
 // WithFilter supplies an event filter that will be invoked before Bubble Tea
 // processes a tea.Msg. The event filter can return any tea.Msg which will then
 // get handled by Bubble Tea instead of the original event. If the event filter

--- a/options_test.go
+++ b/options_test.go
@@ -100,6 +100,10 @@ func TestOptions(t *testing.T) {
 			exercise(t, WithANSICompressor(), withANSICompressor)
 		})
 
+		t.Run("without skip render identical lines", func(t *testing.T) {
+			exercise(t, WithoutSkipRenderIdenticalLines(), withANSICompressor)
+		})
+
 		t.Run("without catch panics", func(t *testing.T) {
 			exercise(t, WithoutCatchPanics(), withoutCatchPanics)
 		})

--- a/tea.go
+++ b/tea.go
@@ -105,6 +105,12 @@ const (
 	withoutCatchPanics
 	withoutBracketedPaste
 	withReportFocus
+	// The standard renderer is optimised to skip writing a line to the screen,
+	// if the same line written on the last render is identical.
+	// This is usually without consequences, but can be unwanted if an ANSI coloring tag
+	// is added on both sides of the unchanged line. If the line is not rewritten
+	// (even though identical) it will not be colored in some terminals
+	withoutSkipRenderIdenticalLines
 )
 
 // channelHandlers manages the series of channels returned by various processes.
@@ -642,7 +648,11 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 
 	// If no renderer is set use the standard one.
 	if p.renderer == nil {
-		p.renderer = newRenderer(p.output, p.startupOptions.has(withANSICompressor), p.fps)
+		p.renderer = newRenderer(
+			p.output,
+			p.startupOptions.has(withANSICompressor),
+			p.startupOptions.has(withoutSkipRenderIdenticalLines),
+			p.fps)
 	}
 
 	// Check if output is a TTY before entering raw mode, hiding the cursor and


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Closes https://github.com/charmbracelet/bubbletea/issues/1501

I don't think my usecase is possible to create a proper test case for (since it would need an integration test with a visual representation in iTerm2). Any way i have tested that it fixes my problem and this solution should be completely non-breaking.