### PR TITLE
fix: prevent data race when Kill() is called shortly after Run()

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -993,16 +993,23 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 		return nil, errors.New("bubbletea: InitialModel cannot be nil")
 	}
 
-	// Initialize context and teardown channel.
-	p.handlers = channelHandlers{}
-	cmds := make(chan Cmd)
-
 	p.finished = make(chan struct{})
 	defer func() {
 		close(p.finished)
 	}()
 
 	defer p.cancel()
+
+	// If the context has already been cancelled (e.g. Kill() was
+	// called before Run()), return early without initializing the
+	// terminal.
+	if p.ctx.Err() != nil {
+		return p.initialModel, ErrProgramKilled
+	}
+
+	// Initialize context and teardown channel.
+	p.handlers = channelHandlers{}
+	cmds := make(chan Cmd)
 
 	if p.disableInput {
 		p.input = nil
@@ -1202,7 +1209,7 @@ func (p *Program) Quit() {
 // The final render that you would normally see when quitting will be skipped.
 // [program.Run] returns a [ErrProgramKilled] error.
 func (p *Program) Kill() {
-	p.shutdown(true)
+	p.cancel()
 }
 
 // Wait waits/blocks until the underlying Program finished shutting down.

--- a/tea_test.go
+++ b/tea_test.go
@@ -649,3 +649,27 @@ func BenchmarkTeaRun(b *testing.B) {
 		_ = r.CloseWithError(io.EOF)
 	}
 }
+
+func TestKillDuringStartupRace(t *testing.T) {
+	for range 100 {
+		p := NewProgram(&testModel{},
+			WithInput(bytes.NewBuffer(nil)),
+			WithOutput(io.Discard),
+			WithoutSignals(),
+		)
+
+		done := make(chan struct{})
+		go func() {
+			_, _ = p.Run()
+			close(done)
+		}()
+
+		p.Kill()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("program did not stop")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `Kill()` now calls `cancel()` instead of `shutdown()` directly, preventing data races on `handlers`, `cancelReader`, and `renderer` when `shutdown()` reads fields that `Run()` is still initializing
- `Run()` checks `ctx.Err()` before terminal initialization, so calling `Kill()` before `Run()` finishes returns `ErrProgramKilled` cleanly
- Adds `TestKillDuringStartupRace` (100 iterations of Kill-during-Run) to cover the fix

Fixes #1689

## Test plan

- [x] `go test -race -v ./...` passes, including `TestKillDuringStartupRace`
- [x] `channelHandlers.shutdown()` on zero-value is safe (no-op)
- [x] Kill() remains async, matching existing API contract