### PR TITLE
fix: add WithHardTabs option to disable tab cursor optimization

### DIFF
--- a/options.go
+++ b/options.go
@@ -166,3 +166,14 @@ func WithWindowSize(width, height int) ProgramOption {
 		p.height = height
 	}
 }
+
+// WithHardTabs sets whether to use hard tabs to optimize cursor movements.
+// When true (the default), the renderer may replace space runs with tab
+// characters for faster cursor movement. When false, tab compression is
+// disabled, preserving space-based column alignment in View() output.
+// Use WithHardTabs(false) if your layout relies on spaces for alignment.
+func WithHardTabs(enable bool) ProgramOption {
+	return func(p *Program) {
+		p.hardTabsOverride = &enable
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -93,5 +93,21 @@ func TestOptions(t *testing.T) {
 				}
 			})
 		})
+
+		t.Run("with hard tabs", func(t *testing.T) {
+			exercise(t, WithHardTabs(true), func(p *Program) {
+				if p.hardTabsOverride == nil || !*p.hardTabsOverride {
+					t.Errorf("expected hardTabsOverride to be true, got %v", p.hardTabsOverride)
+				}
+			})
+		})
+
+		t.Run("without hard tabs", func(t *testing.T) {
+			exercise(t, WithHardTabs(false), func(p *Program) {
+				if p.hardTabsOverride == nil || *p.hardTabsOverride {
+					t.Errorf("expected hardTabsOverride to be false, got %v", p.hardTabsOverride)
+				}
+			})
+		})
 	})
 }

--- a/tea.go
+++ b/tea.go
@@ -526,6 +526,8 @@ type Program struct {
 
 	// whether to use hard tabs to optimize cursor movements
 	useHardTabs bool
+
+	hardTabsOverride *bool // nil = use termios detection; non-nil = override
 	// whether to use backspace to optimize cursor movements
 	useBackspace bool
 
@@ -1054,7 +1056,11 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 			// don't change and the we end up working in cooked mode instead of
 			// raw mode. See issue #1572.
 			mapNl := runtime.GOOS != "windows" && p.ttyInput == nil
-			r.setOptimizations(p.useHardTabs, p.useBackspace, mapNl)
+			hardTabs := p.useHardTabs
+			if p.hardTabsOverride != nil {
+				hardTabs = *p.hardTabsOverride
+			}
+			r.setOptimizations(hardTabs, p.useBackspace, mapNl)
 			p.renderer = r
 		}
 	}


### PR DESCRIPTION
## Summary
Fixes #1635.
**Root cause:** Hard-tab cursor optimization replaced space runs with tabs, breaking column alignment in `View()` output for space-based layouts.
**Fix:** Added `WithHardTabs(bool)` program option that allows disabling tab compression while maintaining backward compatibility (defaults to termios detection).
## Changes
- `options.go`: Added `WithHardTabs` option
- `tea.go`: Added `hardTabsOverride` field and logic to use it in `setOptimizations`
- `options_test.go`: Added tests for `WithHardTabs(true)` and `WithHardTabs(false)`
## Testing
- Verified column alignment is preserved when `WithHardTabs(false)` is used
- Default behavior unchanged (termios detection when option not set)
- All tests pass

Made with [Cursor](https://cursor.com)