### PR TITLE
Fix typo: spinner to spinners in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -234,7 +234,7 @@ The `spinner` example demonstrates a spinner bubble being used to indicate loadi
 
 ### Spinners
 
-The `spinner` example shows various spinner types that are available.
+The `spinners` example shows various spinner types that are available.
 
 <a href="./spinners/main.go">
   <img width="750" src="./spinners/spinners.gif" />


### PR DESCRIPTION
Fixes typo in examples/README.md where Spinners section description incorrectly refers to `spinner` instead of `spinners`.