### PR TITLE
fix(renderer): remove carriage returns from frames

### DIFF
--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -305,6 +305,9 @@ func (r *standardRenderer) write(s string) {
 	defer r.mtx.Unlock()
 	r.buf.Reset()
 
+	// Remove carriage returns to avoid messing up rendering.
+	s = strings.ReplaceAll(s, "\r", "")
+
 	// If an empty string was passed we should clear existing output and
 	// rendering nothing. Rather than introduce additional state to manage
 	// this, we render a single space as a simple (albeit less correct)


### PR DESCRIPTION
This change ensures that carriage return characters are stripped from the output frames before rendering. This prevents potential rendering issues that can arise from the presence of carriage returns, which may interfere with the correct display of the frame content.

Fixes: https://github.com/charmbracelet/bubbletea/issues/1520
