### PR TITLE
feat: add configurable scroll optimization

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"image/color"
 	"io"
-	"runtime"
 	"strings"
 	"sync"
 
@@ -31,17 +30,19 @@ type cursedRenderer struct {
 	hardTabs      bool // whether to use hard tabs to optimize cursor movements
 	backspace     bool // whether to use backspace to optimize cursor movements
 	mapnl         bool
+	scrollOptim   bool // whether to use terminal scroll/insert/delete-line optimizations
 	syncdUpdates  bool // whether to use synchronized output mode for updates
 	starting      bool // indicates whether the renderer is starting after being stopped
 }
 
 var _ renderer = &cursedRenderer{}
 
-func newCursedRenderer(w io.Writer, env []string, width, height int) (s *cursedRenderer) {
+func newCursedRenderer(w io.Writer, env []string, width, height int, scrollOptim bool) (s *cursedRenderer) {
 	s = new(cursedRenderer)
 	s.w = w
 	s.env = env
 	s.term = uv.Environ(env).Getenv("TERM")
+	s.scrollOptim = scrollOptim
 	s.width, s.height = width, height // This needs to happen before [cursedRenderer.reset].
 	s.cellbuf = uv.NewScreenBuffer(s.width, s.height)
 	reset(s)
@@ -603,7 +604,7 @@ func reset(s *cursedRenderer) {
 	}
 	scr.SetBackspace(s.backspace)
 	scr.SetMapNewline(s.mapnl)
-	scr.SetScrollOptim(runtime.GOOS != "windows") // disable scroll optimization on Windows due to bugs in some terminals
+	scr.SetScrollOptim(s.scrollOptim)
 	s.scr = scr
 }
 

--- a/cursed_renderer_test.go
+++ b/cursed_renderer_test.go
@@ -1,11 +1,52 @@
 package tea
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 )
+
+func renderScrolledFrame(t *testing.T, scrollOptim, resetRenderer bool) string {
+	t.Helper()
+	var output bytes.Buffer
+	r := newCursedRenderer(&output, []string{"TERM=xterm-256color"}, 10, 5, scrollOptim)
+	if resetRenderer {
+		r.reset()
+	}
+	r.render(View{Content: "AAAAAAAAAA\nBBBBBBBBBB\nCCCCCCCCCC\nDDDDDDDDDD\nEEEEEEEEEE", AltScreen: true})
+	if err := r.flush(false); err != nil {
+		t.Fatalf("initial flush failed: %v", err)
+	}
+	output.Reset()
+	r.render(View{Content: "CCCCCCCCCC\nDDDDDDDDDD\nEEEEEEEEEE\nFFFFFFFFFF\nGGGGGGGGGG", AltScreen: true})
+	if err := r.flush(false); err != nil {
+		t.Fatalf("scrolled flush failed: %v", err)
+	}
+	return output.String()
+}
+
+func TestCursedRenderer_scrollOptimization(t *testing.T) {
+	for _, resetRenderer := range []bool{false, true} {
+		resetRenderer := resetRenderer
+		t.Run(fmt.Sprintf("reset=%v", resetRenderer), func(t *testing.T) {
+			t.Parallel()
+			enabled := renderScrolledFrame(t, true, resetRenderer)
+			disabled := renderScrolledFrame(t, false, resetRenderer)
+
+			if !strings.Contains(enabled, "\x1b[2S") {
+				t.Fatalf("enabled renderer did not use scroll optimization: %q", enabled)
+			}
+			for _, sequence := range []string{"\x1b[S", "\x1b[2S", "\x1b[T", "\x1b[2T", "\x1b[L", "\x1b[M"} {
+				if strings.Contains(disabled, sequence) {
+					t.Fatalf("disabled renderer emitted scroll optimization sequence %q: %q", sequence, disabled)
+				}
+			}
+		})
+	}
+}
 
 type mouseRaceModel struct {
 	i int

--- a/cursed_renderer_test.go
+++ b/cursed_renderer_test.go
@@ -39,6 +39,9 @@ func TestCursedRenderer_scrollOptimization(t *testing.T) {
 			if !strings.Contains(enabled, "\x1b[2S") {
 				t.Fatalf("enabled renderer did not use scroll optimization: %q", enabled)
 			}
+			if strings.Contains(disabled, "\x1b[2J") {
+				t.Fatalf("disabled renderer used a full-screen clear for a regular frame update: %q", disabled)
+			}
 			for _, sequence := range []string{"\x1b[S", "\x1b[2S", "\x1b[T", "\x1b[2T", "\x1b[L", "\x1b[M"} {
 				if strings.Contains(disabled, sequence) {
 					t.Fatalf("disabled renderer emitted scroll optimization sequence %q: %q", sequence, disabled)

--- a/options.go
+++ b/options.go
@@ -101,6 +101,20 @@ func WithoutRenderer() ProgramOption {
 	}
 }
 
+// WithScrollOptimization controls whether the renderer may use terminal
+// scrolling primitives when transforming one frame into the next. By default,
+// scroll optimization is enabled on non-Windows platforms and disabled on
+// Windows for compatibility with terminals that mishandle these sequences.
+//
+// Disable this option when the display terminal is known to render scroll,
+// insert-line, or delete-line sequences incorrectly. It has no effect when the
+// renderer is disabled with [WithoutRenderer].
+func WithScrollOptimization(enabled bool) ProgramOption {
+	return func(p *Program) {
+		p.scrollOptimization = &enabled
+	}
+}
+
 // WithFilter supplies an event filter that will be invoked before Bubble Tea
 // processes a tea.Msg. The event filter can return any tea.Msg which will then
 // get handled by Bubble Tea instead of the original event. If the event filter

--- a/options_test.go
+++ b/options_test.go
@@ -3,6 +3,7 @@ package tea
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -23,6 +24,40 @@ func TestOptions(t *testing.T) {
 		p := NewProgram(nil, WithoutRenderer())
 		if !p.disableRenderer {
 			t.Errorf("expected renderer to be a nilRenderer, got %v", p.renderer)
+		}
+	})
+
+	t.Run("scroll optimization", func(t *testing.T) {
+		for _, enabled := range []bool{false, true} {
+			enabled := enabled
+			t.Run(fmt.Sprint(enabled), func(t *testing.T) {
+				t.Parallel()
+				p := NewProgram(nil, WithScrollOptimization(enabled))
+				if p.scrollOptimization == nil || *p.scrollOptimization != enabled {
+					t.Fatalf("expected scroll optimization %v, got %v", enabled, p.scrollOptimization)
+				}
+			})
+		}
+
+		trueValue := true
+		falseValue := false
+		for _, tt := range []struct {
+			name       string
+			goos       string
+			configured *bool
+			want       bool
+		}{
+			{name: "windows default", goos: "windows", want: false},
+			{name: "non-windows default", goos: "linux", want: true},
+			{name: "windows explicit true", goos: "windows", configured: &trueValue, want: true},
+			{name: "non-windows explicit false", goos: "darwin", configured: &falseValue, want: false},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+				if got := scrollOptimizationEnabled(tt.goos, tt.configured); got != tt.want {
+					t.Fatalf("scrollOptimizationEnabled(%q, %v) = %v, want %v", tt.goos, tt.configured, got, tt.want)
+				}
+			})
 		}
 	})
 

