### PR TITLE
fix: avoid Exec restore panic with WithInput(nil)

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -14,9 +14,17 @@ type testExecModel struct {
 	err error
 }
 
+type testExecNoInputModel struct{ testExecModel }
+
 func (m *testExecModel) Init() Cmd {
 	c := exec.Command(m.cmd) //nolint:gosec
 	return ExecProcess(c, func(err error) Msg {
+		return execFinishedMsg{err}
+	})
+}
+
+func (m *testExecNoInputModel) Init() Cmd {
+	return ExecProcess(successExecCommand(), func(err error) Msg {
 		return execFinishedMsg{err}
 	})
 }
@@ -40,6 +48,13 @@ func (m *testExecModel) View() View {
 type spyRenderer struct {
 	renderer
 	calledReset bool
+}
+
+func successExecCommand() *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/c", "exit 0")
+	}
+	return exec.Command("true")
 }
 
 func TestTeaExec(t *testing.T) {
@@ -99,5 +114,22 @@ func TestTeaExec(t *testing.T) {
 				t.Error("expected error, got nil")
 			}
 		})
+	}
+}
+
+func TestTeaExecWithNilInput(t *testing.T) {
+	var buf bytes.Buffer
+
+	m := &testExecNoInputModel{}
+	p := NewProgram(m,
+		WithInput(nil),
+		WithOutput(&buf),
+	)
+
+	if _, err := p.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if m.err != nil {
+		t.Fatalf("expected no error, got %v", m.err)
 	}
 }

--- a/tea.go
+++ b/tea.go
@@ -1347,8 +1347,10 @@ func (p *Program) RestoreTerminal() error {
 	if err := p.initTerminal(); err != nil {
 		return err
 	}
-	if err := p.initInputReader(false); err != nil {
-		return err
+	if p.input != nil {
+		if err := p.initInputReader(false); err != nil {
+			return err
+		}
 	}
 
 	p.startRenderer()


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary

Fix the `WithInput(nil)` + `ExecProcess` panic reported in the `#761` discussion.

## Problem

`#761` recommends `tea.WithInput(nil)` as the workaround when there is no TTY available. That works until a program executes `tea.ExecProcess(...)` and returns to Bubble Tea.

At that point `RestoreTerminal()` always called `initInputReader(false)`, even when input had been explicitly disabled. That rebuilds the cancel reader with `p.input == nil` and panics in `cancelreader`.

Minimal repro:

```go
func (m model) Init() tea.Cmd {
    return tea.ExecProcess(exec.Command("true"), func(err error) tea.Msg {
        return finishedMsg{err}
    })
}

func main() {
    _, err := tea.NewProgram(model{}, tea.WithInput(nil)).Run()
    if err != nil {
        panic(err)
    }
}
```

## Fix

Make `RestoreTerminal()` match the initial startup path in `Run()` and only reinitialize the input reader when `p.input != nil`.

Added `TestTeaExecWithNilInput` to cover the regression.

## Validation

- `go test -run 'TestTeaExec|TestTeaExecWithNilInput' .`
- `go test ./...`
