### PR TITLE
fix: don't panic in ProgressBarState.String() for out-of-range values

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -317,7 +317,8 @@ const (
 	ProgressBarWarning
 )
 
-// String return a human-readable value for the given [ProgressBarState].
+// String returns a human-readable name for the given [ProgressBarState].
+// Values outside the known range return "Unknown".
 func (s ProgressBarState) String() string {
 	states := [...]string{
 		"None",

--- a/tea.go
+++ b/tea.go
@@ -320,17 +320,20 @@ const (
 // String returns a human-readable name for the given [ProgressBarState].
 // Values outside the known range return "Unknown".
 func (s ProgressBarState) String() string {
-	states := [...]string{
-		"None",
-		"Default",
-		"Error",
-		"Indeterminate",
-		"Warning",
-	}
-	if s < 0 || int(s) >= len(states) {
+	switch s {
+	case ProgressBarNone:
+		return "None"
+	case ProgressBarDefault:
+		return "Default"
+	case ProgressBarError:
+		return "Error"
+	case ProgressBarIndeterminate:
+		return "Indeterminate"
+	case ProgressBarWarning:
+		return "Warning"
+	default:
 		return "Unknown"
 	}
-	return states[s]
 }
 
 // ProgressBar represents the terminal progress bar.

--- a/tea.go
+++ b/tea.go
@@ -319,13 +319,17 @@ const (
 
 // String return a human-readable value for the given [ProgressBarState].
 func (s ProgressBarState) String() string {
-	return [...]string{
+	states := [...]string{
 		"None",
 		"Default",
 		"Error",
 		"Indeterminate",
 		"Warning",
-	}[s]
+	}
+	if s < 0 || int(s) >= len(states) {
+		return "Unknown"
+	}
+	return states[s]
 }
 
 // ProgressBar represents the terminal progress bar.

--- a/tea_test.go
+++ b/tea_test.go
@@ -669,3 +669,23 @@ func BenchmarkTeaRun(b *testing.B) {
 		_ = r.CloseWithError(io.EOF)
 	}
 }
+
+// TestProgressBarStateStringOutOfRange is a regression test for
+// https://github.com/charmbracelet/bubbletea/issues/1711: String panicked
+// with an index-out-of-range error for any ProgressBarState outside the
+// [ProgressBarNone, ProgressBarWarning] range. Since State is an exported
+// field on ProgressBar, callers can assign such a value without going
+// through NewProgressBar.
+func TestProgressBarStateStringOutOfRange(t *testing.T) {
+	for _, s := range []ProgressBarState{-1, 5, 100} {
+		if got, want := s.String(), "Unknown"; got != want {
+			t.Errorf("ProgressBarState(%d).String() = %q, want %q", int(s), got, want)
+		}
+	}
+
+	for s := ProgressBarNone; s <= ProgressBarWarning; s++ {
+		if got := s.String(); got == "Unknown" {
+			t.Errorf("ProgressBarState(%d).String() = %q, want a known name", int(s), got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`ProgressBarState.String()` indexes a fixed 5-element array literal directly with the receiver value:

```go
func (s ProgressBarState) String() string {
	return [...]string{
		"None", "Default", "Error", "Indeterminate", "Warning",
	}[s]
}
```

`ProgressBar.State` is an exported field, so a caller can assign a value outside `[ProgressBarNone, ProgressBarWarning]` without going through `NewProgressBar`, e.g.:

```go
var s tea.ProgressBarState = 5
s.String() // panics: index out of range [5] with length 5
```

Negative values panic too (`index out of range [-1]`).

## Fix

Add a bounds check and return `"Unknown"` for anything outside the known range, matching the general expectation that a `Stringer` implementation should never panic (it's often invoked implicitly via `%v`/`%s` formatting or logging).

## Testing

- Added `TestProgressBarStateStringOutOfRange`, which checks that out-of-range values (`-1`, `5`, `100`) return `"Unknown"` without panicking, and that every defined state still returns its own name.
- Verified by reverting just the `tea.go` change: the test fails with the exact panic from the issue (`index out of range [-1]`, at the indexing expression in `String`).
- Ran the full test suite (`go build ./...` and `go test ./...`); everything passes.

Fixes #1711