### PR TITLE
fix: drain pending TTY input on shutdown to prevent DECRPM garbage

### DIFF
--- a/drain_bsd.go
+++ b/drain_bsd.go
@@ -1,0 +1,31 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package tea
+
+import "golang.org/x/sys/unix"
+
+// drainInput discards any pending input on the TTY. It is called during
+// shutdown to remove unsolicited terminal responses (e.g. DECRPM replies to
+// mode 2026/2027 queries) that arrived after the input reader was cancelled.
+// Without this, those bytes are read by the user's shell after exit and
+// printed as garbage characters.
+func (p *Program) drainInput() {
+	if p.ttyInput == nil {
+		return
+	}
+	fd := int(p.ttyInput.Fd())
+	fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}} //nolint:gosec // tty fd never overflows int32
+
+	// Responses can arrive in bursts, so flush, then poll, then flush
+	// again until nothing more arrives within the timeout window.
+	// FREAD (1) tells TIOCFLUSH to discard the read queue only.
+	for {
+		_ = unix.IoctlSetPointerInt(fd, unix.TIOCFLUSH, 1)
+
+		n, err := unix.Poll(fds, drainTimeoutMs)
+		if err != nil || n <= 0 {
+			return
+		}
+	}
+}

--- a/drain_other.go
+++ b/drain_other.go
@@ -1,0 +1,8 @@
+//go:build !windows && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !aix
+// +build !windows,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris,!aix
+
+package tea
+
+// drainInput is a no-op on platforms where we don't have a portable way to
+// discard pending TTY input.
+func (p *Program) drainInput() {}

--- a/drain_posix.go
+++ b/drain_posix.go
@@ -1,0 +1,9 @@
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris || aix
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris aix
+
+package tea
+
+// drainTimeoutMs is how long we wait for additional bytes to arrive after
+// flushing the input buffer. Local terminals reply within microseconds; this
+// budget exists so SSH round-trips don't slip through.
+const drainTimeoutMs = 200

--- a/drain_unix.go
+++ b/drain_unix.go
@@ -1,0 +1,30 @@
+//go:build linux || solaris || aix
+// +build linux solaris aix
+
+package tea
+
+import "golang.org/x/sys/unix"
+
+// drainInput discards any pending input on the TTY. It is called during
+// shutdown to remove unsolicited terminal responses (e.g. DECRPM replies to
+// mode 2026/2027 queries) that arrived after the input reader was cancelled.
+// Without this, those bytes are read by the user's shell after exit and
+// printed as garbage characters.
+func (p *Program) drainInput() {
+	if p.ttyInput == nil {
+		return
+	}
+	fd := int(p.ttyInput.Fd())
+	fds := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}} //nolint:gosec // tty fd never overflows int32
+
+	// Responses can arrive in bursts, so flush, then poll, then flush
+	// again until nothing more arrives within the timeout window.
+	for {
+		_ = unix.IoctlSetInt(fd, unix.TCFLSH, 0) // TCIFLUSH: discard input
+
+		n, err := unix.Poll(fds, drainTimeoutMs)
+		if err != nil || n <= 0 {
+			return
+		}
+	}
+}

--- a/drain_windows.go
+++ b/drain_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+// +build windows
+
+package tea
+
+import "golang.org/x/sys/windows"
+
+// drainInput discards any pending console input events to remove unsolicited
+// terminal responses that arrived after the input reader was cancelled.
+// Without this, those bytes can be read by the user's shell after exit and
+// printed as garbage characters.
+func (p *Program) drainInput() {
+	if p.ttyInput == nil {
+		return
+	}
+	_ = windows.FlushConsoleInputBuffer(windows.Handle(p.ttyInput.Fd()))
+}

--- a/tty.go
+++ b/tty.go
@@ -34,6 +34,14 @@ func (p *Program) restoreTerminalState() error {
 	// Flush queued commands.
 	_ = p.flush()
 
+	// Drain any pending terminal responses from the TTY input buffer before
+	// restoring it. The program may have sent capability queries (e.g.
+	// DECRQM for modes 2026/2027) whose responses arrive asynchronously and
+	// were not consumed by the cancelled input reader. Without this, those
+	// bytes are read by the user's shell after exit and printed as garbage
+	// characters. See issue #1590.
+	p.drainInput()
+
 	return p.restoreInput()
 }
 


### PR DESCRIPTION
Fixes #1590.

## Background

During init, bubbletea queries the terminal for synchronized output (mode 2026) and unicode core (mode 2027) support:

```go
p.execute(ansi.RequestModeSynchronizedOutput +
    ansi.RequestModeUnicodeCore)
```

The terminal replies asynchronously with `DECRPM` reports. The input reader normally consumes them, but in very short-lived programs, the replies can land after the reader has been cancelled and before the TTY is restored. The bytes then sit in the kernel TTY input queue and get read by the user's shell after the process exits, showing up as:

```
^[[?2026;2$y^[[?2027;1$y
```

Several people have hit this — it surfaces with the `huh` spinner once the action is fast, and with the `package-manager` example at low random delays. It's also reproducible on Ghostty / Windows Terminal / Wezterm + zsh/nushell with the small repro in the issue.

## Fix

Add a per-platform `drainInput()` and call it from `restoreTerminalState` right before we hand the TTY back to the shell:

| platform | call |
| --- | --- |
| linux / solaris / aix | `ioctl(fd, TCFLSH, TCIFLUSH)` |
| darwin / dragonfly / freebsd / netbsd / openbsd | `ioctl(fd, TIOCFLUSH, &FREAD)` |
| windows | `FlushConsoleInputBuffer` |
| anything else | no-op |

On unix the call sits in a flush-then-poll loop with a 200 ms budget. Local terminals reply within microseconds and the loop exits on the first iteration; the budget exists so SSH round-trips (which often deliver replies in bursts after the first flush) don't slip through. The output flush in `restoreTerminalState` is preserved so renderer reset sequences still make it out.

## Verification

- `go test -race ./...` passes locally on linux/amd64.
- `go vet ./...` clean.
- `golangci-lint run` clean for linux, darwin, freebsd, openbsd, netbsd, dragonfly, windows.
- Cross-compile (`CGO_ENABLED=0`) succeeds on linux (amd64/arm64/arm/mips/mips64/ppc64/riscv64/s390x), darwin (amd64/arm64), freebsd, openbsd, netbsd, dragonfly, solaris, windows. AIX fails on an unrelated `ultraviolet` symbol (`termios.GetWinsize`), not on this change.
- Repro behavior:
  - I ran the issue's repro under a PTY harness that delays the DECRPM replies until the program is mid-shutdown. With debug instrumentation in `drainInput` I observed the second iteration finding 22 bytes pending (the two DECRPM replies) and discarding them, then the poll timing out so the loop exits cleanly. Without the fix those 22 bytes remain in the slave's input queue.

## Notes

- The `restoreTerminalState` path is also reached via `releaseTerminal` (used by `Suspend`/`Kill`/`ReleaseTerminal`), so the drain runs there too — same race, same fix.
- I deliberately kept the loop bounded by `Poll` returning `<= 0` rather than a fixed iteration count: if a misbehaving terminal somehow streams data forever the worst case is one extra 200 ms wait per iteration, which is still bounded by the read traffic actually being there.