### PR TITLE
fix: guard ProgressBarState string conversion

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -319,13 +319,17 @@ const (
 
 // String return a human-readable value for the given [ProgressBarState].
 func (s ProgressBarState) String() string {
-	return [...]string{
+	names := [...]string{
 		"None",
 		"Default",
 		"Error",
 		"Indeterminate",
 		"Warning",
-	}[s]
+	}
+	if s < 0 || int(s) >= len(names) {
+		return fmt.Sprintf("ProgressBarState(%d)", s)
+	}
+	return names[s]
 }
 
 // ProgressBar represents the terminal progress bar.

--- a/tea_test.go
+++ b/tea_test.go
@@ -30,6 +30,34 @@ type testModel struct {
 	counter  atomic.Value
 }
 
+func TestProgressBarStateString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		state ProgressBarState
+		want  string
+	}{
+		{ProgressBarNone, "None"},
+		{ProgressBarDefault, "Default"},
+		{ProgressBarError, "Error"},
+		{ProgressBarIndeterminate, "Indeterminate"},
+		{ProgressBarWarning, "Warning"},
+		{ProgressBarState(-1), "ProgressBarState(-1)"},
+		{ProgressBarState(5), "ProgressBarState(5)"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.state.String(); got != tt.want {
+				t.Fatalf("ProgressBarState(%d).String() = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
 func (m *testModel) Init() Cmd {
 	return nil
 }


### PR DESCRIPTION
## Summary
- return a safe fallback for unknown ProgressBarState values instead of panicking
- cover valid and out-of-range ProgressBarState.String values

## Tests
- go test -run '^TestProgressBarStateString$' -count=1 .\n- go test ./...\n\nFixes #1711