### PR TITLE
fix: don't panic in ProgressBarState.String for unknown values

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -319,13 +319,17 @@ const (
 
 // String return a human-readable value for the given [ProgressBarState].
 func (s ProgressBarState) String() string {
-	return [...]string{
+	names := [...]string{
 		"None",
 		"Default",
 		"Error",
 		"Indeterminate",
 		"Warning",
-	}[s]
+	}
+	if s < 0 || int(s) >= len(names) {
+		return "ProgressBarState(" + strconv.Itoa(int(s)) + ")"
+	}
+	return names[s]
 }
 
 // ProgressBar represents the terminal progress bar.

--- a/tea_test.go
+++ b/tea_test.go
@@ -669,3 +669,45 @@ func BenchmarkTeaRun(b *testing.B) {
 		_ = r.CloseWithError(io.EOF)
 	}
 }
+
+func TestProgressBarStateString(t *testing.T) {
+	for _, tc := range []struct {
+		state ProgressBarState
+		want  string
+	}{
+		{ProgressBarNone, "None"},
+		{ProgressBarDefault, "Default"},
+		{ProgressBarError, "Error"},
+		{ProgressBarIndeterminate, "Indeterminate"},
+		{ProgressBarWarning, "Warning"},
+	} {
+		if got := tc.state.String(); got != tc.want {
+			t.Errorf("ProgressBarState(%d).String() = %q, want %q", int(tc.state), got, tc.want)
+		}
+	}
+}
+
+// State is an exported field, so a ProgressBar can carry a value that was never
+// declared as a constant. String must describe it rather than panic.
+func TestProgressBarStateStringOutOfRange(t *testing.T) {
+	for _, tc := range []struct {
+		state ProgressBarState
+		want  string
+	}{
+		{ProgressBarState(-1), "ProgressBarState(-1)"},
+		{ProgressBarState(5), "ProgressBarState(5)"},
+		{ProgressBarState(7), "ProgressBarState(7)"},
+	} {
+		got := func() (s string) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("ProgressBarState(%d).String() panicked: %v", int(tc.state), r)
+				}
+			}()
+			return tc.state.String()
+		}()
+		if got != tc.want {
+			t.Errorf("ProgressBarState(%d).String() = %q, want %q", int(tc.state), got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1711

### Problem

`ProgressBarState.String()` indexes a fixed five-element array with the receiver:

```go
func (s ProgressBarState) String() string {
	return [...]string{
		"None", "Default", "Error", "Indeterminate", "Warning",
	}[s]
}
```

Any value outside `0..4` panics rather than returning a string:

```
runtime error: index out of range [7] with length 5
runtime error: index out of range [-1]
```

`ProgressBar.State` is an exported field, so a value that was never declared as a constant can reach it without going through `NewProgressBar`. A panicking `String` is particularly awkward because `fmt` calls it implicitly — logging or formatting a `ProgressBar` in an error path would take the program down at exactly the wrong moment.

### Fix

Bounds-check before indexing and fall back to the same format `stringer` emits for unknown values:

```go
if s < 0 || int(s) >= len(names) {
	return "ProgressBarState(" + strconv.Itoa(int(s)) + ")"
}
```

So `ProgressBarState(7).String()` returns `"ProgressBarState(7)"`. I followed the `stringer` convention because the repo doesn't currently have an established one for unknown enum values — happy to switch to `"Unknown"` or anything else you'd prefer. `strconv` was already imported.

Behaviour for the five declared constants is unchanged.

### Testing

Two tests: one pinning the existing names, one covering `-1`, `5` and `7` with a `recover` so a regression reports as a failure rather than taking the suite down.

Verified they're real regression tests — against the current code `TestProgressBarStateStringOutOfRange` fails:

```
--- FAIL: TestProgressBarStateStringOutOfRange (0.00s)
    tea_test.go:704: ProgressBarState(-1).String() panicked: runtime error: index out of range [-1]
```

and passes with the fix. `go test ./...`, `go vet ./...` and `gofmt` are all clean.
