### PR TITLE
docs: add readmes for examples

### DIFF
--- a/examples/autocomplete/README.md
+++ b/examples/autocomplete/README.md
@@ -1,0 +1,4 @@
+# Autocomplete
+
+The `autocomplete` example fetches Charm repositories from the GitHub API and
+uses them as suggestions in a `textinput` bubble.

--- a/examples/cellbuffer/README.md
+++ b/examples/cellbuffer/README.md
@@ -1,0 +1,4 @@
+# Cellbuffer
+
+The `cellbuffer` example draws and animates an ellipse on a cellular grid using
+window size and mouse input.

--- a/examples/eyes/README.md
+++ b/examples/eyes/README.md
@@ -1,0 +1,4 @@
+# Eyes
+
+The `eyes` example renders a pair of blinking eyes and updates the drawing when
+the terminal window changes size.

--- a/examples/file-picker/README.md
+++ b/examples/file-picker/README.md
@@ -1,0 +1,4 @@
+# File Picker
+
+The `file-picker` example shows how to use the file picker bubble to browse for
+files and handle disabled file selections.

--- a/examples/focus-blur/README.md
+++ b/examples/focus-blur/README.md
@@ -1,0 +1,4 @@
+# Focus Blur
+
+The `focus-blur` example demonstrates focus and blur reporting with
+`tea.FocusMsg`, `tea.BlurMsg`, and the `ReportFocus` view option.

--- a/examples/mouse/README.md
+++ b/examples/mouse/README.md
@@ -1,0 +1,4 @@
+# Mouse
+
+The `mouse` example enables mouse tracking and prints mouse coordinates and
+events from `tea.MouseMsg`.

--- a/examples/prevent-quit/README.md
+++ b/examples/prevent-quit/README.md
@@ -1,0 +1,4 @@
+# Prevent Quit
+
+The `prevent-quit` example demonstrates how to intercept quit events with
+`tea.WithFilter` when there are unsaved changes.

--- a/examples/set-window-title/README.md
+++ b/examples/set-window-title/README.md
@@ -1,0 +1,4 @@
+# Set Window Title
+
+The `set-window-title` example shows how to set the terminal window title from
+a Bubble Tea view.

--- a/examples/suspend/README.md
+++ b/examples/suspend/README.md
@@ -1,0 +1,4 @@
+# Suspend
+
+The `suspend` example demonstrates suspending, resuming, interrupting, and
+quitting a Bubble Tea program.

--- a/examples/table-resize/README.md
+++ b/examples/table-resize/README.md
@@ -1,0 +1,4 @@
+# Table Resize
+
+The `table-resize` example shows a table that responds to terminal resize
+events and updates its rendered width and height.


### PR DESCRIPTION
## Summary

- add example-specific README files for ten example directories listed in #1574
- describe what each example demonstrates without adding generated assets

Fixes #1574.

## Tests

- go test ./...
- (cd examples && go test ./...)