### PR TITLE
perf: scroll-optimised flush() in cursedRenderer

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -16,23 +16,24 @@ import (
 )
 
 type cursedRenderer struct {
-	w             io.Writer
-	buf           bytes.Buffer // updates buffer to be flushed to [w]
-	scr           *uv.TerminalRenderer
-	cellbuf       uv.ScreenBuffer
-	lastView      *View
-	env           []string
-	term          string // the terminal type $TERM
-	width, height int
-	mu            sync.Mutex
-	profile       colorprofile.Profile
-	logger        uv.Logger
-	view          View
-	hardTabs      bool // whether to use hard tabs to optimize cursor movements
-	backspace     bool // whether to use backspace to optimize cursor movements
-	mapnl         bool
-	syncdUpdates  bool // whether to use synchronized output mode for updates
-	starting      bool // indicates whether the renderer is starting after being stopped
+	w                io.Writer
+	buf              bytes.Buffer // updates buffer to be flushed to [w]
+	scr              *uv.TerminalRenderer
+	cellbuf          uv.ScreenBuffer
+	lastView         *View
+	env              []string
+	term             string // the terminal type $TERM
+	width, height    int
+	mu               sync.Mutex
+	profile          colorprofile.Profile
+	logger           uv.Logger
+	view             View
+	hardTabs         bool // whether to use hard tabs to optimize cursor movements
+	backspace        bool // whether to use backspace to optimize cursor movements
+	mapnl            bool
+	syncdUpdates     bool     // whether to use synchronized output mode for updates
+	starting         bool     // indicates whether the renderer is starting after being stopped
+	lastContentLines []string // previous frame's View lines for scroll detection
 }
 
 var _ renderer = &cursedRenderer{}
@@ -303,12 +304,69 @@ func (s *cursedRenderer) flush(closing bool) error {
 		// and to avoid rendering issues when the frame area is smaller than
 		// the screen buffer.
 		s.cellbuf.Resize(frameArea.Dx(), frameArea.Dy())
+
+		// Clear after resize so stale cells at newly-visible positions don't
+		// persist if content doesn't cover them.
+		s.cellbuf.Clear()
+
+		// Invalidate scroll detection state after resize: dimensions changed so
+		// previous content lines don't correspond to new buffer geometry.
+		s.lastContentLines = nil
 	}
 
-	// Clear our screen buffer before copying the new frame into it to ensure
-	// we erase any old content.
-	s.cellbuf.Clear()
-	content.Draw(s.cellbuf, s.cellbuf.Bounds())
+	// Detect content scroll and shift cellbuf lines so DrawOver finds
+	// matching cells for preserved lines. Only the N new lines get marked
+	// as touched, so transformLine skips the shifted lines entirely.
+	//
+	// When no shift is detected, fall back to the original Clear+Draw path
+	// to avoid stale cells from DrawOver (printString doesn't clear cells
+	// beyond each line's content, so shorter lines would leave artifacts).
+	newLines := strings.Split(view.Content, "\n")
+	if shift, regionStart, matchCount := detectContentShift(s.lastContentLines, newLines); shift != 0 {
+		absShift := shift
+		if absShift < 0 {
+			absShift = -absShift
+		}
+		regionEnd := regionStart + matchCount + absShift
+		shiftCellbufRegion(&s.cellbuf, regionStart, regionEnd, shift)
+		s.scr.HardScroll(s.cellbuf.RenderBuffer, shift, regionStart, regionEnd-1)
+
+		// Clear lines outside the shifted region that changed.
+		for i := regionEnd; i < len(newLines) && i < len(s.lastContentLines); i++ {
+			if newLines[i] != s.lastContentLines[i] {
+				clearCellbufLine(&s.cellbuf, i)
+			}
+		}
+
+		width := s.cellbuf.Width()
+		height := s.cellbuf.Height()
+		drawStart := regionStart + matchCount
+
+		if shift > 0 {
+			changedContent := strings.Join(newLines[drawStart:], "\n")
+			partial := uv.NewStyledString(changedContent)
+			partial.DrawOver(s.cellbuf, uv.Rect(0, drawStart, width, height))
+		} else {
+			topEnd := regionStart + absShift
+			topContent := strings.Join(newLines[regionStart:topEnd], "\n")
+			top := uv.NewStyledString(topContent)
+			top.DrawOver(s.cellbuf, uv.Rect(0, regionStart, width, topEnd))
+			if regionEnd < len(newLines) {
+				bottomContent := strings.Join(newLines[regionEnd:], "\n")
+				bottom := uv.NewStyledString(bottomContent)
+				bottom.DrawOver(s.cellbuf, uv.Rect(0, regionEnd, width, height))
+			}
+		}
+
+		contentHeight := strings.Count(view.Content, "\n") + 1
+		if contentHeight < height {
+			s.cellbuf.ClearArea(uv.Rect(0, contentHeight, width, height))
+		}
+	} else {
+		s.cellbuf.Clear()
+		content.Draw(s.cellbuf, s.cellbuf.Bounds())
+	}
+	s.lastContentLines = newLines
 
 	// If the frame height is greater than the screen height, we drop the
 	// lines from the top of the buffer.
