### PR TITLE
feat(render): add option to show render time in the view

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -457,7 +457,7 @@ func (s *cursedRenderer) flush(closing bool) error {
 	}
 
 	if s.showRenderDebug {
-		renderTime := uv.NewStyledString(fmt.Sprintf("render time: %s", s.lastRenderTime))
+		renderTime := uv.NewStyledString(fmt.Sprintf("%s", s.lastRenderTime))
 		if len(content.Text) > 0 && !frameArea.Empty() {
 			renderTime.Draw(s.cellbuf, renderTime.Bounds())
 		}

--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -456,16 +456,15 @@ func (s *cursedRenderer) flush(closing bool) error {
 		setProgressBar(s, view.ProgressBar)
 	}
 
-	// Render and queue changes to the screen buffer.
-	s.scr.Render(s.cellbuf.Buffer)
-
 	if s.showRenderDebug {
 		renderTime := uv.NewStyledString(fmt.Sprintf("render time: %s", s.lastRenderTime))
 		if len(content.Text) > 0 && !frameArea.Empty() {
 			renderTime.Draw(s.cellbuf, renderTime.Bounds())
-			s.scr.Render(s.cellbuf.Buffer)
 		}
 	}
+
+	// Render and queue changes to the screen buffer.
+	s.scr.Render(s.cellbuf.Buffer)
 
 	if cur := view.Cursor; cur != nil {
 		// MoveTo must come after [uv.TerminalRenderer.Render] because the


### PR DESCRIPTION
This change makes it possible to display the time taken to render each frame on the terminal screen itself. This is controlled by the TEA_RENDER_DEBUG environment variable. When set to true, the renderer will overlay the render time on the view.

<img width="912" height="630" alt="2026-01-26_11-45-31" src="https://github.com/user-attachments/assets/0a685f28-26dd-4be1-88ec-2316a8df0c29" />
