### PR TITLE
fix(renderer): flush queued view before insert above

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -705,12 +705,22 @@ func (s *cursedRenderer) setWidthMethod(method ansi.Method) {
 
 // insertAbove implements renderer.
 func (s *cursedRenderer) insertAbove(str string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	if len(str) == 0 {
 		return nil
 	}
+
+	// render only queues the latest View; the frame ticker flushes it later.
+	// A Println can therefore reach insertAbove after the model has changed
+	// View but before that frame is physically on the terminal. Scrolling with
+	// the previous cellbuf geometry can weld rows from the stale frame into
+	// native scrollback. Flush the queued View first so cellbuf, the terminal,
+	// and the geometry below all describe one frame.
+	if err := s.flush(false); err != nil {
+		return fmt.Errorf("bubbletea: error flushing before insert above: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	var sb strings.Builder
 	w, h := s.cellbuf.Width(), s.cellbuf.Height()

--- a/cursed_renderer_test.go
+++ b/cursed_renderer_test.go
@@ -1,8 +1,10 @@
 package tea
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 )
@@ -76,5 +78,39 @@ func TestCursedRenderer_mouseVsFlush(t *testing.T) {
 	case <-runDone:
 	case <-time.After(5 * time.Second):
 		t.Fatal("program did not exit after Quit")
+	}
+}
+
+func TestCursedRenderer_insertAboveFlushesQueuedView(t *testing.T) {
+	var output bytes.Buffer
+	r := newCursedRenderer(
+		&output,
+		[]string{"TERM=xterm-256color", "TERM_PROGRAM=Apple_Terminal"},
+		80,
+		24,
+	)
+
+	r.render(NewView("stale frame\nstale row"))
+	if err := r.flush(false); err != nil {
+		t.Fatalf("flush initial view: %v", err)
+	}
+
+	output.Reset()
+	r.render(NewView("current frame"))
+	if err := r.insertAbove("committed block"); err != nil {
+		t.Fatalf("insert above: %v", err)
+	}
+
+	if r.lastView == nil || r.lastView.Content != "current frame" {
+		t.Fatalf("insertAbove did not flush the queued view: %#v", r.lastView)
+	}
+	written := output.String()
+	currentAt := strings.Index(written, "current frame")
+	committedAt := strings.Index(written, "committed block")
+	if currentAt < 0 || committedAt < 0 {
+		t.Fatalf("output missing markers (current=%d, committed=%d): %q", currentAt, committedAt, written)
+	}
+	if currentAt > committedAt {
+		t.Fatalf("inserted scrollback before flushing current frame: %q", written)
 	}
 }


### PR DESCRIPTION
## Summary

- flush the latest queued inline `View` before `insertAbove` calculates scroll geometry
- propagate a flush failure instead of inserting scrollback against stale renderer state
- add a regression test that verifies the current frame is rendered before the committed block

## Root cause

`render` only queues the latest `View`; the frame ticker flushes it asynchronously. `Println` can therefore reach `insertAbove` after the model has produced a shorter view but before that view has reached the terminal.

At that point, `insertAbove` uses the previous `cellbuf` and cursor geometry. Rows from the stale managed frame can then be moved into native scrollback and remain there permanently.

Flushing at the renderer boundary keeps the queued view, `cellbuf`, terminal output, and the subsequent scroll calculation on the same frame.

Fixes #1736.

Downstream regression and integration coverage: https://github.com/genai-io/san/pull/401

## Testing

- `go test ./...`
- `go test -race ./...`