@@ -592,6 +650,7 @@ func (s *cursedRenderer) reset() {
 
 func reset(s *cursedRenderer) {
 	s.buf.Reset()
+	s.lastContentLines = nil
 	scr := uv.NewTerminalRenderer(&s.buf, s.env)
 	scr.SetColorProfile(s.profile)
 	scr.SetRelativeCursor(true) // Always start in inline mode

--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -322,7 +322,13 @@ func (s *cursedRenderer) flush(closing bool) error {
 	// to avoid stale cells from DrawOver (printString doesn't clear cells
 	// beyond each line's content, so shorter lines would leave artifacts).
 	newLines := strings.Split(view.Content, "\n")
-	if shift, regionStart, matchCount := detectContentShift(s.lastContentLines, newLines); shift != 0 {
+	shift, regionStart, matchCount := detectContentShift(s.lastContentLines, newLines)
+	var repair []int
+	shiftOK := true
+	if shift != 0 {
+		repair, shiftOK = verifyShift(s.lastContentLines, newLines, shift, regionStart, matchCount)
+	}
+	if shift != 0 && shiftOK {
 		absShift := shift
 		if absShift < 0 {
 			absShift = -absShift
@@ -341,6 +347,11 @@ func (s *cursedRenderer) flush(closing bool) error {
 		width := s.cellbuf.Width()
 		height := s.cellbuf.Height()
 		drawStart := regionStart + matchCount
+
+		for _, r := range repair {
+			s.cellbuf.ClearArea(uv.Rect(0, r, width, 1))
+			uv.NewStyledString(newLines[r]).DrawOver(s.cellbuf, uv.Rect(0, r, width, 1))
+		}
 
 		if shift > 0 {
 			changedContent := strings.Join(newLines[drawStart:], "\n")

--- a/cursed_renderer_bench_test.go
+++ b/cursed_renderer_bench_test.go
@@ -1,0 +1,244 @@
+package tea
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// generateStyledContent creates ANSI-styled content simulating a TUI viewport.
+// Each line has foreground color, bold text, and a reset — similar to real TUI output.
+func generateStyledContent(width, height, offset int) string {
+	var sb strings.Builder
+	for y := 0; y < height; y++ {
+		lineNum := offset + y
+		prefix := fmt.Sprintf("\x1b[38;2;200;200;200m\x1b[48;2;30;30;46m%4d │ ", lineNum)
+		body := fmt.Sprintf("Line content for row %d with some text that fills the width", lineNum)
+		visibleLen := 7 + len(body)
+		if visibleLen < width {
+			body += strings.Repeat(" ", width-visibleLen)
+		} else if visibleLen > width {
+			body = body[:width-7]
+		}
+		sb.WriteString(prefix)
+		sb.WriteString(body)
+		sb.WriteString("\x1b[0m")
+		if y < height-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func BenchmarkFlushScroll(b *testing.B) {
+	const width, height = 200, 50
+	const scrollStep = 3
+
+	env := []string{"TERM=xterm-256color", "COLORTERM=truecolor"}
+	r := newCursedRenderer(io.Discard, env, width, height)
+	r.syncdUpdates = false
+
+	view := View{
+		Content:   generateStyledContent(width, height, 0),
+		AltScreen: true,
+	}
+	r.render(view)
+	_ = r.flush(false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		offset := (i + 1) * scrollStep
+		view.Content = generateStyledContent(width, height, offset)
+		r.render(view)
+		_ = r.flush(false)
+	}
+}
+
+func BenchmarkFlushStatic(b *testing.B) {
+	const width, height = 200, 50
+
+	env := []string{"TERM=xterm-256color", "COLORTERM=truecolor"}
+	r := newCursedRenderer(io.Discard, env, width, height)
+	r.syncdUpdates = false
+
+	view := View{
+		Content:   generateStyledContent(width, height, 0),
+		AltScreen: true,
+	}
+	r.render(view)
+	_ = r.flush(false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		r.render(view)
+		_ = r.flush(false)
+	}
+}
+
+func BenchmarkFlushFullChange(b *testing.B) {
+	const width, height = 200, 50
+
+	env := []string{"TERM=xterm-256color", "COLORTERM=truecolor"}
+	r := newCursedRenderer(io.Discard, env, width, height)
+	r.syncdUpdates = false
+
+	view := View{
+		Content:   generateStyledContent(width, height, 0),
+		AltScreen: true,
+	}
+	r.render(view)
+	_ = r.flush(false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		view.Content = generateStyledContent(width, height, (i+1)*height)
+		r.render(view)
+		_ = r.flush(false)
+	}
+}
+
+// generatePartialScrollContent creates content simulating steiner's layout:
+// topChromeLines constant lines at top, contentLines scrolling, bottomChromeLines
+// constant at bottom. This mirrors real TUI apps that have padding/header at the
+// top and status/input at the bottom.
+func generatePartialScrollContent(width, topChromeLines, contentLines, bottomChromeLines, offset int) string {
+	var sb strings.Builder
+	height := topChromeLines + contentLines + bottomChromeLines
+	for y := 0; y < height; y++ {
+		var line string
+		if y < topChromeLines {
+			line = fmt.Sprintf("\x1b[48;2;30;30;46m%s\x1b[0m", strings.Repeat(" ", width))
+		} else if y < topChromeLines+contentLines {
+			lineNum := offset + y - topChromeLines
+			prefix := fmt.Sprintf("\x1b[38;2;200;200;200m\x1b[48;2;30;30;46m%4d │ ", lineNum)
+			body := fmt.Sprintf("Line content for row %d with some text", lineNum)
+			visibleLen := 7 + len(body)
+			if visibleLen < width {
+				body += strings.Repeat(" ", width-visibleLen)
+			}
+			line = prefix + body + "\x1b[0m"
+		} else {
+			switch y - topChromeLines - contentLines {
+			case 0:
+				line = strings.Repeat("─", width)
+			case 1:
+				line = fmt.Sprintf("> %s", strings.Repeat(" ", width-2))
+			default:
+				line = fmt.Sprintf("\x1b[7m steiner \x1b[0m%s", strings.Repeat(" ", width-9))
+			}
+		}
+		sb.WriteString(line)
+		if y < height-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func BenchmarkFlushScrollPartial(b *testing.B) {
+	const width = 200
+	const topChrome = 1
+	const contentLines = 39
+	const bottomChrome = 10
+	const scrollStep = 3
+
+	height := topChrome + contentLines + bottomChrome
+	env := []string{"TERM=xterm-256color", "COLORTERM=truecolor"}
+	r := newCursedRenderer(io.Discard, env, width, height)
+	r.syncdUpdates = false
+
+	view := View{
+		Content:   generatePartialScrollContent(width, topChrome, contentLines, bottomChrome, 0),
+		AltScreen: true,
+	}
+	r.render(view)
+	_ = r.flush(false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		offset := (i + 1) * scrollStep
+		view.Content = generatePartialScrollContent(width, topChrome, contentLines, bottomChrome, offset)
+		r.render(view)
+		_ = r.flush(false)
+	}
+}
+
+// generateSuffixContent creates ANSI-styled content where each line ends with a
+// scrollbar character that varies per frame (thumbPos controls which line gets
+// the thumb). This simulates a viewport with a live scrollbar: the content
+// prefix is stable across frames so prefix-match fires, but exact equality
+// fails because the thumb position shifts.
+func generateSuffixContent(width, height, offset int, thumbPos int) string {
+	var sb strings.Builder
+	for y := 0; y < height; y++ {
+		lineNum := offset + y
+		prefix := fmt.Sprintf("\x1b[38;2;200;200;200m\x1b[48;2;30;30;46m%4d │ ", lineNum)
+		body := fmt.Sprintf("Line content for row %d with some text that fills the width", lineNum)
+		visibleLen := 7 + len(body)
+		if visibleLen < width-3 {
+			body += strings.Repeat(" ", width-3-visibleLen)
+		}
+		var scrollChar string
+		if y == thumbPos {
+			scrollChar = "\x1b[7m▓\x1b[0m" // reverse-video thumb
+		} else {
+			scrollChar = "│"
+		}
+		sb.WriteString(prefix)
+		sb.WriteString(body)
+		sb.WriteString(scrollChar)
+		sb.WriteString("\x1b[0m")
+		if y < height-1 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func BenchmarkFlushScrollWithSuffix(b *testing.B) {
+	const width, height = 200, 50
+	const scrollStep = 3
+
+	env := []string{"TERM=xterm-256color", "COLORTERM=truecolor"}
+	r := newCursedRenderer(io.Discard, env, width, height)
+	r.syncdUpdates = false
+
+	view := View{
+		Content:   generateSuffixContent(width, height, 0, 25),
+		AltScreen: true,
+	}
+	r.render(view)
+	_ = r.flush(false)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		offset := (i + 1) * scrollStep
+		thumbPos := (offset * height / (height * 10)) % height // moves slowly
+		view.Content = generateSuffixContent(width, height, offset, thumbPos)
+		r.render(view)
+		_ = r.flush(false)
+	}
+}
+
+func BenchmarkDrawOnly(b *testing.B) {
+	const width, height = 200, 50
+
+	content := generateStyledContent(width, height, 0)
+	cellbuf := uv.NewScreenBuffer(width, height)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		cellbuf.Clear()
+		s := uv.NewStyledString(content)
+		s.Draw(cellbuf, cellbuf.Bounds())
+	}
+}

--- a/cursed_renderer_scroll.go
+++ b/cursed_renderer_scroll.go
@@ -1,0 +1,150 @@
+package tea
+
+import (
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// linesMatchForShift reports whether two lines represent the same content for
+// the purpose of scroll-shift detection. It first tries exact equality (zero
+// overhead when lines are identical), then falls back to a prefix comparison
+// that ignores up to maxTrailingDiff bytes at the end. This tolerates styled
+// trailing decorations such as scrollbar characters whose ANSI escapes cause
+// the suffix to differ between frames even when the content is the same.
+func linesMatchForShift(a, b string) bool {
+	if a == b {
+		return true
+	}
+	n := min(len(a), len(b))
+	const maxTrailingDiff = 40
+	if n <= maxTrailingDiff {
+		return false
+	}
+	compareLen := n - maxTrailingDiff
+	return a[:compareLen] == b[:compareLen]
+}
+
+// detectContentShift compares old and new content lines to detect a vertical
+// scroll within the frame. Returns a positive shift for scroll-up (content
+// moved up, new lines appear at bottom) and negative for scroll-down. Returns
+// 0 if no shift is detected or dimensions changed.
+//
+// regionStart is the index of the first line in the scrolling region (after
+// stripping identical leading chrome). matchCount is the number of consecutive
+// lines within that region that matched the shifted pattern.
+//
+// The algorithm strips identical leading and trailing lines (non-scrolling
+// chrome such as padding, status bars, input areas) before detecting shift.
+// This allows apps with fixed chrome at both top and bottom of the frame to
+// benefit from scroll optimisation.
+func detectContentShift(oldLines, newLines []string) (shift, regionStart, matchCount int) {
+	if len(oldLines) != len(newLines) || len(oldLines) < 4 {
+		return 0, 0, 0
+	}
+	height := len(oldLines)
+
+	top := 0
+	for top < height && oldLines[top] == newLines[top] {
+		top++
+	}
+	bot := height
+	for bot > top && oldLines[bot-1] == newLines[bot-1] {
+		bot--
+	}
+
+	regionHeight := bot - top
+	if regionHeight < 4 {
+		return 0, 0, 0
+	}
+
+	maxShift := min(10, regionHeight/2)
+	minMatch := max(4, regionHeight/4)
+	old := oldLines[top:bot]
+	new_ := newLines[top:bot]
+
+	for shift := 1; shift <= maxShift; shift++ {
+		count := 0
+		for i := 0; i+shift < regionHeight; i++ {
+			if !linesMatchForShift(old[i+shift], new_[i]) {
+				break
+			}
+			count++
+		}
+		if count >= minMatch {
+			return shift, top, count
+		}
+	}
+
+	for shift := 1; shift <= maxShift; shift++ {
+		count := 0
+		for i := 0; i+shift < regionHeight; i++ {
+			if !linesMatchForShift(old[i], new_[i+shift]) {
+				break
+			}
+			count++
+		}
+		if count >= minMatch {
+			return -shift, top, count
+		}
+	}
+
+	return 0, 0, 0
+}
+
+// shiftCellbufRegion shifts lines [regionStart, regionEnd) of the cell buffer
+// by n positions in-place. Lines outside this range are left untouched.
+// Positive n = scroll up; negative n = scroll down.
+// After shifting, ALL lines get a nil Touched reset so updateHashmap and
+// transformLine skip them; DrawOver sets Touched only on genuinely changed lines.
+func shiftCellbufRegion(buf *uv.ScreenBuffer, regionStart, regionEnd, n int) {
+	height := buf.Height()
+	if regionEnd > height {
+		regionEnd = height
+	}
+	regionLen := regionEnd - regionStart
+	if regionLen < 1 {
+		return
+	}
+	region := buf.Lines[regionStart:regionEnd]
+	if n < 0 {
+		n = -n
+		if n >= regionLen {
+			return
+		}
+		var saved [10]uv.Line
+		copy(saved[:n], region[regionLen-n:regionLen])
+		copy(region[n:regionLen], region[:regionLen-n])
+		for i := 0; i < n; i++ {
+			clearLine(saved[i])
+			region[i] = saved[i]
+		}
+	} else {
+		if n >= regionLen {
+			return
+		}
+		var saved [10]uv.Line
+		copy(saved[:n], region[:n])
+		copy(region[:regionLen-n], region[n:regionLen])
+		for i := 0; i < n; i++ {
+			clearLine(saved[i])
+			region[regionLen-n+i] = saved[i]
+		}
+	}
+
+	for i := range buf.Touched {
+		buf.Touched[i] = nil
+	}
+}
+
+// clearCellbufLine sets all cells in line i to EmptyCell and resets its
+// Touched sentinel so DrawOver writes the line fresh.
+func clearCellbufLine(buf *uv.ScreenBuffer, i int) {
+	clearLine(buf.Lines[i])
+	buf.Touched[i] = nil
+}
+
+// clearLine sets all cells in the line to EmptyCell in place.
+func clearLine(l uv.Line) {
+	for i := range l {
+		l[i] = uv.EmptyCell
+	}
+}

--- a/cursed_renderer_scroll.go
+++ b/cursed_renderer_scroll.go
@@ -61,6 +61,8 @@ func detectContentShift(oldLines, newLines []string) (shift, regionStart, matchC
 	old := oldLines[top:bot]
 	new_ := newLines[top:bot]
 
+	bestShift, bestCount := 0, 0
+
 	for shift := 1; shift <= maxShift; shift++ {
 		count := 0
 		for i := 0; i+shift < regionHeight; i++ {
@@ -69,8 +71,8 @@ func detectContentShift(oldLines, newLines []string) (shift, regionStart, matchC
 			}
 			count++
 		}
-		if count >= minMatch {
-			return shift, top, count
+		if count >= minMatch && count > bestCount && matchedRunHasVariety(new_, 0, count) {
+			bestShift, bestCount = shift, count
 		}
 	}
 
@@ -82,12 +84,57 @@ func detectContentShift(oldLines, newLines []string) (shift, regionStart, matchC
 			}
 			count++
 		}
-		if count >= minMatch {
-			return -shift, top, count
+		if count >= minMatch && count > bestCount && matchedRunHasVariety(new_, shift, count) {
+			bestShift, bestCount = -shift, count
 		}
 	}
 
-	return 0, 0, 0
+	if bestShift == 0 {
+		return 0, 0, 0
+	}
+	return bestShift, top, bestCount
+}
+
+// matchedRunHasVariety reports whether the run of lines new_[start:start+count]
+// contains at least 2 distinct values. This guards against accepting a shift
+// candidate over degenerate (e.g. all-blank) content, which would otherwise
+// "match" any shift and trigger a pointless scroll sequence.
+func matchedRunHasVariety(new_ []string, start, count int) bool {
+	if count < 2 {
+		return false
+	}
+	first := new_[start]
+	for i := start + 1; i < start+count; i++ {
+		if new_[i] != first {
+			return true
+		}
+	}
+	return false
+}
+
+// verifyShift returns the absolute row indices within the matched run whose
+// content is not exactly equal to its shifted source, and whether the
+// optimisation is still worth taking. linesMatchForShift is a fuzzy check
+// used only to *find* a candidate shift; only exact equality may be *trusted*
+// to skip a repaint, so every row in the matched run is re-verified here.
+func verifyShift(oldLines, newLines []string, shift, regionStart, matchCount int) (repair []int, ok bool) {
+	if shift > 0 {
+		for r := regionStart; r < regionStart+matchCount; r++ {
+			if newLines[r] != oldLines[r+shift] {
+				repair = append(repair, r)
+			}
+		}
+	} else {
+		absShift := -shift
+		start := regionStart + absShift
+		for r := start; r < start+matchCount; r++ {
+			if newLines[r] != oldLines[r-absShift] {
+				repair = append(repair, r)
+			}
+		}
+	}
+	ok = matchCount-len(repair) >= 4
+	return repair, ok
 }
 
 // shiftCellbufRegion shifts lines [regionStart, regionEnd) of the cell buffer

--- a/cursed_renderer_scroll_test.go
+++ b/cursed_renderer_scroll_test.go
@@ -1,0 +1,413 @@
+package tea
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+// makeLines returns a slice of n strings starting from offset, e.g.
+// makeLines(0, 4) → ["line0", "line1", "line2", "line3"].
+func makeLines(offset, n int) []string {
+	lines := make([]string, n)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("line%d", offset+i)
+	}
+	return lines
+}
+
+// makeSuffixLines returns n lines like "content{offset+i}" padded to ~100 bytes
+// plus the given suffix. Used to simulate scrollbar decoration that changes
+// between frames while content prefix is stable.
+func makeSuffixLines(offset, n int, suffix string) []string {
+	lines := make([]string, n)
+	for i := range lines {
+		base := fmt.Sprintf("content%d", offset+i)
+		// Pad base to ~100 bytes so prefix comparison has room.
+		if len(base) < 100 {
+			base += strings.Repeat(" ", 100-len(base))
+		}
+		lines[i] = base + suffix
+	}
+	return lines
+}
+
+func TestLinesMatchForShift(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{
+			name: "exact match short strings",
+			a:    "hello",
+			b:    "hello",
+			want: true, // fast path: a==b
+		},
+		{
+			name: "both empty",
+			a:    "",
+			b:    "",
+			want: true, // fast path: a==b
+		},
+		{
+			name: "exact match longer strings",
+			a:    strings.Repeat("a", 40),
+			b:    strings.Repeat("a", 40),
+			want: true, // fast path: a==b
+		},
+		{
+			name: "too short to prefix-compare different strings",
+			a:    strings.Repeat("x", 30),
+			b:    strings.Repeat("y", 30),
+			want: false, // n=30 <= maxTrailingDiff=40; fast path fails; returns false
+		},
+		{
+			name: "prefix differs content completely different",
+			a:    strings.Repeat("a", 50) + "TAIL",
+			b:    strings.Repeat("b", 50) + "TAIL",
+			want: false, // prefix a[:14]="aa..." != b[:14]="bb..."
+		},
+		{
+			name: "suffix-only difference within trailing margin",
+			a:    strings.Repeat("a", 100) + "SCROLLBAR1",
+			b:    strings.Repeat("a", 100) + "SCROLLBAR2",
+			want: true, // n=110, compareLen=70; a[:70]==b[:70]; suffixes differ but within 40 bytes
+		},
+		{
+			name: "prefix match suffix change exactly at boundary",
+			a:    strings.Repeat("z", 80) + strings.Repeat("X", 40),
+			b:    strings.Repeat("z", 80) + strings.Repeat("Y", 40),
+			want: true, // n=120, compareLen=80; a[:80]==b[:80]
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := linesMatchForShift(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("linesMatchForShift(%q, %q) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectContentShift(t *testing.T) {
+	tests := []struct {
+		name            string
+		old             []string
+		new             []string
+		wantShift       int
+		wantRegionStart int
+		wantMatchCount  int
+	}{
+		{
+			name:           "no change",
+			old:            makeLines(0, 20),
+			new:            makeLines(0, 20),
+			wantShift:      0,
+			wantMatchCount: 0,
+		},
+		{
+			name:           "scroll up by 1",
+			old:            makeLines(0, 20),
+			new:            append(makeLines(1, 19), "newline"),
+			wantShift:      1,
+			wantMatchCount: 19,
+		},
+		{
+			name:           "scroll up by 2",
+			old:            makeLines(0, 20),
+			new:            append(makeLines(2, 18), "new0", "new1"),
+			wantShift:      2,
+			wantMatchCount: 18,
+		},
+		{
+			name:           "scroll down by 1",
+			old:            makeLines(1, 20),
+			new:            append([]string{"line0"}, makeLines(1, 19)...),
+			wantShift:      -1,
+			wantMatchCount: 19,
+		},
+		{
+			name:           "completely different",
+			old:            makeLines(0, 20),
+			new:            makeLines(100, 20),
+			wantShift:      0,
+			wantMatchCount: 0,
+		},
+		{
+			name:           "too short",
+			old:            []string{"a", "b", "c"},
+			new:            []string{"b", "c", "d"},
+			wantShift:      0,
+			wantMatchCount: 0,
+		},
+		{
+			name:           "different lengths",
+			old:            []string{"a", "b", "c", "d"},
+			new:            []string{"a", "b", "c"},
+			wantShift:      0,
+			wantMatchCount: 0,
+		},
+		{
+			name: "scroll up with fixed chrome at bottom",
+			old: func() []string {
+				s := make([]string, 20)
+				for i := 0; i < 17; i++ {
+					s[i] = fmt.Sprintf("content%d", i)
+				}
+				s[17], s[18], s[19] = "chrome-divider", "chrome-input", "chrome-status"
+				return s
+			}(),
+			new: func() []string {
+				s := make([]string, 20)
+				for i := 0; i < 16; i++ {
+					s[i] = fmt.Sprintf("content%d", i+1)
+				}
+				s[16] = "content-new"
+				s[17], s[18], s[19] = "chrome-divider", "chrome-input", "chrome-status"
+				return s
+			}(),
+			wantShift:      1,
+			wantMatchCount: 16,
+		},
+		{
+			name: "no shift when too few content lines match",
+			old: func() []string {
+				s := make([]string, 20)
+				for i := range s {
+					s[i] = fmt.Sprintf("content%d", i)
+				}
+				return s
+			}(),
+			new: func() []string {
+				s := make([]string, 20)
+				for i := 0; i < 4; i++ {
+					s[i] = fmt.Sprintf("content%d", i+1)
+				}
+				for i := 4; i < 20; i++ {
+					s[i] = fmt.Sprintf("different%d", i)
+				}
+				return s
+			}(),
+			wantShift:      0,
+			wantMatchCount: 0,
+		},
+		{
+			name:           "scroll up with scrollbar suffix",
+			old:            makeSuffixLines(0, 20, "│▓│"),
+			new:            append(makeSuffixLines(1, 19, "│░│"), makeSuffixLines(20, 1, "│░│")...),
+			wantShift:      1,
+			wantMatchCount: 19,
+		},
+		{
+			name:           "scroll down with scrollbar suffix",
+			old:            append(makeSuffixLines(1, 19, "│▓│"), makeSuffixLines(20, 1, "│▓│")...),
+			new:            makeSuffixLines(0, 20, "│░│"),
+			wantShift:      -1,
+			wantMatchCount: 19,
+		},
+		{
+			// Steiner pattern: 1 constant top chrome + 16 scrolling + 3 bottom chrome.
+			// Chrome is stripped, shift detected in the scrolling region.
+			name: "scroll up with chrome at top and bottom",
+			old: func() []string {
+				s := make([]string, 20)
+				s[0] = "padded-empty-line"
+				for i := 1; i < 17; i++ {
+					s[i] = fmt.Sprintf("content%d", i-1)
+				}
+				s[17], s[18], s[19] = "chrome-divider", "chrome-input", "chrome-status"
+				return s
+			}(),
+			new: func() []string {
+				s := make([]string, 20)
+				s[0] = "padded-empty-line"
+				for i := 1; i < 16; i++ {
+					s[i] = fmt.Sprintf("content%d", i) // shifted by 1
+				}
+				s[16] = "content-new"
+				s[17], s[18], s[19] = "chrome-divider", "chrome-input", "chrome-status"
+				return s
+			}(),
+			wantShift:       1,
+			wantRegionStart: 1,
+			wantMatchCount:  15,
+		},
+		{
+			// Scroll down with chrome at both ends.
+			name: "scroll down with chrome at top and bottom",
+			old: func() []string {
+				s := make([]string, 20)
+				s[0] = "padded-empty-line"
+				for i := 1; i < 17; i++ {
+					s[i] = fmt.Sprintf("content%d", i)
+				}
+				s[17], s[18], s[19] = "chrome-divider", "chrome-input", "chrome-status"
+				return s
+			}(),
+			new: func() []string {
+				s := make([]string, 20)
+				s[0] = "padded-empty-line"
+				s[1] = "content-new-top"
+				for i := 2; i < 17; i++ {
+					s[i] = fmt.Sprintf("content%d", i-1)
+				}
+				s[17], s[18], s[19] = "chrome-divider", "chrome-input", "chrome-status"
+				return s
+			}(),
+			wantShift:       -1,
+			wantRegionStart: 1,
+			wantMatchCount:  15,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotShift, gotRegionStart, gotMatch := detectContentShift(tt.old, tt.new)
+			if gotShift != tt.wantShift || gotRegionStart != tt.wantRegionStart || gotMatch != tt.wantMatchCount {
+				t.Errorf("detectContentShift() = (%d, %d, %d), want (%d, %d, %d)",
+					gotShift, gotRegionStart, gotMatch, tt.wantShift, tt.wantRegionStart, tt.wantMatchCount)
+			}
+		})
+	}
+}
+
+func TestShiftCellbufRegion(t *testing.T) {
+	const width = 5
+	const height = 10
+
+	// fillLine sets every cell in row to a string tag (single char repeated).
+	fillLine := func(buf *uv.ScreenBuffer, row int, tag string) {
+		for i := range buf.Lines[row] {
+			buf.Lines[row][i] = uv.Cell{Content: tag, Width: 1}
+		}
+	}
+
+	// firstCellContent returns the Content field of the first cell in a row.
+	firstCellContent := func(buf *uv.ScreenBuffer, row int) string {
+		return buf.Lines[row][0].Content
+	}
+
+	// isBlankLine reports whether all cells in row match EmptyCell.
+	isBlankLine := func(buf *uv.ScreenBuffer, row int) bool {
+		for _, cell := range buf.Lines[row] {
+			if cell != uv.EmptyCell {
+				return false
+			}
+		}
+		return true
+	}
+
+	t.Run("shift up within region leaves chrome untouched", func(t *testing.T) {
+		buf := uv.NewScreenBuffer(width, height)
+		for i := 0; i < 7; i++ {
+			fillLine(&buf, i, string(rune('A'+i)))
+		}
+		for i := 7; i < 10; i++ {
+			fillLine(&buf, i, "X")
+		}
+
+		shiftCellbufRegion(&buf, 0, 7, 2)
+
+		for i := 0; i < 5; i++ {
+			want := string(rune('C' + i))
+			if got := firstCellContent(&buf, i); got != want {
+				t.Errorf("row %d: got %q, want %q", i, got, want)
+			}
+		}
+		for i := 5; i < 7; i++ {
+			if !isBlankLine(&buf, i) {
+				t.Errorf("row %d: expected blank after shift up, got non-blank", i)
+			}
+		}
+		for i := 7; i < 10; i++ {
+			if got := firstCellContent(&buf, i); got != "X" {
+				t.Errorf("chrome row %d: got %q, want \"X\"", i, got)
+			}
+		}
+	})
+
+	t.Run("shift down within region leaves chrome untouched", func(t *testing.T) {
+		buf := uv.NewScreenBuffer(width, height)
+		for i := 0; i < 7; i++ {
+			fillLine(&buf, i, string(rune('A'+i)))
+		}
+		for i := 7; i < 10; i++ {
+			fillLine(&buf, i, "X")
+		}
+
+		shiftCellbufRegion(&buf, 0, 7, -2)
+
+		for i := 0; i < 2; i++ {
+			if !isBlankLine(&buf, i) {
+				t.Errorf("row %d: expected blank after shift down, got non-blank", i)
+			}
+		}
+		for i := 2; i < 7; i++ {
+			want := string(rune('A' + i - 2))
+			if got := firstCellContent(&buf, i); got != want {
+				t.Errorf("row %d: got %q, want %q", i, got, want)
+			}
+		}
+		for i := 7; i < 10; i++ {
+			if got := firstCellContent(&buf, i); got != "X" {
+				t.Errorf("chrome row %d: got %q, want \"X\"", i, got)
+			}
+		}
+	})
+
+	t.Run("shift with regionStart skips top chrome", func(t *testing.T) {
+		buf := uv.NewScreenBuffer(width, height)
+		fillLine(&buf, 0, "T") // top chrome
+		for i := 1; i < 8; i++ {
+			fillLine(&buf, i, string(rune('A'+i-1)))
+		}
+		for i := 8; i < 10; i++ {
+			fillLine(&buf, i, "X")
+		}
+
+		// Shift region [1,8) up by 2. Top chrome at 0 and bottom chrome at 8-9 untouched.
+		shiftCellbufRegion(&buf, 1, 8, 2)
+
+		if got := firstCellContent(&buf, 0); got != "T" {
+			t.Errorf("top chrome row 0: got %q, want \"T\"", got)
+		}
+		for i := 1; i < 6; i++ {
+			want := string(rune('A' + i + 1))
+			if got := firstCellContent(&buf, i); got != want {
+				t.Errorf("row %d: got %q, want %q", i, got, want)
+			}
+		}
+		for i := 6; i < 8; i++ {
+			if !isBlankLine(&buf, i) {
+				t.Errorf("row %d: expected blank after shift up, got non-blank", i)
+			}
+		}
+		for i := 8; i < 10; i++ {
+			if got := firstCellContent(&buf, i); got != "X" {
+				t.Errorf("bottom chrome row %d: got %q, want \"X\"", i, got)
+			}
+		}
+	})
+
+	t.Run("nil Touched for all lines after shift", func(t *testing.T) {
+		buf := uv.NewScreenBuffer(width, height)
+		for i := range buf.Touched {
+			buf.Touched[i] = &uv.LineData{FirstCell: 0, LastCell: width - 1}
+		}
+
+		shiftCellbufRegion(&buf, 0, 7, 1)
+
+		// After shift, ALL lines must have nil Touched so updateHashmap and
+		// transformLine skip them entirely.
+		for i := range buf.Touched {
+			if buf.Touched[i] != nil {
+				t.Errorf("Touched[%d] = %v, want nil", i, buf.Touched[i])
+			}
+		}
+	})
+}

--- a/cursed_renderer_scroll_test.go
+++ b/cursed_renderer_scroll_test.go
@@ -2,6 +2,7 @@ package tea
 
 import (
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -197,6 +198,37 @@ func TestDetectContentShift(t *testing.T) {
 			wantMatchCount: 0,
 		},
 		{
+			// A short shift=1 candidate matches by coincidence (count=5,
+			// eligible since minMatch=5), but a shift=-2 candidate matches
+			// more of the region (count=10). detectContentShift must pick
+			// the larger candidate rather than the first one found.
+			name: "picks best of multiple eligible candidates",
+			old: func() []string {
+				s := make([]string, 20)
+				s[0], s[1], s[2], s[3], s[4], s[5] = "C", "A", "B", "C", "A", "B"
+				for i := 6; i < 10; i++ {
+					s[i] = fmt.Sprintf("X%d", i)
+				}
+				for i := 10; i < 20; i++ {
+					s[i] = fmt.Sprintf("O%d", i)
+				}
+				return s
+			}(),
+			new: func() []string {
+				s := make([]string, 20)
+				s[0], s[1], s[2], s[3], s[4], s[5] = "A", "B", "C", "A", "B", "C"
+				s[6], s[7] = "A", "B"
+				s[8], s[9] = "X6", "X7"
+				s[10], s[11] = "X8", "X9"
+				for i := 12; i < 20; i++ {
+					s[i] = fmt.Sprintf("N%d", i)
+				}
+				return s
+			}(),
+			wantShift:      -2,
+			wantMatchCount: 10,
+		},
+		{
 			name:           "scroll up with scrollbar suffix",
 			old:            makeSuffixLines(0, 20, "│▓│"),
 			new:            append(makeSuffixLines(1, 19, "│░│"), makeSuffixLines(20, 1, "│░│")...),
@@ -273,6 +305,136 @@ func TestDetectContentShift(t *testing.T) {
 					gotShift, gotRegionStart, gotMatch, tt.wantShift, tt.wantRegionStart, tt.wantMatchCount)
 			}
 		})
+	}
+}
+
+func TestVerifyShift(t *testing.T) {
+	t.Run("shift up all trusted rows match exactly", func(t *testing.T) {
+		old := makeLines(0, 20)
+		new_ := append(makeLines(1, 19), "newline")
+		repair, ok := verifyShift(old, new_, 1, 0, 19)
+		if len(repair) != 0 {
+			t.Errorf("repair = %v, want empty", repair)
+		}
+		if !ok {
+			t.Errorf("ok = false, want true")
+		}
+	})
+
+	t.Run("shift down all trusted rows match exactly", func(t *testing.T) {
+		old := makeLines(1, 20)
+		new_ := append([]string{"line0"}, makeLines(1, 19)...)
+		repair, ok := verifyShift(old, new_, -1, 0, 19)
+		if len(repair) != 0 {
+			t.Errorf("repair = %v, want empty", repair)
+		}
+		if !ok {
+			t.Errorf("ok = false, want true")
+		}
+	})
+
+	t.Run("shift up suffix-only mismatch is flagged for repair", func(t *testing.T) {
+		old := makeSuffixLines(0, 20, "│")
+		old[10] = strings.TrimSuffix(old[10], "│") + "\x1b[7mT\x1b[0m"
+		new_ := append(makeSuffixLines(1, 19, "│"), makeSuffixLines(20, 1, "│")...)
+
+		repair, ok := verifyShift(old, new_, 1, 0, 19)
+		if !ok {
+			t.Fatalf("ok = false, want true")
+		}
+		if len(repair) != 1 || repair[0] != 9 {
+			t.Errorf("repair = %v, want [9]", repair)
+		}
+	})
+
+	t.Run("shift down suffix-only mismatch is flagged for repair", func(t *testing.T) {
+		new_ := makeSuffixLines(0, 20, "│")
+		new_[9] = strings.TrimSuffix(new_[9], "│") + "\x1b[7mT\x1b[0m"
+		old := append(makeSuffixLines(1, 19, "│"), makeSuffixLines(20, 1, "│")...)
+
+		// shift=-1, regionStart=0, matchCount=19: trusted rows are [1,19),
+		// compared as new_[r] vs old[r-1].
+		repair, ok := verifyShift(old, new_, -1, 0, 19)
+		if !ok {
+			t.Fatalf("ok = false, want true")
+		}
+		if len(repair) != 1 || repair[0] != 9 {
+			t.Errorf("repair = %v, want [9]", repair)
+		}
+	})
+
+	t.Run("too many mismatches makes shift not worthwhile", func(t *testing.T) {
+		old := makeLines(0, 20)
+		new_ := append(makeLines(1, 19), "newline")
+		for i := 0; i < 17; i++ {
+			new_[i] = fmt.Sprintf("corrupted%d", i)
+		}
+		repair, ok := verifyShift(old, new_, 1, 0, 19)
+		if len(repair) != 17 {
+			t.Errorf("len(repair) = %d, want 17", len(repair))
+		}
+		if ok {
+			t.Errorf("ok = true, want false (matchCount-len(repair) = %d < 4)", 19-len(repair))
+		}
+	})
+}
+
+// TestScrollShiftSuffixOnlyMismatchIsRepainted is a regression test for a bug
+// where linesMatchForShift's fuzzy trailing-byte tolerance let a row with a
+// genuinely different scrollbar thumb glyph pass as "matching" during shift
+// detection, silently skipping its repaint. verifyShift must catch this and
+// the flush pipeline must repaint the row (and mark it Touched) rather than
+// leaving stale content in place.
+func TestScrollShiftSuffixOnlyMismatchIsRepainted(t *testing.T) {
+	old := makeSuffixLines(0, 20, "│")
+	old[10] = strings.TrimSuffix(old[10], "│") + "\x1b[7mT\x1b[0m"
+	new_ := append(makeSuffixLines(1, 19, "│"), makeSuffixLines(20, 1, "│")...)
+
+	shift, regionStart, matchCount := detectContentShift(old, new_)
+	if shift != 1 {
+		t.Fatalf("detectContentShift() shift = %d, want 1", shift)
+	}
+
+	repair, ok := verifyShift(old, new_, shift, regionStart, matchCount)
+	if !ok {
+		t.Fatalf("verifyShift() ok = false, want true")
+	}
+	if len(repair) != 1 || repair[0] != 9 {
+		t.Fatalf("verifyShift() repair = %v, want [9]", repair)
+	}
+
+	// Drive a real flush() to confirm the row is actually repainted and
+	// marked Touched, not silently skipped.
+	const width, height = 200, 20
+	env := []string{"TERM=xterm-256color", "COLORTERM=truecolor"}
+	r := newCursedRenderer(io.Discard, env, width, height)
+	r.syncdUpdates = false
+
+	view := View{Content: strings.Join(old, "\n"), AltScreen: true}
+	r.render(view)
+	if err := r.flush(false); err != nil {
+		t.Fatalf("flush() error = %v", err)
+	}
+
+	view.Content = strings.Join(new_, "\n")
+	r.render(view)
+	if err := r.flush(false); err != nil {
+		t.Fatalf("flush() error = %v", err)
+	}
+
+	row := 9
+	var got strings.Builder
+	for _, cell := range r.cellbuf.Lines[row] {
+		got.WriteString(cell.Content)
+	}
+	if !strings.Contains(got.String(), "│") {
+		t.Errorf("row %d content = %q, want it to contain the new track glyph", row, got.String())
+	}
+	if strings.Contains(got.String(), "T") {
+		t.Errorf("row %d content = %q, still contains stale thumb glyph", row, got.String())
+	}
+	if r.cellbuf.Touched[row] == nil {
+		t.Errorf("row %d Touched = nil, want non-nil (repaint must mark the row touched)", row)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -26,3 +26,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.21.0 // indirect
 )
+
+replace github.com/charmbracelet/ultraviolet => /home/luis/Projects/AI/ultraviolet-fork

--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,4 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 )
 
-replace github.com/charmbracelet/ultraviolet => /home/luis/Projects/AI/ultraviolet-fork
+replace github.com/charmbracelet/ultraviolet => github.com/luispabon/ultraviolet v0.0.0-20260625204701-67215642e1d1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWp
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/charmbracelet/colorprofile v0.4.3 h1:QPa1IWkYI+AOB+fE+mg/5/4HRMZcaXex9t5KX76i20Q=
 github.com/charmbracelet/colorprofile v0.4.3/go.mod h1:/zT4BhpD5aGFpqQQqw7a+VtHCzu+zrQtt1zhMt9mR4Q=
-github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 h1:3FmWoGNWK4STvqg0O0Aeav2T7rodWJAPeF0QpH+8gFw=
-github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7/go.mod h1:f/jRa757WUmaOZrbPspXymbg/GnbF+rwe4OLsG7aXYo=
 github.com/charmbracelet/x/ansi v0.11.7 h1:kzv1kJvjg2S3r9KHo8hDdHFQLEqn4RBCb39dAYC84jI=
 github.com/charmbracelet/x/ansi v0.11.7/go.mod h1:9qGpnAVYz+8ACONkZBUWPtL7lulP9No6p1epAihUZwQ=
 github.com/charmbracelet/x/exp/golden v0.0.0-20241212170349-ad4b7ae0f25f h1:UytXHv0UxnsDFmL/7Z9Q5SBYPwSuRLXHbwx+6LycZ2w=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/lucasb-eyer/go-colorful v1.4.0 h1:UtrWVfLdarDgc44HcS7pYloGHJUjHV/4FwW4TvVgFr4=
 github.com/lucasb-eyer/go-colorful v1.4.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/luispabon/ultraviolet v0.0.0-20260625204701-67215642e1d1 h1:/NzRUXHEv54rfRy8jcLNaDmknK4kcwNstHT0HZYgX6Q=
+github.com/luispabon/ultraviolet v0.0.0-20260625204701-67215642e1d1/go.mod h1:f/jRa757WUmaOZrbPspXymbg/GnbF+rwe4OLsG7aXYo=
 github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
 github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=


### PR DESCRIPTION
Closes #1724

Depends on charmbracelet/ultraviolet#130.

This optimises `cursedRenderer.flush()` for vertical scrolling by detecting string-level line shifts, trimming identical fixed chrome, shifting the cell buffer in place, and using ultraviolet `HardScroll` plus `DrawOver` only for newly exposed lines. When no scroll pattern is detected, it falls back to the original `Clear` + `Draw` path.

## Benchstat (`sec/op`)

| Benchmark | Before | After | Delta |
| --- | ---: | ---: | ---: |
| FlushScroll-16 | 833.3µs | 160.2µs | -80.78% |
| FlushScrollPartial-16 | 871.7µs | 202.1µs | -76.82% |
| FlushScrollWithSuffix-16 | 873.0µs | 181.0µs | -79.27% |

`FlushStatic-16` and `FlushFullChange-16` were regression-free in `sec/op` (`p=0.183` and `p=1.000`, respectively).

## Files

New files:
- `cursed_renderer_bench_test.go`
- `cursed_renderer_scroll.go`
- `cursed_renderer_scroll_test.go`

Modified files:
- `cursed_renderer.go`
- `go.mod`
- `go.sum`
