### PR TITLE
perft: lazy render model after event loop

### DIFF
--- a/tea_test.go
+++ b/tea_test.go
@@ -46,7 +46,10 @@ func (m *testModel) Update(msg Msg) (Model, Cmd) {
 		}
 
 	case KeyPressMsg:
-		return m, Quit
+		switch msg.String() {
+		case "q", "ctrl+c":
+			return m, Quit
+		}
 
 	case panicMsg:
 		panic("testing panic behavior")
@@ -584,5 +587,27 @@ func TestTeaGoroutinePanic(t *testing.T) {
 
 	if !errors.Is(err, ErrProgramKilled) {
 		t.Fatalf("Expected %v, got %v", ErrProgramKilled, err)
+	}
+}
+
+func BenchmarkTeaRun(b *testing.B) {
+	for b.Loop() {
+		var buf bytes.Buffer
+		var in bytes.Buffer
+
+		m := &testModel{}
+		p := NewProgram(m,
+			WithInput(&in),
+			WithOutput(&buf),
+			WithWindowSize(80, 24),
+		)
+
+		in.Reset()
+		in.Write([]byte("abc123q"))
+		buf.Reset()
+
+		if _, err := p.Run(); err != nil {
+			b.Errorf("Run failed: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
On a large program, this can reduce repeated model render calls when the model is getting updated rapidly. This change makes the model stored as an atomic pointer for safe concurrent access between the event loop and the render loop.

The model is now stored internally as an atomic pointer, and updated after each event loop iteration. The render loop reads the latest model from the atomic pointer before rendering its View.

Benchmarks show a slight reduction in allocations for the TeaTest example.
```
goos: darwin
goarch: arm64
pkg: github.com/charmbracelet/bubbletea/v2
cpu: Apple M3 Max
          │   old.txt   │            new.txt            │
          │   sec/op    │   sec/op     vs base          │
TeaRun-16   321.2µ ± 3%   318.3µ ± 4%  ~ (p=0.247 n=10)

          │   old.txt    │            new.txt             │
          │     B/op     │     B/op      vs base          │
TeaRun-16   623.0Ki ± 0%   622.2Ki ± 0%  ~ (p=0.105 n=10)

          │   old.txt   │              new.txt               │
          │  allocs/op  │  allocs/op   vs base               │
TeaRun-16   1.837k ± 0%   1.828k ± 0%  -0.52% (p=0.000 n=10)
```