### PR TITLE
fix(examples): add missing WithWidth to table example

### DIFF
--- a/examples/table/main.go
+++ b/examples/table/main.go
@@ -162,6 +162,7 @@ func main() {
 		table.WithRows(rows),
 		table.WithFocused(true),
 		table.WithHeight(7),
+		table.WithWidth(42),
 	)
 
 	s := table.DefaultStyles()


### PR DESCRIPTION
## Summary
Add missing `table.WithWidth(42)` to the table example.

## Root cause
Without an explicit width set, the table has no bounds to render rows within,
resulting in a blank table body.

The width is derived from the sum of all column widths:
  Rank(4) + City(10) + Country(10) + Population(10) = 34 
\+ 8 for borders = 42

## Before
Table renders with no rows visible.

## After
Table renders correctly with all rows and scroll behavior working.

Fixes #1597

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
