### PR TITLE
docs(example): add textarea dynamic height example

### DIFF
--- a/examples/dynamic-textarea/main.go
+++ b/examples/dynamic-textarea/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+)
+
+func main() {
+	p := tea.NewProgram(initialModel())
+	if _, err := p.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+type model struct {
+	textarea textarea.Model
+}
+
+func initialModel() model {
+	ti := textarea.New()
+	ti.Placeholder = "Schnrr..."
+	ti.ShowLineNumbers = true
+	ti.DynamicHeight = true
+	ti.MinHeight = 3
+	ti.MaxHeight = 15
+	ti.MaxContentHeight = 20
+	ti.SetWidth(60)
+	ti.SetVirtualCursor(false)
+	ti.Focus()
+
+	return model{textarea: ti}
+}
+
+func (m model) Init() tea.Cmd {
+	return tea.Batch(textarea.Blink, tea.RequestBackgroundColor)
+}
+
+func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+	var cmd tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.BackgroundColorMsg:
+		m.textarea.SetStyles(textarea.DefaultStyles(msg.IsDark()))
+	case tea.KeyPressMsg:
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		}
+	}
+
+	m.textarea, cmd = m.textarea.Update(msg)
+	cmds = append(cmds, cmd)
+	return m, tea.Batch(cmds...)
+}
+
+func (m model) statusView() string {
+	return fmt.Sprintf(
+		"\nHeight: %d · Lines: %d · Cursor: (%d, %d) · Scroll: %.0f%%",
+		m.textarea.Height(),
+		m.textarea.LineCount(),
+		m.textarea.Line(),
+		m.textarea.Column(),
+		m.textarea.ScrollPercent()*100,
+	)
+}
+
+func (m model) View() tea.View {
+	const gap = 1
+
+	var c *tea.Cursor
+	if !m.textarea.VirtualCursor() {
+		c = m.textarea.Cursor()
+		c.Y += gap
+	}
+
+	f := strings.Repeat("\n", gap)
+	f += strings.Join([]string{
+		m.textarea.View(),
+		m.statusView(),
+		"\n(ctrl+c to quit)",
+	}, "\n")
+
+	v := tea.NewView(f)
+	v.Cursor = c
+	return v
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -5,8 +5,8 @@ go 1.25.8
 replace charm.land/bubbletea/v2 => ../
 
 require (
-	charm.land/bubbles/v2 v2.0.0
-	charm.land/bubbletea/v2 v2.0.0
+	charm.land/bubbles/v2 v2.1.0
+	charm.land/bubbletea/v2 v2.0.2
 	charm.land/glamour/v2 v2.0.0
 	charm.land/lipgloss/v2 v2.0.2
 	github.com/charmbracelet/colorprofile v0.4.3
@@ -33,7 +33,7 @@ require (
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
-	github.com/mattn/go-runewidth v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.21 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.27 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,5 @@
-charm.land/bubbles/v2 v2.0.0 h1:tE3eK/pHjmtrDiRdoC9uGNLgpopOd8fjhEe31B/ai5s=
-charm.land/bubbles/v2 v2.0.0/go.mod h1:rCHoleP2XhU8um45NTuOWBPNVHxnkXKTiZqcclL/qOI=
+charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
+charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
 charm.land/glamour/v2 v2.0.0 h1:IDBoqLEy7Hdpb9VOXN+khLP/XSxtJy1VsHuW/yF87+U=
 charm.land/glamour/v2 v2.0.0/go.mod h1:kjq9WB0s8vuUYZNYey2jp4Lgd9f4cKdzAw88FZtpj/w=
 charm.land/lipgloss/v2 v2.0.2 h1:xFolbF8JdpNkM2cEPTfXEcW1p6NRzOWTSamRfYEw8cs=
@@ -58,8 +58,8 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.20 h1:WcT52H91ZUAwy8+HUkdM3THM6gXqXuLJi9O3rjcQQaQ=
-github.com/mattn/go-runewidth v0.0.20/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
+github.com/mattn/go-runewidth v0.0.21 h1:jJKAZiQH+2mIinzCJIaIG9Be1+0NR+5sz/lYEEjdM8w=
+github.com/mattn/go-runewidth v0.0.21/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=


### PR DESCRIPTION
* Bubbles PR: https://github.com/charmbracelet/bubbles/pull/910

This adds an example of a textarea with a dynamic height.

<p><img width="500" src="https://github.com/user-attachments/assets/6f990de7-833d-4742-b3de-c87ffff8b77e" /></p>

Requires: https://github.com/charmbracelet/bubbles/pull/910