### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/inputreader_other.go
+++ b/inputreader_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package tea
 

--- a/inputreader_windows.go
+++ b/inputreader_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package tea
 

--- a/key_other.go
+++ b/key_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package tea
 

--- a/key_windows.go
+++ b/key_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package tea
 

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix || zos
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix zos
 
 package tea
 

--- a/signals_windows.go
+++ b/signals_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package tea
 

--- a/tty_unix.go
+++ b/tty_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix || zos
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix zos
 
 package tea
 

--- a/tty_windows.go
+++ b/tty_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package tea
 


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).


From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild

