### PR TITLE
fix: downsample insertAbove content to the color profile

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -712,6 +712,17 @@ func (s *cursedRenderer) insertAbove(str string) error {
 		return nil
 	}
 
+	if s.profile != colorprofile.TrueColor {
+		// Downsample the queued content to the renderer's color profile,
+		// matching what the screen renderer does for view content. Only the
+		// message content goes through the writer; the cursor movements
+		// composed below must reach the terminal untouched.
+		var conv strings.Builder
+		cw := colorprofile.Writer{Forward: &conv, Profile: s.profile}
+		_, _ = cw.WriteString(str) // writing to a strings.Builder cannot fail
+		str = conv.String()
+	}
+
 	var sb strings.Builder
 	w, h := s.cellbuf.Width(), s.cellbuf.Height()
 	_, y := s.scr.Position()

--- a/cursed_renderer_test.go
+++ b/cursed_renderer_test.go
@@ -1,10 +1,14 @@
 package tea
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/colorprofile"
 )
 
 type mouseRaceModel struct {
@@ -77,4 +81,46 @@ func TestCursedRenderer_mouseVsFlush(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("program did not exit after Quit")
 	}
+}
+
+// Fixes: https://github.com/charmbracelet/bubbletea/issues/1709
+func TestCursedRenderer_insertAboveDownsamples(t *testing.T) {
+	t.Parallel()
+
+	const colored = "println: \x1b[38;2;255;0;0mred\x1b[m"
+	env := []string{"TERM=xterm-256color"}
+
+	t.Run("ascii", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		s := newCursedRenderer(&buf, env, 80, 24)
+		s.setColorProfile(colorprofile.Ascii)
+
+		if err := s.insertAbove(colored); err != nil {
+			t.Fatal(err)
+		}
+		out := buf.String()
+		if strings.Contains(out, "\x1b[38;2;255;0;0m") {
+			t.Errorf("insertAbove kept a color the profile cannot display: %q", out)
+		}
+		if !strings.Contains(out, "red") {
+			t.Errorf("insertAbove dropped message content: %q", out)
+		}
+	})
+
+	t.Run("truecolor", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		s := newCursedRenderer(&buf, env, 80, 24)
+		s.setColorProfile(colorprofile.TrueColor)
+
+		if err := s.insertAbove(colored); err != nil {
+			t.Fatal(err)
+		}
+		if out := buf.String(); !strings.Contains(out, "\x1b[38;2;255;0;0mred") {
+			t.Errorf("insertAbove altered content the profile can display: %q", out)
+		}
+	})
 }


### PR DESCRIPTION
### Changes in this PR

Content delivered through `tea.Println` / `Program.Println` reached the terminal verbatim, bypassing the color-profile downsampling that view content gets through the screen renderer. Under `NO_COLOR` (or a 16-color/ascii profile) the live view obeyed the profile while every line committed to scrollback kept its original colors.

This routes the queued content through a `colorprofile.Writer` in `insertAbove` before the insert sequence is composed, so message colors degrade the same way view colors do. The cursor movements composed around the content are untouched, and the `TrueColor` case skips the conversion entirely since the writer is a passthrough there.

- closes #1709
- Added a regression test covering both the ascii (downsampled) and truecolor (passthrough) cases; the ascii case fails on `main`.

---

- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).