### PR TITLE
fix(tea): fall back to 80x24 when initial GetSize returns 0 (blank first frame under tmux)

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -985,6 +985,30 @@ func shouldQuerySynchronizedOutput(environ uv.Environ) bool {
 		strings.Contains(termType, "rio")
 }
 
+// Standard fallback terminal dimensions, used when the initial size
+// query returns a zero dimension (see fallbackZeroSize).
+const (
+	fallbackWidth  = 80
+	fallbackHeight = 24
+)
+
+// fallbackZeroSize substitutes standard dimensions for any zero
+// dimension reported by the initial terminal size query. Some terminals
+// — tmux is the common one — return 0 from the startup size ioctl with
+// no error, before the pty size has been negotiated. Using that 0 to
+// size the renderer blanks the entire first frame until a real SIGWINCH
+// arrives. A non-zero fallback lets the first frame paint; the genuine
+// size then arrives via WindowSizeMsg and re-renders correctly.
+func fallbackZeroSize(w, h int) (int, int) {
+	if w <= 0 {
+		w = fallbackWidth
+	}
+	if h <= 0 {
+		h = fallbackHeight
+	}
+	return w, h
+}
+
 // Run initializes the program and runs its event loops, blocking until it gets
 // terminated by either [Program.Quit], [Program.Kill], or its signal handler.
 // Returns the final model.
@@ -1047,7 +1071,14 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 			return p.initialModel, fmt.Errorf("bubbletea: error getting terminal size: %w", err)
 		}
 
-		width, height = w, h
+		// Some terminals (notably tmux before the pty size is
+		// negotiated) return 0 from the initial size ioctl with no
+		// error. Resizing the renderer to 0 blanks the whole first
+		// frame until a real SIGWINCH arrives, which looks like the
+		// program hung. Fall back to a standard size so the first frame
+		// paints; the real size replaces it via WindowSizeMsg a moment
+		// later.
+		width, height = fallbackZeroSize(w, h)
 	}
 
 	p.width, p.height = width, height

--- a/tea_test.go
+++ b/tea_test.go
@@ -669,3 +669,23 @@ func BenchmarkTeaRun(b *testing.B) {
 		_ = r.CloseWithError(io.EOF)
 	}
 }
+
+func TestFallbackZeroSize(t *testing.T) {
+	cases := []struct {
+		w, h           int
+		wantW, wantH   int
+	}{
+		{0, 0, fallbackWidth, fallbackHeight},   // tmux startup: both zero
+		{0, 50, fallbackWidth, 50},              // zero width only
+		{120, 0, 120, fallbackHeight},           // zero height only
+		{200, 50, 200, 50},                      // real size: unchanged
+		{-1, -5, fallbackWidth, fallbackHeight}, // defensive: negatives
+	}
+	for _, c := range cases {
+		gotW, gotH := fallbackZeroSize(c.w, c.h)
+		if gotW != c.wantW || gotH != c.wantH {
+			t.Errorf("fallbackZeroSize(%d, %d) = (%d, %d); want (%d, %d)",
+				c.w, c.h, gotW, gotH, c.wantW, c.wantH)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Launching a Bubble Tea v2 program inside **tmux** (and some other pty setups) shows a **blank screen** until the first event — the user resizes the window or presses a key — at which point the UI finally paints. It looks like the program hung.

## Root cause

`Program.Run` reads the terminal size once at startup and trusts the result, checking only the error:

```go
w, h, err := term.GetSize(p.ttyOutput.Fd())
if err != nil {
    return p.initialModel, fmt.Errorf("bubbletea: error getting terminal size: %w", err)
}
width, height = w, h            // no check for w==0 / h==0
```

Under tmux the pty size often isn't negotiated yet at this instant, so `term.GetSize` returns `(0, 0)` **with `err == nil`**. `Run` then resizes the renderer to `0x0`. Because the event loop only paints *after* it receives a message, and the only startup message is the resulting `WindowSizeMsg{0,0}`, the first frame is clipped to a 0x0 viewport — blank — until a real `SIGWINCH` arrives.

This is independent of the model's `View()`: even a view that ignores width entirely renders blank, because the *renderer viewport* is `0x0`.

## Fix

Fall back to a standard `80x24` for any zero dimension, mirroring what terminal apps conventionally do. The first frame then paints, and the genuine size replaces it via `WindowSizeMsg` a moment later.

```go
width, height = fallbackZeroSize(w, h)
```

Adds `fallbackZeroSize` (a small pure helper) plus a unit test. The startup `GetSize` path itself is awkward to unit-test (it needs a real tty Fd), so the fallback logic is factored into a tested helper.

## Validation

- Rebased onto current upstream `main` on 2026-08-08.
- `go test ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go test ./...` in `examples/`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- `go test -run TestFallbackZeroSize -count=100 .`
- `git diff --check`
- Reproduction: a minimal v2 program launched in an early/detached tmux pane renders blank until the first event; with the fallback it paints immediately.

- [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
