### PR TITLE
fix(examples): use SetWidth to fix type mismatch in help

### DIFF
--- a/examples/help/main.go
+++ b/examples/help/main.go
@@ -89,7 +89,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		// If we set a width on the help menu it can gracefully truncate
 		// its view as needed.
-		m.help.Width = msg.Width
+		m.help.SetWidth(msg.Width)
 
 	case tea.KeyPressMsg:
 		switch {


### PR DESCRIPTION
# Summery
Updates the help example to set the help model width via SetWidth() instead of assigning to Width directly, resolving a type mismatch

Fixes #1617

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).
