### PR TITLE
fix: add missing signal.Stop in suspendProcess to prevent signal channel leak

### DIFF
--- a/tty_unix.go
+++ b/tty_unix.go
@@ -40,6 +40,7 @@ const suspendSupported = true
 func suspendProcess() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGCONT)
+	defer signal.Stop(c)
 	_ = syscall.Kill(0, syscall.SIGTSTP)
 	// blocks until a CONT happens...
 	<-c


### PR DESCRIPTION
## Summary

This PR fixes a signal channel leak in `suspendProcess()` in `tty_unix.go`.

## Problem

`suspendProcess()` calls `signal.Notify(c, syscall.SIGCONT)` to wait for SIGCONT after sending SIGTSTP, but never calls `signal.Stop(c)` afterward. Each Ctrl+Z suspend/resume cycle leaks a registered signal channel.

```go
// Before (buggy):
func suspendProcess() {
    c := make(chan os.Signal, 1)
    signal.Notify(c, syscall.SIGCONT)  // registered but never stopped
    _ = syscall.Kill(0, syscall.SIGTSTP)
    <-c
}
```

## Fix

Added `defer signal.Stop(c)` immediately after `signal.Notify`, consistent with how all other signal handlers in the codebase work (`handleSignals` in `tea.go` and `listenForResize` in `signals_unix.go`).

```go
// After (fixed):
func suspendProcess() {
    c := make(chan os.Signal, 1)
    signal.Notify(c, syscall.SIGCONT)
    defer signal.Stop(c)   // properly deregister the channel
    _ = syscall.Kill(0, syscall.SIGTSTP)
    <-c
}
```

Closes #1673