### PR TITLE
fix: guard ProgressBarState.String against out-of-range values

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -317,8 +317,13 @@ const (
 	ProgressBarWarning
 )
 
-// String return a human-readable value for the given [ProgressBarState].
+// String returns a human-readable value for the given [ProgressBarState].
+// Values outside the defined range are rendered as ProgressBarState(N) rather
+// than panicking, since [ProgressBar.State] is exported and may hold any int.
 func (s ProgressBarState) String() string {
+	if s < ProgressBarNone || s > ProgressBarWarning {
+		return fmt.Sprintf("ProgressBarState(%d)", int(s))
+	}
 	return [...]string{
 		"None",
 		"Default",

--- a/tea_test.go
+++ b/tea_test.go
@@ -669,3 +669,32 @@ func BenchmarkTeaRun(b *testing.B) {
 		_ = r.CloseWithError(io.EOF)
 	}
 }
+
+func TestProgressBarStateString(t *testing.T) {
+	type test struct {
+		name  string
+		state ProgressBarState
+		want  string
+	}
+
+	tests := []test{
+		{name: "none", state: ProgressBarNone, want: "None"},
+		{name: "default", state: ProgressBarDefault, want: "Default"},
+		{name: "error", state: ProgressBarError, want: "Error"},
+		{name: "indeterminate", state: ProgressBarIndeterminate, want: "Indeterminate"},
+		{name: "warning", state: ProgressBarWarning, want: "Warning"},
+		{name: "above range", state: ProgressBarWarning + 1, want: "ProgressBarState(5)"},
+		{name: "negative", state: -1, want: "ProgressBarState(-1)"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			// String must never panic, even for values outside the
+			// defined range, because ProgressBar.State is exported.
+			if got := test.state.String(); got != test.want {
+				t.Errorf("ProgressBarState(%d).String() = %q, want %q", int(test.state), got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`ProgressBar.State` is an exported field, so it can be assigned any `int` without going through `NewProgressBar`. `ProgressBarState.String()` indexed a fixed length-5 array literal directly with the receiver, which panics for any value outside `[0, 4]`:

```go
var s tea.ProgressBarState = 5
_ = s.String() // panic: runtime error: index out of range [5] with length 5
```

This bounds-checks the receiver and falls back to the stringer-style `ProgressBarState(N)` for unknown values, so `String()` never panics. Added a table-driven test covering the five defined states plus an above-range and a negative value.

`go test ./...` passes; `gofmt`/`go vet` clean.

Fixes #1711