### PR TITLE
fix(render): execute insert above immediately

### DIFF
--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -17,7 +17,7 @@ func (n nilRenderer) start() {}
 func (n nilRenderer) clearScreen() {}
 
 // insertAbove implements renderer.
-func (n nilRenderer) insertAbove(string) {}
+func (n nilRenderer) insertAbove(string) error { return nil }
 
 // resize implements renderer.
 func (n nilRenderer) resize(int, int) {}

--- a/renderer.go
+++ b/renderer.go
@@ -31,7 +31,7 @@ type renderer interface {
 	reset()
 
 	// insertAbove inserts unmanaged lines above the renderer.
-	insertAbove(string)
+	insertAbove(string) error
 
 	// setSyncdUpdates sets whether to use synchronized updates.
 	setSyncdUpdates(bool)


### PR DESCRIPTION
This commit modifies the behavior of the `insertAbove` method in the renderer to execute the insertion of lines immediately rather than queuing them for later processing. This change ensures that lines are inserted above the current view without delay.

