### PR TITLE
fix: guard ProgressBarState.String against out-of-range values

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -319,13 +319,17 @@ const (
 
 // String return a human-readable value for the given [ProgressBarState].
 func (s ProgressBarState) String() string {
-	return [...]string{
+	names := [...]string{
 		"None",
 		"Default",
 		"Error",
 		"Indeterminate",
 		"Warning",
-	}[s]
+	}
+	if s < 0 || int(s) >= len(names) {
+		return fmt.Sprintf("ProgressBarState(%d)", int(s))
+	}
+	return names[s]
 }
 
 // ProgressBar represents the terminal progress bar.

--- a/tea_test.go
+++ b/tea_test.go
@@ -669,3 +669,22 @@ func BenchmarkTeaRun(b *testing.B) {
 		_ = r.CloseWithError(io.EOF)
 	}
 }
+
+func TestProgressBarStateString(t *testing.T) {
+	for _, tc := range []struct {
+		state ProgressBarState
+		want  string
+	}{
+		{ProgressBarNone, "None"},
+		{ProgressBarDefault, "Default"},
+		{ProgressBarError, "Error"},
+		{ProgressBarIndeterminate, "Indeterminate"},
+		{ProgressBarWarning, "Warning"},
+		{ProgressBarState(5), "ProgressBarState(5)"},
+		{ProgressBarState(-1), "ProgressBarState(-1)"},
+	} {
+		if got := tc.state.String(); got != tc.want {
+			t.Errorf("ProgressBarState(%d).String() = %q, want %q", int(tc.state), got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
- [x] I have read [`CONTRIBUTING.md`](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).
- [ ] I have created a discussion that was approved by a maintainer (for new features).

## Summary

Closes #1711.

`ProgressBarState.String()` indexed a fixed length-5 array directly with the receiver, so any value outside `[0, 4]` panicked with an index-out-of-range error. Since `State` is an exported field on `ProgressBar`, a value can reach the method without going through `NewProgressBar`.

## Fix

Bounds-check before indexing and return a formatted fallback (`ProgressBarState(N)`) for unknown values, matching the convention used by `stringer`-generated code.

## Before / after

Before, `ProgressBarState(5).String()` panics. After, it returns `"ProgressBarState(5)"`, and valid states are unchanged.

Added a table test covering the five defined states plus an out-of-range and a negative value.
