### PR TITLE
fix: assign MouseButton11 = uv.MouseButton11

### DIFF
--- a/mouse.go
+++ b/mouse.go
@@ -38,7 +38,7 @@ const (
 	MouseBackward   = uv.MouseBackward
 	MouseForward    = uv.MouseForward
 	MouseButton10   = uv.MouseButton10
-	MouseButton11
+	MouseButton11   = uv.MouseButton11
 )
 
 // MouseMsg represents a mouse message. This is a generic mouse message that


### PR DESCRIPTION
## Bug

In `mouse.go` the `MouseButton11` constant is missing its explicit initializer:

```go
// before
MouseButton10   = uv.MouseButton10
MouseButton11                         // repeats previous expression
```

In Go, a `const` entry that omits its value repeats the **expression** of the immediately preceding entry (not a numeric increment). Since the preceding expression is `uv.MouseButton10`, `MouseButton11` silently evaluates to `uv.MouseButton10` (value `10`).

Consequently `tea.MouseButton11 == tea.MouseButton10`, and any code that matches on `tea.MouseButton11` can never trigger correctly - the switch arm collides with button 10.

## Fix

Explicitly map the constant to its upstream value, matching the pattern of every other constant in the block:

```go
// after
MouseButton10   = uv.MouseButton10
MouseButton11   = uv.MouseButton11
```

One-line fix. No behaviour changes for any other constant.

## Verification

- All other constants in the block use the `= uv.<Name>` pattern
- `uv.MouseButton11` is defined in `charmbracelet/ultraviolet` as iota value `11`
- After this fix `tea.MouseButton11 == 11` and `tea.MouseButton10 == 10`, matching the X11 numbering in the block's comment

- [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md)