### PR TITLE
fix: use fmt.Sprintln for correct newline handling in Println

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -70,7 +70,7 @@ type printLineMessage struct {
 func Println(args ...any) Cmd {
 	return func() Msg {
 		return printLineMessage{
-			messageBody: fmt.Sprint(args...),
+			messageBody: fmt.Sprintln(args...),
 		}
 	}
 }

--- a/tea.go
+++ b/tea.go
@@ -1350,7 +1350,7 @@ func (p *Program) RestoreTerminal() error {
 // If the altscreen is active no output will be printed.
 func (p *Program) Println(args ...any) {
 	p.msgs <- printLineMessage{
-		messageBody: fmt.Sprint(args...),
+		messageBody: fmt.Sprintln(args...),
 	}
 }
 


### PR DESCRIPTION
# Summary

Both the renderer and tea implement `Println()` that takes args and should behave like `fmt.Println`. The current implementation uses `fmt.Sprint`, which does not handle newlines correctly. This change switches to `fmt.Sprintln` so newlines are handled as expected.

Fixes #1613

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
