### PR TITLE
fix: data race between cancelReader.Close() and wait() during shutdown

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -1228,12 +1228,17 @@ func (p *Program) shutdown(kill bool) {
 
 		// Check if the cancel reader has been setup before waiting and closing.
 		if p.cancelReader != nil {
-			// Wait for input loop to finish.
-			if p.cancelReader.Cancel() {
-				if !kill {
-					p.waitForReadLoop()
-				}
+			// Cancel the reader to unblock any pending Read calls.
+			p.cancelReader.Cancel()
+
+			// Always wait for the read loop goroutine to finish before
+			// closing the cancel reader. This prevents a data race between
+			// cancelReader.Close() and the goroutine still accessing
+			// cancelSignalReader.Fd() inside cancelreader.wait().
+			if !kill {
+				p.waitForReadLoop()
 			}
+
 			_ = p.cancelReader.Close()
 		}
 


### PR DESCRIPTION
## Summary
- Fix a race condition where `cancelReader.Close()` runs concurrently with a goroutine still accessing `cancelSignalReader.Fd()`
- Always wait for the read loop goroutine to finish before closing the cancel reader

## Root Cause
The shutdown code only called `waitForReadLoop()` when `cancelReader.Cancel()` returned `true`. But when the context was already cancelled by `p.cancel()`, `Cancel()` could return `false` while the inner goroutine spawned by `ultraviolet.StreamEvents` was still blocked in `cancelreader.Read()`.

Race sequence:
1. `shutdown()` calls `p.cancel()` — context cancelled
2. `StreamEvents` returns on `ctx.Done()`, but inner goroutine still in `cancelreader.Read()`
3. `readLoopDone` closes
4. `Cancel()` returns `false` → `waitForReadLoop()` skipped
5. `Close()` destroys `cancelSignalReader` while goroutine still calls `.Fd()` → **DATA RACE**

## Fix
Always call `Cancel()` unconditionally, then always `waitForReadLoop()` before `Close()`. This ensures the goroutine has fully exited before the file descriptor is destroyed.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

Closes #1599

🤖 Generated with [Claude Code](https://claude.com/claude-code)