### PR TITLE
fix: restore mouse state after ExecProcess

### DIFF
--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -17,6 +17,8 @@ func (n nilRenderer) enableMouseCellMotion()     {}
 func (n nilRenderer) disableMouseCellMotion()    {}
 func (n nilRenderer) enableMouseAllMotion()      {}
 func (n nilRenderer) disableMouseAllMotion()     {}
+func (n nilRenderer) mouseCellMotionActive() bool { return false }
+func (n nilRenderer) mouseAllMotionActive() bool  { return false }
 func (n nilRenderer) enableBracketedPaste()      {}
 func (n nilRenderer) disableBracketedPaste()     {}
 func (n nilRenderer) enableMouseSGRMode()        {}

--- a/nil_renderer_test.go
+++ b/nil_renderer_test.go
@@ -18,7 +18,13 @@ func TestNilRenderer(t *testing.T) {
 	r.showCursor()
 	r.hideCursor()
 	r.enableMouseCellMotion()
+	if r.mouseCellMotionActive() {
+		t.Errorf("mouseCellMotionActive should always return false")
+	}
 	r.disableMouseCellMotion()
 	r.enableMouseAllMotion()
+	if r.mouseAllMotionActive() {
+		t.Errorf("mouseAllMotionActive should always return false")
+	}
 	r.disableMouseAllMotion()
 }

--- a/renderer.go
+++ b/renderer.go
@@ -74,6 +74,12 @@ type renderer interface {
 	// reportFocus returns whether reporting focus events is enabled.
 	reportFocus() bool
 
+	// mouseCellMotionActive returns whether mouse cell motion tracking is enabled.
+	mouseCellMotionActive() bool
+
+	// mouseAllMotionActive returns whether mouse all motion tracking is enabled.
+	mouseAllMotionActive() bool
+
 	// enableReportFocus reports focus events to the program.
 	enableReportFocus()
 

--- a/screen_test.go
+++ b/screen_test.go
@@ -80,3 +80,40 @@ func TestClearMsg(t *testing.T) {
 		})
 	}
 }
+
+func TestMouseStateTracking(t *testing.T) {
+	var buf bytes.Buffer
+	r := newRenderer(&buf, false, 60).(*standardRenderer)
+
+	// Initially, mouse should be inactive
+	if r.mouseCellMotionActive() {
+		t.Error("expected mouseCellMotion to be false initially")
+	}
+	if r.mouseAllMotionActive() {
+		t.Error("expected mouseAllMotion to be false initially")
+	}
+
+	// Enable cell motion
+	r.enableMouseCellMotion()
+	if !r.mouseCellMotionActive() {
+		t.Error("expected mouseCellMotion to be true after enable")
+	}
+
+	// Disable cell motion
+	r.disableMouseCellMotion()
+	if r.mouseCellMotionActive() {
+		t.Error("expected mouseCellMotion to be false after disable")
+	}
+
+	// Enable all motion
+	r.enableMouseAllMotion()
+	if !r.mouseAllMotionActive() {
+		t.Error("expected mouseAllMotion to be true after enable")
+	}
+
+	// Disable all motion
+	r.disableMouseAllMotion()
+	if r.mouseAllMotionActive() {
+		t.Error("expected mouseAllMotion to be false after disable")
+	}
+}

--- a/standard_renderer.go
+++ b/standard_renderer.go
@@ -52,6 +52,12 @@ type standardRenderer struct {
 	// reportingFocus whether reporting focus events is enabled
 	reportingFocus bool
 
+	// whether mouse cell motion tracking is enabled
+	mouseCellMotion bool
+
+	// whether mouse all motion tracking is enabled
+	mouseAllMotion bool
+
 	// renderer dimensions; usually the size of the window
 	width  int
 	height int
@@ -416,6 +422,7 @@ func (r *standardRenderer) enableMouseCellMotion() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
+	r.mouseCellMotion = true
 	r.execute(ansi.SetButtonEventMouseMode)
 }
 
@@ -423,6 +430,7 @@ func (r *standardRenderer) disableMouseCellMotion() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
+	r.mouseCellMotion = false
 	r.execute(ansi.ResetButtonEventMouseMode)
 }
 
