### PR TITLE
fix: do not override a forced color profile with a capability report

### DIFF
--- a/options.go
+++ b/options.go
@@ -150,9 +150,13 @@ func WithFPS(fps int) ProgramOption {
 // Tea will try to detect the terminal's color profile from environment
 // variables and terminfo capabilities. Use [tea.WithEnvironment] to set custom
 // environment variables.
+//
+// A profile set with this option is not upgraded when the terminal reports
+// that it supports more colors.
 func WithColorProfile(profile colorprofile.Profile) ProgramOption {
 	return func(p *Program) {
 		p.profile = &profile
+		p.forcedProfile = true
 	}
 }
 

--- a/tea.go
+++ b/tea.go
@@ -505,6 +505,11 @@ type Program struct {
 
 	profile *colorprofile.Profile // the terminal color profile
 
+	// forcedProfile reports that the color profile came from
+	// [WithColorProfile] rather than from detection. A forced profile is not
+	// upgraded when the terminal reports that it supports more colors.
+	forcedProfile bool
+
 	// where to send output, this will usually be os.Stdout.
 	output    io.Writer
 	outputBuf bytes.Buffer // buffer used to queue commands to be sent to the output
@@ -776,7 +781,7 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 			case CapabilityMsg:
 				switch msg.Content {
 				case "RGB", "Tc":
-					if *p.profile != colorprofile.TrueColor {
+					if !p.forcedProfile && *p.profile != colorprofile.TrueColor {
 						tc := colorprofile.TrueColor
 						p.profile = &tc
 						go p.Send(ColorProfileMsg{*p.profile})

--- a/tea_test.go
+++ b/tea_test.go
@@ -11,6 +11,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/colorprofile"
 )
 
 type ctxImplodeMsg struct {
@@ -111,6 +113,40 @@ func TestTeaQuit(t *testing.T) {
 
 	if _, err := p.Run(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestTeaForcedColorProfile: a profile set with [WithColorProfile] must survive
+// a terminal capability report. Before the fix, a "RGB" or "Tc" report replaced
+// it with TrueColor, so the option did not force anything.
+func TestTeaForcedColorProfile(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	var in bytes.Buffer
+
+	m := &testModel{}
+	p := NewProgram(m,
+		WithInput(&in),
+		WithOutput(&buf),
+		WithColorProfile(colorprofile.NoTTY),
+	)
+	go func() {
+		for {
+			time.Sleep(time.Millisecond)
+			if m.executed.Load() != nil {
+				p.Send(CapabilityMsg{Content: "RGB"})
+				p.Quit()
+				return
+			}
+		}
+	}()
+
+	if _, err := p.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := *p.profile; got != colorprofile.NoTTY {
+		t.Errorf("forced color profile became %v, want %v", got, colorprofile.NoTTY)
 	}
 }
 


### PR DESCRIPTION
## What

`WithColorProfile` documents that it forces a color profile, but the event loop
replaces that profile when the terminal answers a capability request:

```go
case CapabilityMsg:
	switch msg.Content {
	case "RGB", "Tc":
		if *p.profile != colorprofile.TrueColor {
```

`Program` keeps no record of where the profile came from, so this code cannot
tell a caller's choice from a detected value. It overwrites both.

## Repro

```go
p := tea.NewProgram(model, tea.WithColorProfile(colorprofile.NoTTY))
// Init or Update returns tea.RequestCapability("RGB").
// On a terminal that answers, the profile becomes TrueColor and color returns.
```

The new test drives the same path with `p.Send(CapabilityMsg{Content: "RGB"})`.

## Fix

Record that the profile came from the option, then skip the upgrade. Detection
is unchanged, and a program that does not use the option behaves as before.

Found while mapping `NO_COLOR` to `NoTTY`. It also affects tests that pin a
profile, which the v2 upgrade guide recommends, and applications with their own
"color: off" setting.

## Note for the reviewer

`ColorProfileMsg` is not sent when the profile is forced, because the profile
does not change. Tell me if you prefer to send it anyway.
