### PR TITLE
docs: fix background color detection example in doc comment

### DIFF
--- a/color.go
+++ b/color.go
@@ -54,8 +54,8 @@ func (e ForegroundColorMsg) IsDark() bool {
 // [BackgroundColorMsg.IsDark] to determine if the color is dark or light. For
 // example:
 //
-//	func (m Model) Init() (Model, Cmd) {
-//	  return m, RequestBackgroundColor()
+//	func (m Model) Init() Cmd {
+//	  return RequestBackgroundColor()
 //	}
 //
 //	func (m Model) Update(msg Msg) (Model, Cmd) {


### PR DESCRIPTION
This revision updates the API in a doc comment explaining how to do light/dark background color detection.