### PR TITLE
fix(renderer): use mapNl optimization when not on Windows and no PTY …

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -1051,8 +1052,8 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 			// issue where when a PTY session is detected, and we don't
 			// allocate a real PTY, the terminal settings (Termios and WinCon)
 			// don't change and the we end up working in cooked mode instead of
-			// raw mode.
-			mapNl := false // p.ttyInput == nil
+			// raw mode. See issue #1572.
+			mapNl := runtime.GOOS != "windows" && p.ttyInput == nil
 			r.setOptimizations(p.useHardTabs, p.useBackspace, mapNl)
 			p.renderer = r
 		}


### PR DESCRIPTION
…input

Without this, emulated-pty Wish sessions on non-Windows platforms can end up messing up the view.

See issue #1572 for more details.
