### PR TITLE
ci: fix examples workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -3,15 +3,15 @@ name: examples
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
     paths:
       - '.github/workflows/examples.yml'
-      - './examples/go.mod'
-      - './examples/go.sum'
-      - './tutorials/go.mod'
-      - './tutorials/go.sum'
-      - './go.mod'
-      - './go.sum'
+      - 'examples/go.mod'
+      - 'examples/go.sum'
+      - 'tutorials/go.mod'
+      - 'tutorials/go.sum'
+      - 'go.mod'
+      - 'go.sum'
   workflow_dispatch: {}
 
 jobs:
@@ -32,7 +32,7 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: go mod tidy tutorials and examples"
-          branch: master
+          branch: main
           commit_user_name: actions-user
           commit_user_email: actions@github.com
 


### PR DESCRIPTION
Hi, and thank you for Bubble Tea.

Small fix: the `examples` workflow (`.github/workflows/examples.yml`) never runs. It triggers on `push` to `master`, but the repo's default branch is `main` and there's no `master` branch — so `actions/workflows/examples.yml/runs` shows `total_count: 0`, and the `go mod tidy` for `examples/` and `tutorials/` is currently done by hand.

This PR:
- changes the trigger branch and the `git-auto-commit-action` target from `master` → `main`, and
- drops the `./` prefixes on the `paths:` filters (GitHub Actions path globs are repo-root-relative and don't match a `./` prefix, so `./examples/go.mod` wouldn't match `examples/go.mod` even once the branch is fixed).

Kept it minimal and single-purpose. Happy to adjust.

For transparency: I used AI assistance to help identify this and draft the change; I verified the workflow, the branch list, and the 0-run count against the live repo myself.
