### PR TITLE
fix(examples): use go.work instead of replace directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 .envrc
+go.work
+go.work.sum
 
 examples/fullscreen/fullscreen
 examples/help/help

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -2,8 +2,6 @@ module examples
 
 go 1.25.8
 
-replace charm.land/bubbletea/v2 => ../
-
 require (
 	charm.land/bubbles/v2 v2.1.0
 	charm.land/bubbletea/v2 v2.0.2

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,7 @@
 charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
 charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbletea/v2 v2.0.2 h1:4CRtRnuZOdFDTWSff9r8QFt/9+z6Emubz3aDMnf/dx0=
+charm.land/bubbletea/v2 v2.0.2/go.mod h1:3LRff2U4WIYXy7MTxfbAQ+AdfM3D8Xuvz2wbsOD9OHQ=
 charm.land/glamour/v2 v2.0.0 h1:IDBoqLEy7Hdpb9VOXN+khLP/XSxtJy1VsHuW/yF87+U=
 charm.land/glamour/v2 v2.0.0/go.mod h1:kjq9WB0s8vuUYZNYey2jp4Lgd9f4cKdzAw88FZtpj/w=
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=

--- a/go.work.example
+++ b/go.work.example
@@ -1,0 +1,13 @@
+// Copy this file to go.work to develop against the local bubbletea source.
+// go.work and go.work.sum are gitignored.
+//
+// Usage:
+//   cp go.work.example go.work
+//   go run ./examples/simple
+
+go 1.25.8
+
+use (
+	.
+	./examples
+)


### PR DESCRIPTION
The `replace` directive in `examples/go.mod` breaks `go run` when fetching from the module proxy:

```
$ go run charm.land/bubbletea/examples/doom-fire@latest
go: charm.land/bubbletea/examples/doom-fire@latest: The go.mod file for the module
providing named packages contains one or more replace directives. It must not contain
directives that would cause it to be interpreted differently than if it were the main module.
```

Dropped the `replace` and added `go.work.example` instead. Copy it to `go.work` for local dev — same effect, doesn't break remote runs.

Also added `go.work` and `go.work.sum` to `.gitignore`.

Closes #1681