### PR TITLE
feat: add WithSIGQUITDump option for goroutine stack dumps

### DIFF
--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package tea
 import (
 	"context"
 	"io"
+	"os"
 	"sync/atomic"
 
 	"github.com/charmbracelet/colorprofile"
@@ -153,6 +154,23 @@ func WithFPS(fps int) ProgramOption {
 func WithColorProfile(profile colorprofile.Profile) ProgramOption {
 	return func(p *Program) {
 		p.profile = &profile
+	}
+}
+
+// WithSIGQUITDump enables writing a goroutine stack dump to the given file
+// when SIGQUIT is received. By default, Bubble Tea captures all signals and
+// SIGQUIT's normal behavior of printing a goroutine dump is suppressed. This
+// option restores that behavior by writing all goroutine stacks to the
+// specified file (typically os.Stderr).
+//
+// On Windows this option is a no-op since SIGQUIT is not available.
+//
+// Example:
+//
+//	p := tea.NewProgram(model, tea.WithSIGQUITDump(os.Stderr))
+func WithSIGQUITDump(w *os.File) ProgramOption {
+	return func(p *Program) {
+		p.sigquitDumpFile = w
 	}
 }
 

--- a/sigquit_unix.go
+++ b/sigquit_unix.go
@@ -1,0 +1,40 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix || zos
+
+package tea
+
+import (
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+)
+
+// handleSIGQUIT listens for SIGQUIT and writes a goroutine dump to the given
+// writer. This restores the default Go runtime behavior of dumping all
+// goroutines on SIGQUIT, which is normally suppressed when Bubble Tea captures
+// signals.
+func (p *Program) handleSIGQUIT(w *os.File) chan struct{} {
+	ch := make(chan struct{})
+
+	go func() {
+		sig := make(chan os.Signal, 1)
+		signal.Notify(sig, syscall.SIGQUIT)
+		defer func() {
+			signal.Stop(sig)
+			close(ch)
+		}()
+
+		for {
+			select {
+			case <-p.ctx.Done():
+				return
+			case <-sig:
+				buf := make([]byte, 1<<20) // 1 MB buffer
+				n := runtime.Stack(buf, true)
+				_, _ = w.Write(buf[:n])
+			}
+		}
+	}()
+
+	return ch
+}

--- a/sigquit_windows.go
+++ b/sigquit_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package tea
+
+import "os"
+
+// handleSIGQUIT is a no-op on Windows since SIGQUIT is not available.
+func (p *Program) handleSIGQUIT(_ *os.File) chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/tea.go
+++ b/tea.go
@@ -512,6 +512,10 @@ type Program struct {
 	// modes keeps track of terminal modes that have been enabled or disabled.
 	ignoreSignals uint32
 
+	// sigquitDumpFile, when set, enables writing goroutine stack dumps to
+	// this file on SIGQUIT.
+	sigquitDumpFile *os.File
+
 	// ticker is the ticker that will be used to write to the renderer.
 	ticker *time.Ticker
 
@@ -996,6 +1000,11 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 			}
 			p.input = ttyIn
 		}
+	}
+
+	// Handle SIGQUIT for goroutine dumps if enabled.
+	if p.sigquitDumpFile != nil {
+		p.handlers.add(p.handleSIGQUIT(p.sigquitDumpFile))
 	}
 
 	// Handle signals.


### PR DESCRIPTION
Adds a WithSIGQUITDump(file) program option that restores the ability to get goroutine stack dumps via SIGQUIT. By default, Bubble Tea captures all signals and suppresses SIGQUIT. This option registers a separate SIGQUIT handler that writes all goroutine stacks to the specified file (typically os.Stderr) without terminating the program.

On Windows this is a no-op since SIGQUIT is not available.

Closes #498