### PR TITLE
docs: fix links to tutorials & examples

### DIFF
--- a/examples/composable-views/main.go
+++ b/examples/composable-views/main.go
@@ -18,8 +18,8 @@ haven't already read our tutorials on the basics of Bubble Tea and working with
 commands, we recommend reading those first.
 
 Find them at:
-https://github.com/charmbracelet/bubbletea/tree/master/tutorials/commands
-https://github.com/charmbracelet/bubbletea/tree/master/tutorials/basics
+https://github.com/charmbracelet/bubbletea/tree/main/tutorials/commands
+https://github.com/charmbracelet/bubbletea/tree/main/tutorials/basics
 */
 
 // sessionState is used to track which model is focused

--- a/tea.go
+++ b/tea.go
@@ -4,9 +4,9 @@
 // both. It's been battle-tested in several large projects and is
 // production-ready.
 //
-// A tutorial is available at https://github.com/charmbracelet/bubbletea/tree/master/tutorials
+// A tutorial is available at https://github.com/charmbracelet/bubbletea/tree/main/tutorials
 //
-// Example programs can be found at https://github.com/charmbracelet/bubbletea/tree/master/examples
+// Example programs can be found at https://github.com/charmbracelet/bubbletea/tree/main/examples
 package tea
 
 import (

--- a/tutorials/basics/README.md
+++ b/tutorials/basics/README.md
@@ -10,7 +10,7 @@ By the way, the non-annotated source code for this program is available
 [on GitHub][tut-source].
 
 [elm]: https://guide.elm-lang.org/architecture/
-[tut-source]: https://github.com/charmbracelet/bubbletea/tree/master/tutorials/basics
+[tut-source]: https://github.com/charmbracelet/bubbletea/tree/main/tutorials/basics
 
 ## Enough! Let’s get to it.
 
@@ -216,8 +216,8 @@ look at the [Command Tutorial][cmd]. It’s pretty simple.
 There are also several [Bubble Tea examples][examples] available and, of course,
 there are [Go Docs][docs].
 
-[cmd]: http://github.com/charmbracelet/bubbletea/tree/master/tutorials/commands/
-[examples]: http://github.com/charmbracelet/bubbletea/tree/master/examples
+[cmd]: https://github.com/charmbracelet/bubbletea/tree/main/tutorials/commands/
+[examples]: https://github.com/charmbracelet/bubbletea/tree/main/examples
 [docs]: https://pkg.go.dev/charm.land/bubbletea/v2?tab=doc
 
 ## Additional Resources

--- a/tutorials/commands/README.md
+++ b/tutorials/commands/README.md
@@ -6,7 +6,7 @@ understanding of [the first tutorial][basics].
 
 You can find the non-annotated version of this program [on GitHub][source].
 
-[basics]: https://github.com/charmbracelet/bubbletea/tree/master/tutorials/basics
+[basics]: https://github.com/charmbracelet/bubbletea/tree/main/tutorials/basics
 [source]: https://github.com/charmbracelet/bubbletea/blob/master/tutorials/commands/main.go
 
 ## Let’s Go!
@@ -222,7 +222,7 @@ And, of course, check out the [Go Docs][docs].
 
 [bubbles]: https://github.com/charmbracelet/bubbles
 [docs]: https://pkg.go.dev/charm.land/bubbletea/v2?tab=doc
-[examples]: https://github.com/charmbracelet/bubbletea/tree/master/examples
+[examples]: https://github.com/charmbracelet/bubbletea/tree/main/examples
 
 ## Additional Resources
 


### PR DESCRIPTION
Change the link from https://github.com/charmbracelet/bubbletea/tree/master to https://github.com/charmbracelet/bubbletea/tree/main whenever mentioned, so that you don't get the annoying error message "Branch not found, redirected to default branch".