### PR TITLE
test: stabilize view model golden output

### DIFF
--- a/screen_test.go
+++ b/screen_test.go
@@ -138,6 +138,9 @@ func TestViewModel(t *testing.T) {
 
 			m := &testViewModel{testModel: &testModel{}}
 			p := NewProgram(m,
+				// Keep the renderer ticker from introducing intermediate frames into
+				// this golden-output test.
+				WithFPS(1),
 				// Set the initial window size for the program.
 				WithWindowSize(80, 24),
 				// Use ANSI256 to increase test coverage.


### PR DESCRIPTION
Closes #1746.

`TestViewModel` compares the complete terminal output against golden files, but its program uses the default 60 FPS renderer ticker. Under the race detector with `GOMAXPROCS=1`, that ticker can flush an intermediate frame before `Quit` is handled, making valid renderer timing change the escape-sequence ordering.

Run this short golden-output test at 1 FPS so the asynchronous renderer tick stays outside the test window. Production behavior is unchanged, and the existing golden files remain unchanged.

Validation:
- `go test -race -count 1000 -cpu 1 -run TestViewModel ./...`
- `go test -race -count 4 -cpu 1,4 ./...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- `git diff --check`