### PR TITLE
fix(logging): preserve Unicode prefix spacing

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"unicode"
+	"unicode/utf8"
 )
 
 // LogToFile sets up default logging to log to a file. This is helpful as we
@@ -42,8 +43,8 @@ func LogToFileWith(path string, prefix string, log LogOptionsSetter) (*os.File, 
 	// Add a space after the prefix if a prefix is being specified and it
 	// doesn't already have a trailing space.
 	if len(prefix) > 0 {
-		finalChar := prefix[len(prefix)-1]
-		if !unicode.IsSpace(rune(finalChar)) {
+		finalRune, _ := utf8.DecodeLastRuneInString(prefix)
+		if !unicode.IsSpace(finalRune) {
 			prefix += " "
 		}
 	}

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,6 +1,7 @@
 package tea
 
 import (
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -25,5 +26,36 @@ func TestLogToFile(t *testing.T) {
 	}
 	if string(out) != prefix+" some test log\n" {
 		t.Fatalf("wrong log msg: %q", string(out))
+	}
+}
+
+func TestLogToFileWithPrefixSpacing(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{"empty", "", ""},
+		{"missing space", "prefix", "prefix "},
+		{"ASCII space", "prefix ", "prefix "},
+		{"non-breaking space", "prefix\u00a0", "prefix\u00a0"},
+		{"ideographic space", "prefix\u3000", "prefix\u3000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.New(io.Discard, "", 0)
+			f, err := LogToFileWith(filepath.Join(t.TempDir(), "log.txt"), tt.prefix, logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			if got := logger.Prefix(); got != tt.want {
+				t.Fatalf("prefix = %q; want %q", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

`LogToFileWith` promises to append an ASCII space only when the supplied prefix does not already end in whitespace. It currently inspects the final byte and converts that byte to a rune:

```go
finalChar := prefix[len(prefix)-1]
unicode.IsSpace(rune(finalChar))
```

That works for ASCII but misreads every multibyte trailing rune. Prefixes ending in valid Unicode whitespace such as U+00A0 NO-BREAK SPACE or U+3000 IDEOGRAPHIC SPACE therefore receive an unwanted extra ASCII space.

## Fix

Decode the final UTF-8 rune before applying `unicode.IsSpace`. ASCII behavior stays unchanged, while multibyte whitespace now follows the documented rule.

The table-driven regression test covers empty prefixes, missing and existing ASCII spaces, U+00A0, and U+3000.

## Validation

- `go test -run TestLogToFile -count=100 ./...`
- `go test -race -run TestLogToFile -count=20 ./...`
- `go test ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go test ./...` in `examples/`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run`
- `git diff --check`

- [x] I have read [CONTRIBUTING.md](https://github.com/charmbracelet/.github/blob/main/CONTRIBUTING.md).