### PR TITLE
feat: add WithoutSkipping option to disable frame skipping

### DIFF
--- a/options.go
+++ b/options.go
@@ -156,6 +156,24 @@ func WithColorProfile(profile colorprofile.Profile) ProgramOption {
 	}
 }
 
+// WithoutSkipping disables frame skipping in the renderer. By default, the
+// renderer operates at a fixed FPS (default 60) and only the most recent view
+// is rendered on each tick. This means that if multiple updates occur between
+// ticks, intermediate frames are skipped.
+//
+// When this option is enabled, every call to View() will be immediately flushed
+// to the terminal. This is useful for programs where every frame matters, such
+// as animations or programs with very infrequent updates where latency is more
+// important than performance.
+//
+// Note that this may reduce performance for programs with very frequent updates
+// since every update triggers an immediate render.
+func WithoutSkipping() ProgramOption {
+	return func(p *Program) {
+		p.disableSkipping = true
+	}
+}
+
 // WithWindowSize sets the initial size of the terminal window. This is useful
 // when you need to set the initial size of the terminal window, for example
 // during testing or when you want to run your program in a non-interactive

--- a/tea.go
+++ b/tea.go
@@ -512,6 +512,11 @@ type Program struct {
 	// modes keeps track of terminal modes that have been enabled or disabled.
 	ignoreSignals uint32
 
+	// disableSkipping, when true, causes the renderer to flush immediately
+	// after every render instead of waiting for the next tick. This ensures
+	// every frame is displayed.
+	disableSkipping bool
+
 	// ticker is the ticker that will be used to write to the renderer.
 	ticker *time.Ticker
 
@@ -867,6 +872,12 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 func (p *Program) render(model Model) {
 	if p.renderer != nil {
 		p.renderer.render(model.View()) // send view to renderer
+		if p.disableSkipping {
+			// When frame skipping is disabled, flush immediately after each
+			// render to ensure every frame is displayed.
+			_ = p.flush()
+			_ = p.renderer.flush(false)
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a WithoutSkipping() program option that disables the renderer's frame skipping. By default the renderer only flushes at FPS intervals, dropping intermediate frames. With this option, every Update that produces a new view is immediately flushed to the terminal.

Useful for animations or programs with infrequent updates where latency matters more than throughput.

Closes #1501