### PR TITLE
fix: renderer: ensure we reset cursor style and color on close

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -393,17 +393,21 @@ func (s *cursedRenderer) flush() error {
 		}
 	}
 
-	if cur := view.Cursor; cur != nil {
-		// Set cursor shape and blink if set.
-		var lcur *Cursor
-		lv := s.lastView
-		if lv != nil {
-			lcur = lv.Cursor
-		}
-		if lv == nil || lcur == nil || cur.Shape != lcur.Shape || cur.Blink != lcur.Blink {
-			curStyle := encodeCursorStyle(cur.Shape, cur.Blink)
-			_, _ = s.scr.WriteString(ansi.SetCursorStyle(curStyle))
-		}
+	// Set cursor shape and blink if set.
+	var ccStyle, lcStyle int
+	var lcur *Cursor
+	ccur := view.Cursor
+	if lv := s.lastView; lv != nil {
+		lcur = lv.Cursor
+	}
+	if ccur != nil {
+		ccStyle = encodeCursorStyle(ccur.Shape, ccur.Blink)
+	}
+	if lcur != nil {
+		lcStyle = encodeCursorStyle(lcur.Shape, lcur.Blink)
+	}
+	if ccStyle != lcStyle {
+		_, _ = s.scr.WriteString(ansi.SetCursorStyle(ccStyle))
 	}
 
 	// Render progress bar if it's changed.


### PR DESCRIPTION
When we change the cursor style or color, then hide it, the cursor might remain changed after closing the renderer. This commit adds flags to track whether we changed the cursor style or color, and ensures we reset them to default when closing the renderer.

Testing notes:

1. Patch the `cursor-style` example with the patch below
2. Run the example
3. Change the style (e.g. bar or underscore)
4. Quit

You should see the cursor style doesn't get reset (unless your shell changes that before you notice it).

Might be related to: https://github.com/charmbracelet/crush/issues/1298