### PR TITLE
Provide the platform input/signal stubs on wasip1/wasip2

### DIFF
--- a/signals_other.go
+++ b/signals_other.go
@@ -1,0 +1,6 @@
+//go:build wasip1 || wasip2
+
+package tea
+
+// listenForResize on WASI: no SIGWINCH; report immediately done.
+func (p *Program) listenForResize(done chan struct{}) { close(done) }

--- a/tty_other.go
+++ b/tty_other.go
@@ -1,0 +1,12 @@
+//go:build wasip1 || wasip2
+
+package tea
+
+// initInput on WASI: there is no raw mode and no /dev/tty; the program
+// runs with non-TTY (pipe) input, which Bubble Tea supports natively.
+func (p *Program) initInput() (err error) { return nil }
+
+// suspendSupported: no SIGTSTP or process groups on WASI.
+const suspendSupported = false
+
+func suspendProcess() {}


### PR DESCRIPTION
Hi, and thanks for maintaining Bubble Tea!

Since Go 1.21 added `GOOS=wasip1` (WASI preview 1), building bubbletea (the v2 line) for the WASI platforms fails, because the per-platform files select nothing there:

```
tea.go:690:8: p.listenForResize undefined
tea.go:772:8: undefined: suspendSupported
tty.go:18:9: undefined: suspendProcess
tty.go:28:14: p.initInput undefined
```

`tty_unix.go` and `signals_unix.go` are gated to an explicit Unix GOOS list, and `tty_windows.go`/`signals_windows.go` to Windows. This breaks downstream users on wasip1 — for example `gh` (github.com/cli/cli), which imports bubbletea via its accessible prompter.

WASI preview 1/2 has no raw terminal mode, no process groups (so no SIGTSTP suspend), and no SIGWINCH. The natural behavior is the one Bubble Tea already supports for non-terminal input:

- `initInput` succeeds without opening a TTY, selecting the non-TTY (pipe) input path
- `suspendSupported = false` and a no-op `suspendProcess`
- `listenForResize` closes its done channel immediately (no resize events)

Verified:
- `GOOS=wasip1 GOARCH=wasm go build .` now succeeds
- native and Windows builds select the same files as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)