### PR TITLE
fix: avoid blocking Program.Print methods after exit

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -1369,10 +1369,11 @@ func (p *Program) RestoreTerminal() error {
 // and will persist across renders by the Program.
 //
 // If the altscreen is active no output will be printed.
+// If the program has already exited this is a no-op.
 func (p *Program) Println(args ...any) {
-	p.msgs <- printLineMessage{
+	p.Send(printLineMessage{
 		messageBody: fmt.Sprint(args...),
-	}
+	})
 }
 
 // Printf prints above the Program. It takes a format template followed by
@@ -1383,10 +1384,11 @@ func (p *Program) Println(args ...any) {
 // its own line.
 //
 // If the altscreen is active no output will be printed.
+// If the program has already exited this is a no-op.
 func (p *Program) Printf(template string, args ...any) {
-	p.msgs <- printLineMessage{
+	p.Send(printLineMessage{
 		messageBody: fmt.Sprintf(template, args...),
-	}
+	})
 }
 
 // startRenderer starts the renderer.

--- a/tea_test.go
+++ b/tea_test.go
@@ -533,6 +533,49 @@ func TestTeaSend(t *testing.T) {
 	p.Send(Quit())
 }
 
+func TestProgramPrintAfterExit(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	var in bytes.Buffer
+
+	p := NewProgram(&testModel{},
+		WithInput(&in),
+		WithOutput(&buf),
+	)
+	go p.Send(Quit())
+	if _, err := p.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name  string
+		print func()
+	}{
+		{"Println", func() { p.Println("after exit") }},
+		{"Printf", func() { p.Printf("after %s", "exit") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done := make(chan struct{})
+			go func() {
+				tt.print()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(100 * time.Millisecond):
+				// Receive only after detecting the block. This releases the
+				// direct channel send used before this regression was fixed,
+				// so the test does not leak a goroutine against the old code.
+				<-p.msgs
+				<-done
+				t.Fatal("print blocked after the program exited")
+			}
+		})
+	}
+}
+
 func TestTeaNoRun(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Problem

`Program.Println` and `Program.Printf` send directly to the unbuffered `p.msgs` channel. After `Run` returns, the event loop is gone and there is no receiver, so either method blocks forever when called during late goroutine cleanup or after program shutdown.

This differs from `Program.Send`, which already documents and implements post-exit calls as a no-op by selecting on the program context.

## Fix

Route both print methods through `Program.Send` and document the post-exit behavior. Printing while the program is running is unchanged; after exit the methods now return instead of leaking or deadlocking a goroutine.

The regression test runs a program to completion and verifies both methods return. Against `main`, each call remains blocked on `p.msgs`.

## Validation

- `go test -run TestProgramPrintAfterExit -count=100 ./...`
- `go test -race -run TestProgramPrintAfterExit -count=50 ./...`
- `go test ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go test ./...` in `examples/`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- `git diff --check`

- [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).