### PR TITLE
docs: fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import will be the Bubble Tea library, which we'll call `tea` for short.
 ```go
 package main
 
-// These imports will be used later on the tutorial. If you save the file
+// These imports will be used later in the tutorial. If you save the file
 // now, Go might complain they are unused, but that's fine.
 // You may also need to run `go mod tidy` to download bubbletea and its
 // dependencies.


### PR DESCRIPTION
## Summary
- Adjust README tutorial wording for grammar.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/charmbracelet/bubbletea/contribute

## Validation/testing
- Not run (docs change only)
