### PR TITLE
feat: add Chain() for automatic command chaining

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -163,6 +163,52 @@ func Tick(d time.Duration, fn func(time.Time) Msg) Cmd {
 	}
 }
 
+// Chain creates a command that pipes the output of each command as input to
+// the next. Unlike [Sequence], which simply runs commands in order and sends
+// each result to Update independently, Chain passes each command's resulting
+// Msg to the next function in the chain. The final Msg is sent to Update.
+//
+// Each function in the chain receives the Msg produced by the previous command
+// and returns a new Cmd. The first function receives nil as its input.
+//
+// This is useful when you need to transform or react to a command's result
+// before deciding what to do next, without going through the Update cycle.
+//
+// Example:
+//
+//	cmd := tea.Chain(
+//	    func(msg tea.Msg) tea.Cmd {
+//	        // First step: start an HTTP request
+//	        return fetchData
+//	    },
+//	    func(msg tea.Msg) tea.Cmd {
+//	        // Second step: msg contains the result of fetchData
+//	        resp := msg.(fetchResponseMsg)
+//	        return processData(resp)
+//	    },
+//	    func(msg tea.Msg) tea.Cmd {
+//	        // Third step: msg contains the result of processData
+//	        return func() tea.Msg { return doneMsg{} }
+//	    },
+//	)
+func Chain(steps ...func(Msg) Cmd) Cmd {
+	if len(steps) == 0 {
+		return nil
+	}
+	return func() Msg {
+		var msg Msg
+		for _, step := range steps {
+			cmd := step(msg)
+			if cmd == nil {
+				msg = nil
+				continue
+			}
+			msg = cmd()
+		}
+		return msg
+	}
+}
+
 type windowSizeMsg struct{}
 
 // RequestWindowSize is a command that queries the terminal for its current

--- a/commands_test.go
+++ b/commands_test.go
@@ -33,6 +33,69 @@ func TestSequence(t *testing.T) {
 	testMultipleCommands[sequenceMsg](t, Sequence)
 }
 
+func TestChain(t *testing.T) {
+	t.Run("empty chain returns nil", func(t *testing.T) {
+		cmd := Chain()
+		if cmd != nil {
+			t.Fatalf("expected nil, got %+v", cmd)
+		}
+	})
+
+	t.Run("single step receives nil and returns msg", func(t *testing.T) {
+		cmd := Chain(func(msg Msg) Cmd {
+			if msg != nil {
+				t.Fatalf("expected nil input, got %+v", msg)
+			}
+			return func() Msg { return "hello" }
+		})
+		result := cmd()
+		if result != "hello" {
+			t.Fatalf("expected 'hello', got %+v", result)
+		}
+	})
+
+	t.Run("chains multiple steps passing msgs through", func(t *testing.T) {
+		cmd := Chain(
+			func(msg Msg) Cmd {
+				return func() Msg { return 1 }
+			},
+			func(msg Msg) Cmd {
+				n := msg.(int)
+				return func() Msg { return n + 10 }
+			},
+			func(msg Msg) Cmd {
+				n := msg.(int)
+				return func() Msg { return n * 2 }
+			},
+		)
+		result := cmd()
+		if result != 22 {
+			t.Fatalf("expected 22, got %+v", result)
+		}
+	})
+
+	t.Run("nil cmd in middle passes nil to next step", func(t *testing.T) {
+		cmd := Chain(
+			func(msg Msg) Cmd {
+				return func() Msg { return "first" }
+			},
+			func(msg Msg) Cmd {
+				return nil // nil command
+			},
+			func(msg Msg) Cmd {
+				if msg != nil {
+					t.Fatalf("expected nil after nil cmd, got %+v", msg)
+				}
+				return func() Msg { return "recovered" }
+			},
+		)
+		result := cmd()
+		if result != "recovered" {
+			t.Fatalf("expected 'recovered', got %+v", result)
+		}
+	})
+}
+
 func testMultipleCommands[T ~[]Cmd](t *testing.T, createFn func(cmd ...Cmd) Cmd) {
 	t.Run("nil cmd", func(t *testing.T) {
 		if b := createFn(nil); b != nil {


### PR DESCRIPTION
## Summary
- Adds a `Chain()` helper function that pipes the output of each command as input to the next step
- Unlike `Sequence`, which runs commands in order and sends each result to `Update` independently, `Chain` passes each command's resulting `Msg` to the next function in the chain
- The final `Msg` is sent to `Update`, enabling multi-step command pipelines without intermediate Update cycles
- Includes comprehensive tests for empty chains, single steps, multi-step pipelines, and nil command handling

## Test plan
- [x] Unit tests for empty chain (returns nil)
- [x] Unit tests for single step (receives nil input, returns msg)
- [x] Unit tests for multi-step chaining (msgs passed through correctly)
- [x] Unit tests for nil cmd in middle of chain (passes nil to next step)
- [x] All existing tests still pass

Closes #984