### PR TITLE
Fixed wrong Type in the README tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ worry about redrawing logic and stuff like that. Bubble Tea takes care of it
 for you.
 
 ```go
-func (m model) View() tea.View {
+func (m model) View() string {
     // The header
     s := "What should we buy at the market?\n\n"
 
@@ -235,7 +235,7 @@ func (m model) View() tea.View {
     s += "\nPress q to quit.\n"
 
     // Send the UI for rendering
-    return tea.NewView(s)
+    return s
 }
 ```
 


### PR DESCRIPTION
The Tutorial in the README is still using tea.view as a return type for the View() method when the expected type is string.

Change return type of View method from tea.View to string.

- [ x ] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
