### PR TITLE
docs: fix progress download comment grammar

### DIFF
--- a/examples/progress-download/main.go
+++ b/examples/progress-download/main.go
@@ -66,8 +66,8 @@ func main() {
 	}
 	defer resp.Body.Close() // nolint:errcheck
 
-	// Don't add TUI if the header doesn't include content size
-	// it's impossible see progress without total
+		// Don't add TUI if the header doesn't include content size, since it's
+		// impossible to show progress without a total.
 	if resp.ContentLength <= 0 {
 		fmt.Println("can't parse content length, aborting download")
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- fix a grammar issue in the `examples/progress-download` comment
- keep the change limited to one file with no behavior impact

## Related issue
- N/A

## Guideline alignment
- Minimal comment-only change aligned with the repo contribution guidance: https://github.com/charmbracelet/bubbletea/contribute

## Validation/testing
- Not run; comment-only change
