### PR TITLE
fix: disable hard-tab cursor optimization that breaks column alignment

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -61,7 +61,11 @@ func (s *cursedRenderer) setOptimizations(hardTabs, backspace, mapnl bool) {
 	s.hardTabs = hardTabs
 	s.backspace = backspace
 	s.mapnl = mapnl
-	s.scr.SetTabStops(s.width)
+	if hardTabs {
+		s.scr.SetTabStops(s.width)
+	} else {
+		s.scr.SetTabStops(-1) // Disable hard tabs to preserve column alignment
+	}
 	s.scr.SetBackspace(s.backspace)
 	s.scr.SetMapNewline(s.mapnl)
 	s.mu.Unlock()
@@ -593,7 +597,11 @@ func reset(s *cursedRenderer) {
 	scr.SetColorProfile(s.profile)
 	scr.SetRelativeCursor(true) // Always start in inline mode
 	scr.SetFullscreen(false)    // Always start in inline mode
-	scr.SetTabStops(s.width)
+	if s.hardTabs {
+		scr.SetTabStops(s.width)
+	} else {
+		scr.SetTabStops(-1) // Disable hard tabs to preserve column alignment
+	}
 	scr.SetBackspace(s.backspace)
 	scr.SetMapNewline(s.mapnl)
 	scr.SetScrollOptim(runtime.GOOS != "windows") // disable scroll optimization on Windows due to bugs in some terminals


### PR DESCRIPTION
## Summary
Fixes #1614.

**Root cause:** The TAB0-based cursor optimization replaced space runs with tabs. Tab stops are every 8 columns. When the target column is not on a tab boundary, the tab overshoots and breaks alignment.

**Fix:** Respect the `hardTabs` parameter in `setOptimizations` and `reset`. When false (the default), call `SetTabStops(-1)` to disable instead of always enabling.

## Changes
- `cursed_renderer.go`: only call `SetTabStops(s.width)` when `hardTabs` is true; otherwise `SetTabStops(-1)` to preserve column alignment.

## Testing
- Verified column alignment is preserved after the fix
- Existing test suite passes

Made with [Cursor](https://cursor.com)