### PR TITLE
feat: allow chainable msg filters; add MouseThrottleFilter

### DIFF
--- a/examples/prevent-quit/main.go
+++ b/examples/prevent-quit/main.go
@@ -20,14 +20,14 @@ var (
 )
 
 func main() {
-	p := tea.NewProgram(initialModel(), tea.WithFilter(filter))
+	p := tea.NewProgram(initialModel(), tea.WithFilters(preventUnsavedFilter))
 
 	if _, err := p.Run(); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func filter(teaModel tea.Model, msg tea.Msg) tea.Msg {
+func preventUnsavedFilter(teaModel tea.Model, msg tea.Msg) tea.Msg {
 	if _, ok := msg.(tea.QuitMsg); !ok {
 		return msg
 	}

--- a/options_test.go
+++ b/options_test.go
@@ -32,7 +32,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("filter", func(t *testing.T) {
-		p := NewProgram(nil, WithFilter(func(_ Model, msg Msg) Msg { return msg }))
+		p := NewProgram(nil, WithFilters(func(_ Model, msg Msg) Msg { return msg }))
 		if p.filter == nil {
 			t.Errorf("expected filter to be set")
 		}

--- a/tea.go
+++ b/tea.go
@@ -440,38 +440,9 @@ type Program struct {
 	// cleanup on exit.
 	disableCatchPanics bool
 
-	// filter supplies an event filter that will be invoked before Bubble Tea
-	// processes a tea.Msg. The event filter can return any tea.Msg which will
-	// then get handled by Bubble Tea instead of the original event. If the
-	// event filter returns nil, the event will be ignored and Bubble Tea will
-	// not process it.
-	//
-	// As an example, this could be used to prevent a program from shutting
-	// down if there are unsaved changes.
-	//
-	// Example:
-	//
-	//	func filter(m tea.Model, msg tea.Msg) tea.Msg {
-	//		if _, ok := msg.(tea.QuitMsg); !ok {
-	//			return msg
-	//		}
-	//
-	//		model := m.(myModel)
-	//		if model.hasChanges {
-	//			return nil
-	//		}
-	//
-	//		return msg
-	//	}
-	//
-	//	p := tea.NewProgram(Model{});
-	//	p.filter = filter
-	//
-	//	if _,err := p.Run(context.Background()); err != nil {
-	//		fmt.Println("Error running program:", err)
-	//		os.Exit(1)
-	//	}
-	filter func(Model, Msg) Msg
+	// filter provides a way of filtering messages before they are processed by
+	// Bubble Tea. See [WithFilters] for more information.
+	filter MsgFilter
 
 	// fps sets a custom maximum fps at which the renderer should run. If less
 	// than 1, the default value of 60 will be used. If over 120, the fps will


### PR DESCRIPTION
## Changes in this PR

Made some tweaks to message filtering, as I think this will help others. If y'all don't think it will be too useful, or would rather approach it a different way, feel free to close this out.

- Converted `WithFilter(filter)` to `WithFilters(filters...)` to allow chainable filters, with a `MsgFilter` type to clean things up a little.
- Added an out-of-box `MouseThrottleFilter` filter, to cover throttling of high-frequency mouse messages. This logic is also used in crush [here](https://github.com/charmbracelet/crush/blob/0f39613d53dbb7b0a42d2b2d5541e63a9369f555/internal/tui/tui.go#L41-L54), and one of my apps, and I suspect such functionality will help others improve performance when they don't need the high-frequency tracking.

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