@@ -430,6 +438,7 @@ func (r *standardRenderer) enableMouseAllMotion() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
+	r.mouseAllMotion = true
 	r.execute(ansi.SetAnyEventMouseMode)
 }
 
@@ -437,6 +446,7 @@ func (r *standardRenderer) disableMouseAllMotion() {
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
 
+	r.mouseAllMotion = false
 	r.execute(ansi.ResetAnyEventMouseMode)
 }
 
@@ -498,6 +508,20 @@ func (r *standardRenderer) reportFocus() bool {
 	defer r.mtx.Unlock()
 
 	return r.reportingFocus
+}
+
+func (r *standardRenderer) mouseCellMotionActive() bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	return r.mouseCellMotion
+}
+
+func (r *standardRenderer) mouseAllMotionActive() bool {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+
+	return r.mouseAllMotion
 }
 
 // setWindowTitle sets the terminal window title.

--- a/tea.go
+++ b/tea.go
@@ -184,8 +184,10 @@ type Program struct {
 	altScreenWasActive bool
 	ignoreSignals      uint32
 
-	bpWasActive bool // was the bracketed paste mode active before releasing the terminal?
-	reportFocus bool // was focus reporting active before releasing the terminal?
+	bpWasActive          bool // was the bracketed paste mode active before releasing the terminal?
+	reportFocus          bool // was focus reporting active before releasing the terminal?
+	mouseCellMotionWasActive bool // was mouse cell motion active before releasing the terminal?
+	mouseAllMotionWasActive  bool // was mouse all motion active before releasing the terminal?
 
 	filter func(Model, Msg) Msg
 
@@ -874,6 +876,8 @@ func (p *Program) ReleaseTerminal() error {
 		p.altScreenWasActive = p.renderer.altScreen()
 		p.bpWasActive = p.renderer.bracketedPasteActive()
 		p.reportFocus = p.renderer.reportFocus()
+		p.mouseCellMotionWasActive = p.renderer.mouseCellMotionActive()
+		p.mouseAllMotionWasActive = p.renderer.mouseAllMotionActive()
 	}
 
 	return p.restoreTerminalState()
@@ -905,6 +909,13 @@ func (p *Program) RestoreTerminal() error {
 	}
 	if p.reportFocus {
 		p.renderer.enableReportFocus()
+	}
+	if p.mouseCellMotionWasActive {
+		p.renderer.enableMouseCellMotion()
+		p.renderer.enableMouseSGRMode()
+	} else if p.mouseAllMotionWasActive {
+		p.renderer.enableMouseAllMotion()
+		p.renderer.enableMouseSGRMode()
 	}
 
 	// If the output is a terminal, it may have been resized while another


### PR DESCRIPTION
## Summary

- Fixes a bug where mouse events (cell motion and all motion tracking) stop working after returning from a process launched via `tea.ExecProcess` (e.g., spawning vim from a TUI program)
- `ReleaseTerminal` already saved and restored bracketed paste, alt screen, and focus reporting state, but mouse mode was missing from this save/restore cycle
- Adds mouse state tracking to the renderer and wires it through `ReleaseTerminal`/`RestoreTerminal`

Fixes #1424

## What changed

- **`renderer.go`**: Added `mouseCellMotionActive()` and `mouseAllMotionActive()` to the renderer interface
- **`standard_renderer.go`**: Added `mouseCellMotion` and `mouseAllMotion` boolean fields, updated enable/disable methods to track state, added getter methods
- **`nil_renderer.go`**: Implemented the new interface methods (always return false)
- **`tea.go`**: Added `mouseCellMotionWasActive` and `mouseAllMotionWasActive` fields to `Program`; `ReleaseTerminal` now saves mouse state; `RestoreTerminal` now re-enables mouse mode (including SGR extended mode) when it was previously active
- **`screen_test.go`** / **`nil_renderer_test.go`**: Added tests for mouse state tracking

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] `go vet ./...` passes cleanly
- [x] New `TestMouseStateTracking` test verifies enable/disable state tracking on the standard renderer
- [x] Nil renderer tests updated to cover new interface methods
- [ ] Manual testing: run a Bubble Tea program with mouse enabled, exec an external process (e.g., vim), exit it, and verify mouse events still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)