### PR TITLE
feat: add ReportAllKeysAsEscapeCodes keyboard enhancement option (#1621)

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -135,6 +135,9 @@ func (s *cursedRenderer) start() {
 	if s.lastView.KeyboardEnhancements.ReportEventTypes {
 		kittyFlags |= ansi.KittyReportEventTypes
 	}
+	if s.lastView.KeyboardEnhancements.ReportAllKeysAsEscapeCodes {
+		kittyFlags |= ansi.KittyReportAllKeysAsEscapeCodes
+	}
 	_, _ = s.scr.WriteString(ansi.KittyKeyboard(kittyFlags, 1))
 }
 
@@ -382,6 +385,9 @@ func (s *cursedRenderer) flush(closing bool) error {
 		kittyFlags := ansi.KittyDisambiguateEscapeCodes // always enable basic key disambiguation
 		if view.KeyboardEnhancements.ReportEventTypes {
 			kittyFlags |= ansi.KittyReportEventTypes
+		}
+		if view.KeyboardEnhancements.ReportAllKeysAsEscapeCodes {
+			kittyFlags |= ansi.KittyReportAllKeysAsEscapeCodes
 		}
 		_, _ = s.scr.WriteString(ansi.KittyKeyboard(kittyFlags, 1))
 		if !closing {

--- a/examples/keyboard-enhancements/main.go
+++ b/examples/keyboard-enhancements/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -19,6 +20,8 @@ type styles struct {
 type model struct {
 	supportsDisambiguation bool
 	supportsEventTypes     bool
+	supportsAllKeys        bool
+	allKeysAsEscapeCodes   bool
 	styles                 styles
 }
 
@@ -46,6 +49,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Check which features were able to be enabled.
 		m.supportsDisambiguation = true // This is always enabled when this msg is received.
 		m.supportsEventTypes = msg.SupportsEventTypes()
+		m.supportsAllKeys = msg.SupportsAllKeysAsEscapeCodes()
 
 	case tea.KeyPressMsg:
 		switch msg.String() {
@@ -70,6 +74,10 @@ func (m model) View() tea.View {
 	var b strings.Builder
 	fmt.Fprintf(&b, "Terminal supports key releases: %v\n", m.supportsEventTypes)
 	fmt.Fprintf(&b, "Terminal supports key disambiguation: %v\n", m.supportsDisambiguation)
+	fmt.Fprintf(&b, "Terminal supports all keys as escape codes: %v\n", m.supportsAllKeys)
+	if m.allKeysAsEscapeCodes {
+		fmt.Fprint(&b, "Mode: all keys as escape codes (--all-keys)\n")
+	}
 	fmt.Fprint(&b, "This demo logs key events. Press ctrl+c to quit.")
 	v.SetContent(b.String() + "\n")
 
@@ -78,6 +86,7 @@ func (m model) View() tea.View {
 	// the ability to distinguish between certain key presses like "enter" and
 	// "shift+enter" or "tab" and "ctrl+i".
 	v.KeyboardEnhancements.ReportEventTypes = true
+	v.KeyboardEnhancements.ReportAllKeysAsEscapeCodes = m.allKeysAsEscapeCodes
 
 	return v
 }
@@ -95,7 +104,9 @@ func (m *model) updateStyles(isDark bool) {
 }
 
 func initialModel() model {
-	m := model{}
+	m := model{
+		allKeysAsEscapeCodes: slices.Contains(os.Args[1:], "--all-keys"),
+	}
 	m.updateStyles(true) // default to dark styles.
 	return m
 }

--- a/keyboard.go
+++ b/keyboard.go
@@ -39,3 +39,9 @@ func (k KeyboardEnhancementsMsg) SupportsKeyDisambiguation() bool {
 func (k KeyboardEnhancementsMsg) SupportsEventTypes() bool {
 	return k.Flags&ansi.KittyReportEventTypes != 0
 }
+
+// SupportsAllKeysAsEscapeCodes returns whether the terminal supports
+// reporting all key events as escape codes, including printable characters.
+func (k KeyboardEnhancementsMsg) SupportsAllKeysAsEscapeCodes() bool {
+	return k.Flags&ansi.KittyReportAllKeysAsEscapeCodes != 0
+}

--- a/tea.go
+++ b/tea.go
@@ -245,6 +245,14 @@ type KeyboardEnhancements struct {
 	// [KeyPressMsg] with the [Key.IsRepeat] field set indicating that this is
 	// a it's part of a key repeat sequence.
 	ReportEventTypes bool
+
+	// ReportAllKeysAsEscapeCodes requests the terminal to report all key
+	// events as escape codes, including printable characters like Space. This
+	// is useful when you need accurate modifier information for all keys.
+	// Without this, keys like Shift+Space may not report the Shift modifier
+	// on press because the terminal sends the raw character byte which
+	// carries no modifier information.
+	ReportAllKeysAsEscapeCodes bool
 }
 
 // SetContent is a helper method to set the content of a [View] with a styled


### PR DESCRIPTION
Some terminals send modified printable keys (e.g. Shift+Space) as raw character bytes on press, losing modifier information. This adds support for requesting Kitty keyboard protocol flag 8 (ReportAllKeysAsEscapeCodes), which ensures all keys are sent as CSI u-escape codes that preserve modifier state.

Add --all-keys argument to keyboard-enhancements demo to exercise it.

- [X] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [X] I have created an issue #1621  for it

I used Claude to navigate the surface of this issue, so I don't have a strong understanding of the Kitty protocol and the ramifications of this change.  I couldn't find reference to `KittyReportAllKeysAsEscapeCodes` on Discord or GitHub.

That said, when I enable this, many messages are flowing in the `keyboard-enhancements` demo when `v.KeyboardEnhancements.ReportAllKeysAsEscapeCodes = true`:

```
$ go run examples/keyboard-enhancements/main.go --all-keys
release: enter
  press: rightshift
release: rightshift
  press: leftshift
release: leftshift
  press: leftshift
  press: shift+space
release: shift+space
  press: shift+space
release: shift+space
  press: shift+space
release: shift+space
release: leftshift
```