### PR TITLE
feat: add Fatal() command for error exit with stderr output

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -163,6 +163,43 @@ func Tick(d time.Duration, fn func(time.Time) Msg) Cmd {
 	}
 }
 
+// FatalErrMsg is a message that, when received by the runtime, causes the
+// program to exit with a non-zero status code. The error message will be
+// written to stderr after the program restores the terminal state. You can send
+// a FatalErrMsg with [Fatal].
+type FatalErrMsg struct {
+	// Err is the error that caused the fatal exit.
+	Err error
+}
+
+// Error returns the error message.
+func (f FatalErrMsg) Error() string {
+	return f.Err.Error()
+}
+
+// Fatal is a command that tells the program to exit with a non-zero status code
+// and write the given error to stderr. The terminal will be properly restored
+// before the error is printed.
+//
+// This is useful when a model encounters an unrecoverable error and wants to
+// communicate that error to the user while ensuring the terminal is left in a
+// clean state.
+//
+// Example:
+//
+//	func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+//	    data, err := loadCriticalData()
+//	    if err != nil {
+//	        return m, tea.Fatal(err)
+//	    }
+//	    return m, nil
+//	}
+func Fatal(err error) Cmd {
+	return func() Msg {
+		return FatalErrMsg{Err: err}
+	}
+}
+
 type windowSizeMsg struct{}
 
 // RequestWindowSize is a command that queries the terminal for its current

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,6 +1,7 @@
 package tea
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -23,6 +24,24 @@ func TestTick(t *testing.T) {
 	if expected != msg {
 		t.Fatalf("expected a msg %v but got %v", expected, msg)
 	}
+}
+
+func TestFatal(t *testing.T) {
+	t.Run("creates FatalErrMsg with error", func(t *testing.T) {
+		err := fmt.Errorf("something went wrong")
+		cmd := Fatal(err)
+		msg := cmd()
+		fatalMsg, ok := msg.(FatalErrMsg)
+		if !ok {
+			t.Fatalf("expected FatalErrMsg, got %T", msg)
+		}
+		if fatalMsg.Err != err {
+			t.Fatalf("expected error %v, got %v", err, fatalMsg.Err)
+		}
+		if fatalMsg.Error() != "something went wrong" {
+			t.Fatalf("expected error string 'something went wrong', got %q", fatalMsg.Error())
+		}
+	})
 }
 
 func TestBatch(t *testing.T) {

--- a/tea.go
+++ b/tea.go
@@ -749,6 +749,9 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			case InterruptMsg:
 				return model, ErrInterrupted
 
+			case FatalErrMsg:
+				return model, msg
+
 			case SuspendMsg:
 				if suspendSupported {
 					p.suspend()


### PR DESCRIPTION
## Summary
- Adds `FatalErrMsg` type and `Fatal(err)` command that allows models to signal unrecoverable errors
- When the runtime receives a `FatalErrMsg`, it exits the event loop with the error, ensuring terminal state is properly restored first
- Callers of `Program.Run()` can inspect the returned error (which will be a `FatalErrMsg` implementing the `error` interface) and write it to stderr with a non-zero exit code
- Includes unit tests for the new command and message type

## Example usage
```go
func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
    data, err := loadCriticalData()
    if err != nil {
        return m, tea.Fatal(err)
    }
    return m, nil
}

// In main:
m, err := p.Run()
if err != nil {
    if fatal, ok := err.(tea.FatalErrMsg); ok {
        fmt.Fprintln(os.Stderr, fatal)
        os.Exit(1)
    }
}
```

## Test plan
- [x] Unit test for FatalErrMsg creation and Error() method
- [x] FatalErrMsg is handled in the event loop and causes program exit
- [x] All existing tests still pass

Closes #980