### PR TITLE
fix(examples): resolve nil pointer dereference

### DIFF
--- a/examples/textarea/main.go
+++ b/examples/textarea/main.go
@@ -92,10 +92,12 @@ func (m model) View() tea.View {
 	if !m.textarea.VirtualCursor() {
 		c = m.textarea.Cursor()
 
-		// Set the y offset of the cursor based on the position of the textarea
-		// in the application.
-		offset := lipgloss.Height(m.headerView())
-		c.Y += offset
+		if c != nil {
+			// Set the y offset of the cursor based on the position of the textarea
+			// in the application.
+			offset := lipgloss.Height(m.headerView())
+			c.Y += offset
+		}
 	}
 
 	f := strings.Join([]string{


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

Fixes a nil pointer dereference panic in this example when you hit "escape", which de-focuses the textarea, so it has no cursor!