### PR TITLE
docs: fix Init signature and Cmd usage in godoc examples

### DIFF
--- a/color.go
+++ b/color.go
@@ -54,8 +54,8 @@ func (e ForegroundColorMsg) IsDark() bool {
 // [BackgroundColorMsg.IsDark] to determine if the color is dark or light. For
 // example:
 //
-//	func (m Model) Init() (Model, Cmd) {
-//	  return m, RequestBackgroundColor()
+//	func (m Model) Init() Cmd {
+//	  return RequestBackgroundColor
 //	}
 //
 //	func (m Model) Update(msg Msg) (Model, Cmd) {
@@ -63,6 +63,7 @@ func (e ForegroundColorMsg) IsDark() bool {
 //	  case BackgroundColorMsg:
 //	      m.styles = newStyles(msg.IsDark())
 //	  }
+//	  return m, nil
 //	}
 type BackgroundColorMsg struct{ color.Color }
 

--- a/commands.go
+++ b/commands.go
@@ -9,8 +9,8 @@ import (
 //
 // Example:
 //
-//	    func (m model) Init() (Model, Cmd) {
-//		       return m, tea.Batch(someCommand, someOtherCommand)
+//	    func (m model) Init() Cmd {
+//		       return tea.Batch(someCommand, someOtherCommand)
 //	    }
 func Batch(cmds ...Cmd) Cmd {
 	return compactCmds[BatchMsg](cmds)
@@ -84,9 +84,9 @@ func compactCmds[T ~[]Cmd](cmds []Cmd) Cmd {
 //	    })
 //	}
 //
-//	func (m model) Init() (Model, Cmd) {
+//	func (m model) Init() Cmd {
 //	    // Start ticking.
-//	    return m, tickEvery()
+//	    return tickEvery()
 //	}
 //
 //	func (m model) Update(msg Msg) (Model, Cmd) {
@@ -138,9 +138,9 @@ func Every(duration time.Duration, fn func(time.Time) Msg) Cmd {
 //	    })
 //	}
 //
-//	func (m model) Init() (Model, Cmd) {
+//	func (m model) Init() Cmd {
 //	    // Start ticking.
-//	    return m, doTick()
+//	    return doTick()
 //	}
 //
 //	func (m model) Update(msg Msg) (Model, Cmd) {


### PR DESCRIPTION
Hit the BackgroundColorMsg example doc and noticed it wouldn't compile against v2:

```go
func (m Model) Init() (Model, Cmd) {
  return m, RequestBackgroundColor()
}
```

Two issues. The Model.Init signature is `Init() Cmd` now (single return, like all the examples in examples/), and `RequestBackgroundColor()` returns a Msg, not a Cmd, so it won't even type-check as the second return. `RequestBackgroundColor` (no parens) is itself the Cmd to hand back.

Same stale `(Model, Cmd)` Init signature showed up in three doc examples in commands.go (Batch, Every, Tick). Updated all four. While in there added the missing `return m, nil` on the BackgroundColorMsg Update example's fall-through path.

Sanity-checked by pasting the fixed BackgroundColorMsg snippet into a fresh `tea.Model` implementation against v2.0.6 and confirming `go build` is clean.