### PR TITLE
fix: prevent data race with cursedRenderer.onMouse

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,6 +1,6 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
 
 tasks:
   lint:
@@ -11,4 +11,4 @@ tasks:
   test:
     desc: Run tests
     cmds:
-      - go test ./... {{.CLI_ARGS}}
+      - go test -race -count 4 -cpu 1,4 ./... {{.CLI_ARGS}}

--- a/commands_test.go
+++ b/commands_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestEvery(t *testing.T) {
+	t.Parallel()
 	expected := "every ms"
 	msg := Every(time.Millisecond, func(t time.Time) Msg {
 		return expected
@@ -16,6 +17,7 @@ func TestEvery(t *testing.T) {
 }
 
 func TestTick(t *testing.T) {
+	t.Parallel()
 	expected := "tick"
 	msg := Tick(time.Millisecond, func(t time.Time) Msg {
 		return expected
@@ -26,31 +28,37 @@ func TestTick(t *testing.T) {
 }
 
 func TestBatch(t *testing.T) {
+	t.Parallel()
 	testMultipleCommands[BatchMsg](t, Batch)
 }
 
 func TestSequence(t *testing.T) {
+	t.Parallel()
 	testMultipleCommands[sequenceMsg](t, Sequence)
 }
 
 func testMultipleCommands[T ~[]Cmd](t *testing.T, createFn func(cmd ...Cmd) Cmd) {
 	t.Run("nil cmd", func(t *testing.T) {
+		t.Parallel()
 		if b := createFn(nil); b != nil {
 			t.Fatalf("expected nil, got %+v", b)
 		}
 	})
 	t.Run("empty cmd", func(t *testing.T) {
+		t.Parallel()
 		if b := createFn(); b != nil {
 			t.Fatalf("expected nil, got %+v", b)
 		}
 	})
 	t.Run("single cmd", func(t *testing.T) {
+		t.Parallel()
 		b := createFn(Quit)()
 		if _, ok := b.(QuitMsg); !ok {
 			t.Fatalf("expected a QuitMsg, got %T", b)
 		}
 	})
 	t.Run("mixed nil cmds", func(t *testing.T) {
+		t.Parallel()
 		b := createFn(nil, Quit, nil, Quit, nil, nil)()
 		if l := len(b.(T)); l != 2 {
 			t.Fatalf("expected a []Cmd with len 2, got %d", l)

--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -764,8 +764,14 @@ func (s *cursedRenderer) insertAbove(str string) error {
 
 // onMouse implements renderer.
 func (s *cursedRenderer) onMouse(m MouseMsg) Cmd {
-	if s.lastView != nil && s.lastView.OnMouse != nil {
-		return s.lastView.OnMouse(m)
+	var onMouse func(MouseMsg) Cmd
+	s.mu.Lock()
+	if s.lastView != nil {
+		onMouse = s.lastView.OnMouse
+	}
+	s.mu.Unlock()
+	if onMouse != nil {
+		return onMouse(m)
 	}
 	return nil
 }

--- a/cursed_renderer_test.go
+++ b/cursed_renderer_test.go
@@ -1,0 +1,80 @@
+package tea
+
+import (
+	"fmt"
+	"io"
+	"testing"
+	"time"
+)
+
+type mouseRaceModel struct {
+	i int
+}
+
+func (m *mouseRaceModel) Init() Cmd { return nil }
+
+func (m *mouseRaceModel) Update(msg Msg) (Model, Cmd) {
+	switch msg.(type) {
+	case MouseClickMsg, MouseMotionMsg, MouseWheelMsg:
+		m.i++
+	}
+	return m, nil
+}
+
+func (m *mouseRaceModel) View() View {
+	return View{
+		Content:   fmt.Sprintf("tick-%d\n", m.i),
+		MouseMode: MouseModeCellMotion,
+	}
+}
+
+// Fixes: https://github.com/charmbracelet/bubbletea/issues/1690
+func TestCursedRenderer_mouseVsFlush(t *testing.T) {
+	t.Parallel()
+
+	pr, pw := io.Pipe()
+	defer func() { _ = pw.Close() }()
+
+	m := &mouseRaceModel{}
+	p := NewProgram(
+		m,
+		WithContext(t.Context()),
+		WithInput(pr),
+		WithOutput(io.Discard),
+		WithEnvironment([]string{
+			"TERM=xterm-256color",
+			"TERM_PROGRAM=Apple_Terminal",
+		}),
+		WithoutSignals(),
+		WithWindowSize(80, 24),
+	)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		_, _ = p.Run()
+	}()
+
+	time.Sleep(150 * time.Millisecond)
+
+	const iterations = 100
+	for i := range iterations {
+		switch i % 4 {
+		case 0:
+			p.Send(MouseClickMsg{X: i % 80, Y: i % 24, Button: MouseLeft})
+		case 1:
+			p.Send(MouseMotionMsg{X: i % 80, Y: i % 24})
+		case 2:
+			p.Send(MouseWheelMsg{X: 0, Y: 0, Button: MouseWheelUp})
+		default:
+			p.Send(MouseReleaseMsg{X: i % 80, Y: i % 24, Button: MouseLeft})
+		}
+	}
+
+	p.Quit()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("program did not exit after Quit")
+	}
+}

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
-	github.com/charmbracelet/ultraviolet v0.0.0-20260413133134-73592393e1ad // indirect
+	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/exp/slice v0.0.0-20250327172914-2fdc97757edf // indirect
 	github.com/charmbracelet/x/termios v0.1.1 // indirect
 	github.com/charmbracelet/x/windows v0.2.2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -22,8 +22,8 @@ github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
 github.com/charmbracelet/harmonica v0.2.0 h1:8NxJWRWg/bzKqqEaaeFNipOu77YR5t8aSwG4pgaUBiQ=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
-github.com/charmbracelet/ultraviolet v0.0.0-20260413133134-73592393e1ad h1:kxhuAdAdSGSiAadbEjP7v06nCb17jXjjqF2QOX+0QiE=
-github.com/charmbracelet/ultraviolet v0.0.0-20260413133134-73592393e1ad/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
+github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 h1:Q9fO0y1Zo5KB/5Vu8JZoLGm1N3RzF9bNj3Ao3xoR+Ac=
+github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468/go.mod h1:bAAz7dh/FTYfC+oiHavL4mX1tOIBZ0ZwYjSi3qE6ivM=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/exp/charmtone v0.0.0-20250602192518-9e722df69bbb h1:oTM8tZxV7FY0ehvYjFuICouuhzE08UZYNqUIp/lDQdY=

--- a/exec_test.go
+++ b/exec_test.go
@@ -90,6 +90,7 @@ func TestTeaExec(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			var buf bytes.Buffer
 			var in bytes.Buffer
 
@@ -118,6 +119,7 @@ func TestTeaExec(t *testing.T) {
 }
 
 func TestTeaExecWithNilInput(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 
 	m := &testExecNoInputModel{}

--- a/options_test.go
+++ b/options_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestOptions(t *testing.T) {
 	t.Run("output", func(t *testing.T) {
+		t.Parallel()
 		var b bytes.Buffer
 		p := NewProgram(nil, WithOutput(&b))
 		if f, ok := p.output.(*os.File); ok {
@@ -18,6 +19,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("renderer", func(t *testing.T) {
+		t.Parallel()
 		p := NewProgram(nil, WithoutRenderer())
 		if !p.disableRenderer {
 			t.Errorf("expected renderer to be a nilRenderer, got %v", p.renderer)
@@ -25,6 +27,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("without signals", func(t *testing.T) {
+		t.Parallel()
 		p := NewProgram(nil, WithoutSignals())
 		if atomic.LoadUint32(&p.ignoreSignals) == 0 {
 			t.Errorf("ignore signals should have been set")
@@ -32,6 +35,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("filter", func(t *testing.T) {
+		t.Parallel()
 		p := NewProgram(nil, WithFilter(func(_ Model, msg Msg) Msg { return msg }))
 		if p.filter == nil {
 			t.Errorf("expected filter to be set")
@@ -39,6 +43,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("external context", func(t *testing.T) {
+		t.Parallel()
 		extCtx, extCancel := context.WithCancel(context.Background())
 		defer extCancel()
 
@@ -55,6 +60,7 @@ func TestOptions(t *testing.T) {
 		}
 
 		t.Run("nil input", func(t *testing.T) {
+			t.Parallel()
 			exercise(t, WithInput(nil), func(p *Program) {
 				if !p.disableInput || p.input != nil {
 					t.Errorf("expected input to be disabled, got %v", p.input)
@@ -63,6 +69,7 @@ func TestOptions(t *testing.T) {
 		})
 
 		t.Run("custom input", func(t *testing.T) {
+			t.Parallel()
 			var b bytes.Buffer
 			exercise(t, WithInput(&b), func(p *Program) {
 				if p.input != &b {
@@ -79,6 +86,7 @@ func TestOptions(t *testing.T) {
 		}
 
 		t.Run("without catch panics", func(t *testing.T) {
+			t.Parallel()
 			exercise(t, WithoutCatchPanics(), func(p *Program) {
 				if !p.disableCatchPanics {
 					t.Errorf("expected catch panics to be disabled")
@@ -87,6 +95,7 @@ func TestOptions(t *testing.T) {
 		})
 
 		t.Run("without signal handler", func(t *testing.T) {
+			t.Parallel()
 			exercise(t, WithoutSignalHandler(), func(p *Program) {
 				if !p.disableSignalHandler {
 					t.Errorf("expected signal handler to be disabled")

--- a/screen_test.go
+++ b/screen_test.go
@@ -132,6 +132,7 @@ func TestViewModel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			var buf bytes.Buffer
 			var in bytes.Buffer
 
@@ -179,6 +180,7 @@ func TestClearMsg(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			var buf bytes.Buffer
 			var in bytes.Buffer
 

--- a/tea_test.go
+++ b/tea_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -66,6 +67,7 @@ func (m *testModel) View() View {
 }
 
 func TestTeaModel(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 	in.Write([]byte("q"))
@@ -88,6 +90,7 @@ func TestTeaModel(t *testing.T) {
 }
 
 func TestTeaQuit(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -112,6 +115,7 @@ func TestTeaQuit(t *testing.T) {
 }
 
 func TestTeaWaitQuit(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -165,6 +169,7 @@ func TestTeaWaitQuit(t *testing.T) {
 }
 
 func TestTeaWaitKill(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -218,9 +223,12 @@ func TestTeaWaitKill(t *testing.T) {
 }
 
 func TestTeaWithFilter(t *testing.T) {
-	testTeaWithFilter(t, 0)
-	testTeaWithFilter(t, 1)
-	testTeaWithFilter(t, 2)
+	for _, preventCount := range []uint32{0, 1, 2} {
+		t.Run(fmt.Sprintf("prevent_%d", preventCount), func(t *testing.T) {
+			t.Parallel()
+			testTeaWithFilter(t, preventCount)
+		})
+	}
 }
 
 func testTeaWithFilter(t *testing.T, preventCount uint32) {
@@ -260,6 +268,7 @@ func testTeaWithFilter(t *testing.T, preventCount uint32) {
 }
 
 func TestTeaKill(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -292,6 +301,7 @@ func TestTeaKill(t *testing.T) {
 }
 
 func TestTeaContext(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(t.Context())
 	var buf bytes.Buffer
 	var in bytes.Buffer
@@ -325,6 +335,7 @@ func TestTeaContext(t *testing.T) {
 }
 
 func TestTeaContextImplodeDeadlock(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(t.Context())
 	var buf bytes.Buffer
 	var in bytes.Buffer
@@ -351,6 +362,7 @@ func TestTeaContextImplodeDeadlock(t *testing.T) {
 }
 
 func TestTeaContextBatchDeadlock(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(t.Context())
 	var buf bytes.Buffer
 	var in bytes.Buffer
@@ -386,6 +398,7 @@ func TestTeaContextBatchDeadlock(t *testing.T) {
 }
 
 func TestTeaBatchMsg(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -421,6 +434,7 @@ func TestTeaBatchMsg(t *testing.T) {
 }
 
 func TestTeaSequenceMsg(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -445,6 +459,7 @@ func TestTeaSequenceMsg(t *testing.T) {
 }
 
 func TestTeaSequenceMsgWithBatchMsg(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -472,6 +487,7 @@ func TestTeaSequenceMsgWithBatchMsg(t *testing.T) {
 }
 
 func TestTeaNestedSequenceMsg(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -496,6 +512,7 @@ func TestTeaNestedSequenceMsg(t *testing.T) {
 }
 
 func TestTeaSend(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -517,6 +534,7 @@ func TestTeaSend(t *testing.T) {
 }
 
 func TestTeaNoRun(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -528,6 +546,7 @@ func TestTeaNoRun(t *testing.T) {
 }
 
 func TestTeaPanic(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 
@@ -558,6 +577,7 @@ func TestTeaPanic(t *testing.T) {
 }
 
 func TestTeaGoroutinePanic(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
 	var in bytes.Buffer
 


### PR DESCRIPTION
### Changes in this PR

Fixes a data race in the cursed renderers `OnMouse` handler. Opted to capture just the handler, rather than duplicating the reference to keep the intent clear.

- closes #1690
- Added `-race`, `-count`, and `-cpu` to taskfile. Ideally, more people should run with these tests to help cover more data race testing, flaky tests, as well as tests which may not actually surface issues unless the CPU > 1, and vice versa.
- Added `t.Parallel()` (to root or within `t.Run()`) to **all viable tests** that don't do any global state or similar mutations.
- Fixed `examples/go.mod` & `examples/go.sum` not being in sync, though unrelated to my change.

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).