### PR TITLE
v2: fix: typo in View struct's doc comments

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -125,7 +125,7 @@ type View struct {
 	OnMouse func(msg MouseMsg) Cmd
 
 	// Cursor represents the cursor position, style, and visibility on the
-	// screen. When not nit, the cursor will be shown at the specified
+	// screen. When not nil, the cursor will be shown at the specified
 	// position.
 	Cursor *Cursor
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).

Fix typo in View struct's doc comments.