### PR TITLE
fix: suppress View output when executing a subprocess

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -100,6 +100,14 @@ func (c *osExecCommand) SetStderr(w io.Writer) {
 
 // exec runs an ExecCommand and delivers the results to the program as a Msg.
 func (p *Program) exec(c ExecCommand, fn ExecCallback) {
+	// Clear the current view before releasing the terminal so the renderer's
+	// final flush doesn't write the last View() output to stdout. Without
+	// this, the view content leaks to the terminal and persists after the
+	// subprocess exits.
+	if p.renderer != nil {
+		p.renderer.render(View{})
+	}
+
 	if err := p.releaseTerminal(false); err != nil {
 		// If we can't release input, abort.
 		if fn != nil {


### PR DESCRIPTION
## The bug

When `ExecProcess` (or `Exec`) runs a subprocess, the renderer's final flush writes the current `View()` output to stdout before the subprocess takes over. This content persists in the terminal after the subprocess exits.

The existing workaround is to set a `quitting` flag and return `""` from `View()` before returning the `ExecProcess` command (see [this gist](https://gist.github.com/bashbunni/e3306e8633512d8134012028288212db)). This is error-prone and shouldn't be required.

## The fix

Render an empty `View{}` before calling `releaseTerminal` in `exec()`. When `stopRenderer` flushes, the empty view produces no output (the renderer sets frame height to 0 when content is empty). This is the same effect as the manual workaround, applied automatically by the framework.

## Changes

One file: `exec.go`. 5 lines of code added (plus comments).

Compiles, `go test ./...` passes, `go vet` clean.

Fixes #431