### PR TITLE
docs: fix Initialization heading level and de-duplicate Init prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,10 @@ type model struct {
 }
 ```
 
-## Initialization
+### Initialization
 
-Next, we’ll define our application’s initial state. `Init` can return a `Cmd`
-that could perform some initial I/O. For now, we don’t need to do any I/O, so
-for the command, we’ll just return `nil`, which translates to “no command.”
+Next, we’ll define our application’s initial state. In this tutorial our
+application’s state is the to-do list and which of its items are selected.
 
 ```go
 func initialModel() model {
@@ -116,10 +115,9 @@ func initialModel() model {
 }
 ```
 
-After that, we’ll define our application’s initial state in the `Init` method. `Init`
-can return a `Cmd` that could perform some initial I/O. For now, we don't need
-to do any I/O, so for the command, we'll just return `nil`, which translates to
-"no command."
+After that, we’ll define the `Init` method. `Init` can return a `Cmd` that
+could perform some initial I/O. For now, we don’t need to do any I/O, so for
+the command, we’ll just return `nil`, which translates to “no command.”
 
 ```go
 func (m model) Init() tea.Cmd {


### PR DESCRIPTION
The tutorial's Initialization section had two issues:

- The `Init` explanation ("`Init` can return a `Cmd` … return `nil`") appeared twice, and the first copy sat before `initialModel()`, which doesn't return a `Cmd`. Replaced it with a sentence about the initial state and kept the `Init` explanation once, where it belongs.
- `## Initialization` was an `h2`, which closed the `## Tutorial` section early and nested *The Update Method*, *The View Method*, and *All Together Now* under Initialization. Demoted it to `### Initialization` so those stay siblings under Tutorial.