--- a/tea.go
+++ b/tea.go
@@ -485,6 +485,10 @@ type Program struct {
 	// UI but still want to take advantage of Bubble Tea's architecture.
 	disableRenderer bool
 
+	// scrollOptimization overrides the platform default for renderer-level
+	// terminal scrolling primitives. Nil preserves the default behavior.
+	scrollOptimization *bool
+
 	// handlers is a list of channels that need to be waited on before the
 	// program can exit.
 	handlers channelHandlers
@@ -1058,11 +1062,13 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 			p.renderer = &nilRenderer{}
 		} else {
 			// If no renderer is set use the cursed one.
+			scrollOptimization := scrollOptimizationEnabled(runtime.GOOS, p.scrollOptimization)
 			r := newCursedRenderer(
 				p.output,
 				p.environ,
 				p.width,
 				p.height,
+				scrollOptimization,
 			)
 			r.setLogger(p.logger)
 			// XXX: This breaks many things especially when we want the output
@@ -1171,6 +1177,13 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 	p.shutdown(killed)
 
 	return model, err
+}
+
+func scrollOptimizationEnabled(goos string, configured *bool) bool {
+	if configured != nil {
+		return *configured
+	}
+	return goos != "windows"
 }
 
 // Send sends a message to the main update function, effectively allowing


### PR DESCRIPTION
## Summary

- add WithScrollOptimization(enabled bool) as a public ProgramOption
- preserve the current default: enabled on non-Windows platforms and disabled on Windows
- keep the resolved policy when the cursed renderer is reset
- cover explicit overrides, platform defaults, reset behavior, and emitted VT output

## Motivation

Bubble Tea currently decides this policy inside cursedRenderer.reset by calling SetScrollOptim(runtime.GOOS != "windows"). That protects Windows terminals but gives applications no way to disable scroll-region, insert-line, or delete-line optimizations for another incompatible display terminal.

Reasonix issue https://github.com/esengine/DeepSeek-Reasonix/issues/8090 exposed the missing capability boundary. An application-level ClearScreen after every viewport shift had originally been added to avoid stale rows in Warp, but on Windows/ConPTY that workaround produced a visible normal-render plus clear-and-redraw pair. A renderer policy is a more appropriate solution than an asynchronous application-level clear.

The option is intentionally tri-state internally so omitting it keeps existing behavior. Explicit true and false override the platform default. WithoutRenderer remains unaffected.

## Verification

- go test ./...
- go vet ./...
- renderer output test confirms disabled mode emits no scroll, insert-line, or delete-line optimization sequences
- renderer reset test confirms the selected policy persists
