### PR TITLE
chore: remove deprecated windows note

### DIFF
--- a/screen.go
+++ b/screen.go
@@ -3,9 +3,7 @@ package tea
 import "github.com/charmbracelet/x/ansi"
 
 // WindowSizeMsg is used to report the terminal size. It's sent to Update once
-// initially and then on every terminal resize. Note that Windows does not
-// have support for reporting when resizes occur as it does not support the
-// SIGWINCH signal.
+// initially and then on every terminal resize.
 type WindowSizeMsg struct {
 	Width  int
 	Height int


### PR DESCRIPTION
I'm not sure if this is no longer an issue for all windows versions or just windows 10 & 11. I can only confirm 10 & 11. Let me know if there are any other considerations that need to be added or if we can just remove the note entirely, like I've done.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [x] This pull request was approved to be created from a Discord conversation.

