### PR TITLE
examples/sequence: fix milisecond typo in SleepPrintln

### DIFF
--- a/examples/sequence/main.go
+++ b/examples/sequence/main.go
@@ -43,10 +43,10 @@ func (m model) Init() tea.Cmd {
 }
 
 // print string after stopping for a certain period of time
-func SleepPrintln(s string, milisecond int) tea.Cmd {
+func SleepPrintln(s string, millisecond int) tea.Cmd {
 	printCmd := tea.Println(s)
 	return func() tea.Msg {
-		time.Sleep(time.Duration(milisecond) * time.Millisecond)
+		time.Sleep(time.Duration(millisecond) * time.Millisecond)
 		return printCmd()
 	}
 }


### PR DESCRIPTION
The `SleepPrintln` helper in the `sequence` example spells its parameter
`milisecond` instead of `millisecond`. This renames it to the correct
spelling (both the declaration and its use inside the returned command).

Docs/example-only change; no behavior change.
