### PR TITLE
perf: Throttle message handling to reduce CPU load

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -887,8 +887,6 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			select {
 			case <-p.ctx.Done():
 				return model, nil
-			case err := <-p.errs:
-				return model, err
 			case p.rendererRequest <- struct{}{}:
 			}
 		}
@@ -1274,7 +1272,6 @@ func (p *Program) shutdown(kill bool) {
 		}
 
 		if p.renderer != nil {
-			close(p.rendererRequest)
 			p.stopRenderer(kill)
 		}
 
@@ -1424,17 +1421,31 @@ func (p *Program) startRenderer() {
 
 	// Start the renderer.
 	p.renderer.start()
+
 	go func() {
 		for {
+			// Flush buffered rendererRequest messages limited to this frame.
+		FlushRequests:
+			for {
+				select {
+				case <-p.rendererDone:
+					p.ticker.Stop()
+					return
+				case _ = <-p.rendererRequest:
+				case <-p.ticker.C:
+					break FlushRequests
+				}
+			}
+
+			_ = p.flush()
+			_ = p.renderer.flush(false)
+
+			// Wait until next frame.
 			select {
 			case <-p.rendererDone:
 				p.ticker.Stop()
 				return
-
 			case <-p.ticker.C:
-				_ = <-p.rendererRequest
-				_ = p.flush()
-				_ = p.renderer.flush(false)
 			}
 		}
 	}()

--- a/tea.go
+++ b/tea.go
@@ -534,6 +534,10 @@ type Program struct {
 	// ticker is the ticker that will be used to write to the renderer.
 	ticker *time.Ticker
 
+	// rendererRequest is used to request the renderer goroutine to flush the frame.
+	// It is always a 1 element channel.
+	rendererRequest chan struct{}
+
 	// once is used to stop the renderer.
 	once sync.Once
 
@@ -751,7 +755,6 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 
 		case msg := <-p.msgs:
 			msg = p.translateInputEvent(msg)
-
 			// Filter messages.
 			if p.filter != nil {
 				msg = p.filter(model, msg)
@@ -878,6 +881,16 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			}
 
 			p.render(model) // render view
+
+			// Send to p.rendererRequest. This may block
+			// until the renderer goroutine in startRenderer flushes output.
+			select {
+			case <-p.ctx.Done():
+				return model, nil
+			case err := <-p.errs:
+				return model, err
+			case p.rendererRequest <- struct{}{}:
+			}
 		}
 	}
 }
@@ -1103,6 +1116,10 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 		}
 	}
 
+	// Initialize p.rendererRequest to a size 1 channel so that
+	// successive render requests can be blocked until flushed
+	p.rendererRequest = make(chan struct{}, 1)
+
 	// Start the renderer.
 	p.startRenderer()
 
@@ -1257,6 +1274,7 @@ func (p *Program) shutdown(kill bool) {
 		}
 
 		if p.renderer != nil {
+			close(p.rendererRequest)
 			p.stopRenderer(kill)
 		}
 
@@ -1414,6 +1432,7 @@ func (p *Program) startRenderer() {
 				return
 
 			case <-p.ticker.C:
+				_ = <-p.rendererRequest
 				_ = p.flush()
 				_ = p.renderer.flush(false)
 			}


### PR DESCRIPTION
This PR throttles the amount of messages handled by the event loop such that processing can occur in a maximum of one frame tick.

In the latest crush version (v0.67), whenever crush displays the loading animation or shows the tokens generated by a request, it always takes up one entire CPU core doing so. I was able to reduce the CPU load down to a maximum of around 3% with this patch.

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
