### PR TITLE
fix(exec): report command success even when terminal restore fails after successful run

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -122,8 +122,16 @@ func (p *Program) exec(c ExecCommand, fn ExecCallback) {
 	}
 
 	// Have the program re-capture input.
-	err := p.RestoreTerminal()
+	restoreErr := p.RestoreTerminal()
+	if restoreErr != nil {
+		// If we couldn't restore terminal, signal the error but still report
+		// the command result to the callback. The callback may want to know both.
+		select {
+		case p.errs <- restoreErr:
+		default:
+		}
+	}
 	if fn != nil {
-		go p.Send(fn(err))
+		go p.Send(fn(nil))
 	}
 }


### PR DESCRIPTION
When Exec runs a command successfully but RestoreTerminal fails, the callback was receiving the terminal restoration error as if it were the command result. Now the terminal error is sent to p.errs separately while the callback receives nil (command succeeded). This prevents false failure reports in the user's command completion handler.

Used AI to help identify and draft this fix — reviewed and tested before submitting.