### PR TITLE
fix: check if os.Stdin is a terminal before opening the TTY

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -987,12 +987,14 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 	if p.disableInput {
 		p.input = nil
 	} else if p.input == nil {
-		// Always open the TTY for input.
-		ttyIn, _, err := OpenTTY()
-		if err != nil {
-			return p.initialModel, fmt.Errorf("bubbletea: error opening TTY: %w", err)
+		p.input = os.Stdin
+		if !term.IsTerminal(os.Stdin.Fd()) {
+			ttyIn, _, err := OpenTTY()
+			if err != nil {
+				return p.initialModel, fmt.Errorf("bubbletea: error opening TTY: %w", err)
+			}
+			p.input = ttyIn
 		}
-		p.input = ttyIn
 	}
 
 	// Handle signals.


### PR DESCRIPTION
This change checks if os.Stdin is a terminal before attempting to open the TTY for input. If os.Stdin is not a terminal, it will proceed to open the TTY as before.

Fixes: https://github.com/charmbracelet/bubbletea/issues/1595
