### PR TITLE
fix(exec): clear View before releasing terminal for subprocess

### DIFF
--- a/cursed_renderer.go
+++ b/cursed_renderer.go
@@ -640,6 +640,18 @@ func (s *cursedRenderer) clearScreen() {
 	s.mu.Unlock()
 }
 
+// clearView implements renderer.
+func (s *cursedRenderer) clearView() {
+	s.mu.Lock()
+	// Blank the view content so the next flush writes nothing to the output.
+	// Terminal mode flags such as AltScreen are preserved so that the screen
+	// mode is restored correctly when the program resumes after the subprocess
+	// exits (see close and start). See issue #431.
+	s.view.Content = ""
+	s.view.Cursor = nil
+	s.mu.Unlock()
+}
+
 // enableAltScreen sets the alt screen mode.
 // Note that this writes to the buffer directly if write is true.
 func enableAltScreen(s *cursedRenderer, enable bool, write bool) {

--- a/exec.go
+++ b/exec.go
@@ -100,6 +100,15 @@ func (c *osExecCommand) SetStderr(w io.Writer) {
 
 // exec runs an ExecCommand and delivers the results to the program as a Msg.
 func (p *Program) exec(c ExecCommand, fn ExecCallback) {
+	// Blank the current view before releasing the terminal so the renderer's
+	// final flush doesn't write the last View() output to stdout. Without
+	// this, the view content leaks to the terminal and persists after the
+	// subprocess exits. Terminal mode flags such as AltScreen are preserved so
+	// the screen mode is restored correctly when the program resumes. See #431.
+	if p.renderer != nil {
+		p.renderer.clearView()
+	}
+
 	if err := p.releaseTerminal(false); err != nil {
 		// If we can't release input, abort.
 		if fn != nil {

--- a/exec_test.go
+++ b/exec_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -133,5 +134,110 @@ func TestTeaExecWithNilInput(t *testing.T) {
 	}
 	if m.err != nil {
 		t.Fatalf("expected no error, got %v", m.err)
+	}
+}
+
+// execLeakModel renders a distinctive marker from View() so a test can detect
+// whether the renderer flushes the View to stdout when ExecProcess hands the
+// terminal to a subprocess. Before the fix for #431, the renderer's final
+// flush on releaseTerminal wrote the last View() output to stdout, where it
+// persisted after the subprocess exited.
+type execLeakModel struct {
+	done      bool
+	altScreen bool
+}
+
+func (m *execLeakModel) Init() Cmd {
+	return ExecProcess(successExecCommand(), func(err error) Msg {
+		return execFinishedMsg{err}
+	})
+}
+
+func (m *execLeakModel) Update(msg Msg) (Model, Cmd) {
+	if _, ok := msg.(execFinishedMsg); ok {
+		m.done = true
+		return m, Quit
+	}
+	return m, nil
+}
+
+func (m *execLeakModel) View() View {
+	v := NewView("EXEC_MARKER")
+	if m.done {
+		v = NewView("QUIT_MARKER")
+	}
+	v.AltScreen = m.altScreen
+	return v
+}
+
+// TestExecProcessDoesNotLeakViewOutput is a regression test for #431: when
+// ExecProcess runs a subprocess, the renderer must not flush the last View()
+// to stdout. The program renders EXEC_MARKER until the subprocess finishes and
+// QUIT_MARKER afterwards, so EXEC_MARKER may only ever reach stdout through
+// the exec hand-off. WithFPS(1) makes the renderer's ticker fire once per
+// second, so during this short test the only flushes are the ones performed
+// when releasing the terminal for the subprocess and when shutting down, which
+// keeps the assertion deterministic.
+func TestExecProcessDoesNotLeakViewOutput(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	var in bytes.Buffer
+
+	m := &execLeakModel{}
+	p := NewProgram(m,
+		WithInput(&in),
+		WithOutput(&buf),
+		WithWindowSize(80, 24),
+		WithFPS(1),
+	)
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "EXEC_MARKER") {
+		t.Errorf("View output leaked to stdout before the subprocess ran; the renderer must not flush the last View() when handing the terminal to a subprocess (see #431)")
+	}
+	if !strings.Contains(out, "QUIT_MARKER") {
+		t.Errorf("expected the final View() (QUIT_MARKER) to be rendered on shutdown, got output: %q", out)
+	}
+}
+
+// TestExecProcessAltscreenNoLeak verifies the #431 fix also holds in alt screen
+// mode and that the program leaves the terminal in a clean state. The fix
+// preserves the AltScreen flag when blanking the view, so the screen mode is
+// restored when the program resumes; every alt screen enter must therefore be
+// paired with a leave.
+func TestExecProcessAltscreenNoLeak(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	var in bytes.Buffer
+
+	m := &execLeakModel{altScreen: true}
+	p := NewProgram(m,
+		WithInput(&in),
+		WithOutput(&buf),
+		WithWindowSize(80, 24),
+		WithFPS(1),
+	)
+	if _, err := p.Run(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "EXEC_MARKER") {
+		t.Errorf("alt screen View output leaked to stdout before the subprocess ran (see #431)")
+	}
+	const (
+		enterAlt = "\x1b[?1049h"
+		leaveAlt = "\x1b[?1049l"
+	)
+	enter := strings.Count(out, enterAlt)
+	leave := strings.Count(out, leaveAlt)
+	if enter == 0 {
+		t.Errorf("expected the program to enter the alt screen at least once, got output: %q", out)
+	}
+	if enter != leave {
+		t.Errorf("alt screen enter/leave unbalanced: enters=%d leaves=%d (output: %q)", enter, leave, out)
 	}
 }

--- a/nil_renderer.go
+++ b/nil_renderer.go
@@ -17,6 +17,9 @@ func (n nilRenderer) start() {}
 // clearScreen implements renderer.
 func (n nilRenderer) clearScreen() {}
 
+// clearView implements renderer.
+func (nilRenderer) clearView() {}
+
 // insertAbove implements renderer.
 func (n nilRenderer) insertAbove(string) error { return nil }
 

--- a/renderer.go
+++ b/renderer.go
@@ -49,6 +49,13 @@ type renderer interface {
 	// clearScreen clears the screen.
 	clearScreen()
 
+	// clearView blanks the current view's content while preserving terminal
+	// mode flags such as AltScreen, so the next flush writes no View output to
+	// the terminal. It is used before handing the terminal to a subprocess
+	// (see Exec and ExecProcess) so the last View() does not leak to stdout
+	// and persist after the subprocess exits. See issue #431.
+	clearView()
+
 	// writeString writes a string to the renderer's output.
 	writeString(string) (int, error)
 


### PR DESCRIPTION
## Summary

Fixes #431.

When `ExecProcess` (or `Exec`) runs a subprocess, the renderer's final flush wrote the current `View()` output to stdout before handing the terminal to the subprocess. In inline (non-alt-screen) mode this content persisted in the terminal after the subprocess exited, which is why the documented workaround is to return an empty string from `View()` right before issuing `ExecProcess`.

## Root cause

`exec()` calls `releaseTerminal(false)`, which calls `stopRenderer(false)` -> `renderer.flush(true)`. That closing flush emits the current view to the output. The view rendered for the message that triggered the exec is therefore written to the terminal immediately before the subprocess takes over.

Concretely, with a program whose `View()` returns `EXEC_MARKER`, the output captured around the exec hand-off is:

```
\x1b[?25l...\r\x1b[JEXEC_MARKER\x1b[>4m...\r\x1b[J\x1b[?25h\x1b[?2004l
```

The `EXEC_MARKER` content is written to stdout and (for multi-line views, where `close()` only erases from the last line down) persists after the subprocess exits.

## The fix

Blank the current view in `exec()` before releasing the terminal, so the closing flush has no content to write:

```go
func (p *Program) exec(c ExecCommand, fn ExecCallback) {
	if p.renderer != nil {
		p.renderer.clearView()
	}
	if err := p.releaseTerminal(false); err != nil {
		...
```

`clearView` is a new renderer method that clears `Content` and `Cursor` **while preserving terminal-mode flags such as `AltScreen`**.

### Why preserve `AltScreen`

`close()` and `start()` key alt-screen exit/re-enter off `lastView.AltScreen`:

- `close()` only writes the exit-alt-screen sequence when `lastView.AltScreen` is true.
- `start()` only re-enters the alt screen on resume when `lastView.AltScreen` is true.

A plain `render(View{})` flips `AltScreen` to false, so on resume `start()` skips re-entering the alt screen and it is only re-entered on the next render flush - a visible flicker, and the screen-mode bookkeeping diverges from the non-exec path. Preserving the flag keeps the alt-screen exit/re-enter symmetric with normal suspend/resume and avoids the flicker.

## Tests

- `TestExecProcessDoesNotLeakViewOutput` - inline program whose `View()` returns a marker until the subprocess finishes and a different marker afterwards; asserts the pre-exec marker never reaches stdout while the post-exec view still renders. Uses `WithFPS(1)` so the only flushes during the short test are the exec hand-off and shutdown, keeping the assertion deterministic.
- `TestExecProcessAltscreenNoLeak` - same in alt-screen mode; asserts no content leak and that alt-screen enter/leave sequences stay balanced (the terminal is left in a clean state).

Both tests fail on `main` and pass with this change. `go test ./...`, `go vet`, `gofumpt`, and `goimports` are clean.

## Notes

There is an older open PR (#1687) that addresses the same symptom by rendering an empty `View{}`. This change takes a different approach - clearing content via `clearView` while preserving `AltScreen` - to avoid the alt-screen resume flicker described above, and adds the regression tests that #1687 lacks. Happy to coordinate/close in favor of whichever the maintainers prefer.

## Checklist

- [x] Code is readable and follows existing conventions
- [x] `go test ./...` passes
- [x] `go vet`, `gofumpt`, `goimports` clean
- [x] Regression tests added (fail before, pass after)
