### PR TITLE
# feat: add WithoutCaps() for disabling specific terminal caps

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -33,6 +33,7 @@ type cursedRenderer struct {
 	mapnl         bool
 	syncdUpdates  bool // whether to use synchronized output mode for updates
 	starting      bool // indicates whether the renderer is starting after being stopped
+	disabledCaps  []uv.Capability // capabilities to disable on the terminal renderer
 }
 
 var _ renderer = &cursedRenderer{}
@@ -597,6 +598,7 @@ func reset(s *cursedRenderer) {
 	scr.SetBackspace(s.backspace)
 	scr.SetMapNewline(s.mapnl)
 	scr.SetScrollOptim(runtime.GOOS != "windows") // disable scroll optimization on Windows due to bugs in some terminals
+	scr.DisableCaps(s.disabledCaps...)
 	s.scr = scr
 }
 
@@ -827,4 +829,13 @@ func viewEquals(a, b *View) bool {
 	}
 
 	return true
+}
+
+// setDisabledCaps stores the capabilities to disable and applies them to the
+// current terminal renderer. They will also be applied on subsequent reset() calls.
+func (s *cursedRenderer) setDisabledCaps(caps []uv.Capability) {
+	s.mu.Lock()
+	s.disabledCaps = caps
+	s.scr.DisableCaps(caps...)
+	s.mu.Unlock()
 }

--- a/options.go
+++ b/options.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 
 	"github.com/charmbracelet/colorprofile"
+	uv "github.com/charmbracelet/ultraviolet"
 )
 
 // ProgramOption is used to set options when initializing a Program. Program can
@@ -164,5 +165,17 @@ func WithWindowSize(width, height int) ProgramOption {
 	return func(p *Program) {
 		p.width = width
 		p.height = height
+	}
+}
+
+// WithoutCaps disables specific ultraviolet terminal capabilities. Use this
+// when a terminal emulator is known to mishandle certain escape sequences.
+// For example, JediTerm (GoLand/IntelliJ) does not correctly implement CBT
+// (Cursor Backward Tab), so you can disable it:
+//
+//	p := tea.NewProgram(model, tea.WithoutCaps(uv.CapCBT))
+func WithoutCaps(caps ...uv.Capability) ProgramOption {
+	return func(p *Program) {
+		p.disabledCaps = caps
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sync/atomic"
 	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
 )
 
 func TestOptions(t *testing.T) {
@@ -93,5 +95,18 @@ func TestOptions(t *testing.T) {
 				}
 			})
 		})
+	})
+
+	t.Run("without caps", func(t *testing.T) {
+		p := NewProgram(nil, WithoutCaps(uv.CapCBT, uv.CapREP))
+		if len(p.disabledCaps) != 2 {
+			t.Fatalf("expected 2 disabled caps, got %d", len(p.disabledCaps))
+		}
+		if p.disabledCaps[0] != uv.CapCBT {
+			t.Errorf("expected first cap to be CapCBT, got %d", p.disabledCaps[0])
+		}
+		if p.disabledCaps[1] != uv.CapREP {
+			t.Errorf("expected second cap to be CapREP, got %d", p.disabledCaps[1])
+		}
 	})
 }

--- a/tea.go
+++ b/tea.go
@@ -529,6 +529,9 @@ type Program struct {
 	// whether to use backspace to optimize cursor movements
 	useBackspace bool
 
+	// disabledCaps is a list of ultraviolet terminal capabilities to disable.
+	disabledCaps []uv.Capability
+
 	mu sync.Mutex
 }
 
@@ -1045,6 +1048,7 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 				p.width,
 				p.height,
 			)
+			r.setDisabledCaps(p.disabledCaps)
 			r.setLogger(p.logger)
 			// XXX: This breaks many things especially when we want the output
 			// to be compatible with terminals that are not necessary a TTY.


### PR DESCRIPTION
# feat: add WithoutCaps() program option for disabling specific terminal capabilities

> **Depends on:** [charmbracelet/ultraviolet#100](https://github.com/charmbracelet/ultraviolet/pull/100) — _`DisableCaps()` must be merged first, then the ultraviolet dependency updated via `go get` and `go mod tidy`._

## Summary

- Add `WithoutCaps(...uv.Capability)` program option so developers can selectively disable terminal capabilities that cause rendering issues on specific terminals
- Capabilities are applied to the renderer on initialization and preserved across renderer resets

## Motivation

Some terminal emulators report a standard `TERM` value (e.g. `xterm-256color`) while not correctly implementing all the capabilities that implies. Currently there is no way for a Bubble Tea application to selectively disable specific rendering optimizations — the only workaround is overriding `TERM` to a less capable terminal type, which degrades the entire rendering pipeline (e.g. losing TrueColor).

`WithoutCaps()` provides fine-grained control: disable only the problematic capability while keeping everything else at full quality.

**Example:** JetBrains GoLand and all IntelliJ-based IDEs use [JediTerm](https://github.com/JetBrains/jediterm), which reports as `xterm-256color` but mishandles **CBT _(Cursor Backward Tab)_**, causing invalid rendering. A follow-up ultraviolet PR will add auto-detection for known problematic terminals; this PR provides the Bubble Tea-level API that lets developers handle cases not yet auto-detected.

## Usage

```go
import uv "github.com/charmbracelet/ultraviolet"

// Disable CBT for terminals that don't support it
p = tea.NewProgram(model, tea.WithoutCaps(uv.CapCBT))
```

## Changes

- **`options.go`** — New `WithoutCaps(...uv.Capability)` program option for manual capability control.
- **`options_test.go`** — Tests for `WithoutCaps`.
- **`cursed_renderer.go`** — New `setDisabledCaps()` method that stores and applies disabled caps. Also applied during `reset()` so caps survive renderer recreation.
- **`tea.go`** — New `disabledCaps []uv.Capability` field on `Program`. 

## Before merging

Once ultraviolet PR #100 is merged then you need to run `go get github.com/charmbracelet/ultraviolet@<commit>` , followed by `go mod tidy`.

## Test plan

- [x] Manual testing with JediTerm (GoLand terminal) confirms rendering issue is resolved
- [x] All existing tests pass
