### PR TITLE
chore: remove unused max func

### DIFF
--- a/examples/package-manager/main.go
+++ b/examples/package-manager/main.go
@@ -125,13 +125,6 @@ func downloadAndInstall(pkg string) tea.Cmd {
 	})
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func main() {
 	if _, err := tea.NewProgram(newModel()).Run(); err != nil {
 		fmt.Println("Error running program:", err)

--- a/examples/pager/main.go
+++ b/examples/pager/main.go
@@ -96,13 +96,6 @@ func (m model) footerView() string {
 	return lipgloss.JoinHorizontal(lipgloss.Center, line, info)
 }
 
-func max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func main() {
 	// Load some text for our viewport
 	content, err := os.ReadFile("artichoke.md")


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).


Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 