### PR TITLE
fix(cursed_renderer): don't scroll viewport on Println/Printf before first flush

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -714,6 +714,26 @@ func (s *cursedRenderer) insertAbove(str string) error {
 
 	var sb strings.Builder
 	w, h := s.cellbuf.Width(), s.cellbuf.Height()
+
+	// The cellbuf is created at the full terminal height in
+	// [newCursedRenderer] and is only resized to the current frame height
+	// inside [cursedRenderer.flush]. If an insertAbove happens before the
+	// first flush (e.g. a tea.Println/tea.Printf issued from Model.Init), the
+	// cellbuf height is still the full terminal height. Using it below would
+	// move the cursor down a full screen and scroll the whole viewport. Clamp
+	// the height to the currently stashed frame height so we only scroll the
+	// lines the frame actually occupies. In alt screen mode the frame always
+	// occupies the full height, so it's left untouched.
+	if !s.view.AltScreen {
+		frameHeight := 0
+		if len(s.view.Content) > 0 {
+			frameHeight = uv.NewStyledString(s.view.Content).Height()
+		}
+		if frameHeight < h {
+			h = frameHeight
+		}
+	}
+
 	_, y := s.scr.Position()
 
 	// We need to scroll the screen up by the number of lines in the queue.

--- a/cursed_renderer_test.go
+++ b/cursed_renderer_test.go
@@ -1,8 +1,12 @@
 package tea
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"regexp"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -77,4 +81,129 @@ func TestCursedRenderer_mouseVsFlush(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("program did not exit after Quit")
 	}
+}
+
+// cursorDownRe matches ANSI cursor-down sequences (CSI n B).
+var cursorDownRe = regexp.MustCompile(`\x1b\[(\d+)B`)
+
+// maxCursorDown returns the largest cursor-down (CSI n B) distance found in s,
+// or 0 if there are none.
+func maxCursorDown(s string) int {
+	max := 0
+	for _, m := range cursorDownRe.FindAllStringSubmatch(s, -1) {
+		if n, err := strconv.Atoi(m[1]); err == nil && n > max {
+			max = n
+		}
+	}
+	return max
+}
+
+// TestCursedRenderer_insertAboveBeforeFlush reproduces
+// https://github.com/charmbracelet/bubbletea/issues/1740.
+//
+// A tea.Println/tea.Printf issued before the renderer's first flush (e.g. from
+// Model.Init) went through insertAbove, which computed the cursor-down distance
+// from the cellbuf height. Since the cellbuf is created at the full terminal
+// height and only resized to the frame height during flush, the cursor was
+// moved down a full screen and the whole viewport scrolled. This drives the
+// renderer directly to keep the assertion deterministic (no ticker race).
+func TestCursedRenderer_insertAboveBeforeFlush(t *testing.T) {
+	t.Parallel()
+
+	const width, height = 80, 24
+	var buf bytes.Buffer
+	r := newCursedRenderer(&buf, []string{"TERM=xterm-256color"}, width, height)
+
+	// Program.Run stashes the initial view via render() before the event loop
+	// starts, but the first flush only happens later on the render ticker.
+	r.render(NewView("hello world"))
+
+	// A tea.Println that runs before that first flush.
+	if err := r.insertAbove("printed from Init"); err != nil {
+		t.Fatalf("insertAbove returned error: %v", err)
+	}
+
+	out := buf.String()
+	if got := maxCursorDown(out); got >= height-1 {
+		t.Fatalf("insertAbove before first flush scrolled the viewport: "+
+			"emitted cursor-down of %d (frame is 1 line tall), output=%q", got, out)
+	}
+}
+
+// printInInitModel issues a tea.Println from Init and renders a single line.
+type printInInitModel struct{}
+
+func (printInInitModel) Init() Cmd { return Println("printed from Init") }
+
+func (printInInitModel) Update(msg Msg) (Model, Cmd) {
+	if _, ok := msg.(KeyPressMsg); ok {
+		return printInInitModel{}, Quit
+	}
+	return printInInitModel{}, nil
+}
+
+func (printInInitModel) View() View { return NewView("hello world") }
+
+// TestCursedRenderer_printlnFromInit drives a full Program with a fixed window
+// size and asserts that a tea.Println from Init does not emit a large cursor
+// down (which would scroll the whole terminal). Regression test for
+// https://github.com/charmbracelet/bubbletea/issues/1740.
+func TestCursedRenderer_printlnFromInit(t *testing.T) {
+	t.Parallel()
+
+	const width, height = 80, 24
+	out := &safeBuffer{}
+
+	p := NewProgram(
+		printInInitModel{},
+		WithContext(t.Context()),
+		WithInput(&bytes.Buffer{}),
+		WithOutput(out),
+		WithEnvironment([]string{
+			"TERM=xterm-256color",
+			"TERM_PROGRAM=Apple_Terminal",
+		}),
+		WithoutSignals(),
+		WithWindowSize(width, height),
+	)
+
+	runDone := make(chan struct{})
+	go func() {
+		defer close(runDone)
+		_, _ = p.Run()
+	}()
+
+	// Give Init's Println time to hit insertAbove and let at least one frame
+	// flush.
+	time.Sleep(200 * time.Millisecond)
+
+	p.Quit()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("program did not exit after Quit")
+	}
+
+	if got := maxCursorDown(out.String()); got >= height-1 {
+		t.Fatalf("Println from Init scrolled the viewport: emitted cursor-down "+
+			"of %d (frame is 1 line tall), output=%q", got, out.String())
+	}
+}
+
+// safeBuffer is a goroutine-safe bytes.Buffer.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }


### PR DESCRIPTION
Fixes #1740

**Root cause:** `insertAbove` derived its cursor-down distance (`down := h - y - 1`) from `cellbuf.Height()`. The cellbuf is allocated at the full terminal height in `newCursedRenderer` and only resized to the current frame height inside `flush()`; `render()`/`resize()` never touch it. So a `tea.Println`/`tea.Printf` before the first flush (e.g. from `Model.Init`) moved the cursor down nearly a full screen and scrolled the scrollback viewport.

**Fix:** In `insertAbove`, clamp the height to the currently-stashed frame's content height (skipped in alt-screen mode, where the frame legitimately fills the screen). No-op once a flush has occurred, since the cellbuf height then already matches the frame height, so normal flush/scroll behavior is unaffected.

**Tests:** Adds `TestCursedRenderer_insertAboveBeforeFlush` (drives the renderer directly, deterministic) and `TestCursedRenderer_printlnFromInit` (drives a full `Program` with `WithWindowSize`), both asserting no large `ESC[nB` is written for a one-line frame. Verified both fail on `main` and pass with the fix. `go test ./...`, `go vet ./...`, and `gofmt` are clean.