### PR TITLE
fix: data race with Kill() and Run()

### DIFF
--- a/tea.go
+++ b/tea.go
@@ -509,6 +509,7 @@ type Program struct {
 	msgs         chan Msg
 	errs         chan error
 	finished     chan struct{}
+	runMu        sync.Mutex
 	shutdownOnce sync.Once
 
 	profile *colorprofile.Profile // the terminal color profile
@@ -605,6 +606,7 @@ func NewProgram(model Model, opts ...ProgramOption) *Program {
 		initialModel: model,
 		msgs:         make(chan Msg),
 		errs:         make(chan error, 1),
+		finished:     make(chan struct{}),
 		rendererDone: make(chan struct{}),
 	}
 
@@ -1001,6 +1003,18 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 		return nil, errors.New("bubbletea: InitialModel cannot be nil")
 	}
 
+	// Acquire runMu for the duration of initialization. Kill() will also
+	// acquire runMu before calling shutdown(), preventing data races between
+	// Run() writing to fields like p.handlers, p.renderer, and
+	// p.cancelReader and Kill() reading them.
+	p.runMu.Lock()
+	initialized := false
+	defer func() {
+		if !initialized {
+			p.runMu.Unlock()
+		}
+	}()
+
 	// Initialize context and teardown channel.
 	p.handlers = channelHandlers{}
 	cmds := make(chan Cmd)
@@ -1147,6 +1161,10 @@ func (p *Program) Run() (returnModel Model, returnErr error) {
 	// Process commands.
 	p.handlers.add(p.handleCommands(cmds))
 
+	// Initialization is complete. Release the lock so Kill() can proceed.
+	p.runMu.Unlock()
+	initialized = true
+
 	// Run event loop, handle updates and draw.
 	var err error
 	model, err = p.eventLoop(model, cmds)
@@ -1209,7 +1227,16 @@ func (p *Program) Quit() {
 // Kill stops the program immediately and restores the former terminal state.
 // The final render that you would normally see when quitting will be skipped.
 // [program.Run] returns a [ErrProgramKilled] error.
+//
+// If [Program.Run] is concurrently initializing, Kill will wait for it to
+// finish before performing shutdown. This prevents data races that could
+// occur when Kill reads fields that Run is still setting up.
 func (p *Program) Kill() {
+	// Wait for Run() to finish initializing before calling shutdown().
+	// This prevents data races between Run() writing to fields like
+	// p.handlers, p.renderer, and p.cancelReader and Kill() reading them.
+	p.runMu.Lock()
+	defer p.runMu.Unlock()
 	p.shutdown(true)
 }
 

--- a/tea_test.go
+++ b/tea_test.go
@@ -222,6 +222,31 @@ func TestTeaWaitKill(t *testing.T) {
 	}
 }
 
+func TestKillDuringStartupRace(t *testing.T) {
+	t.Parallel()
+	for range 100 {
+		p := NewProgram(&testModel{},
+			WithInput(bytes.NewBuffer(nil)),
+			WithOutput(io.Discard),
+			WithoutSignals(),
+		)
+
+		done := make(chan struct{})
+		go func() {
+			_, _ = p.Run()
+			close(done)
+		}()
+
+		p.Kill()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("program did not stop")
+		}
+	}
+}
+
 func TestTeaWithFilter(t *testing.T) {
 	for _, preventCount := range []uint32{0, 1, 2} {
 		t.Run(fmt.Sprintf("prevent_%d", preventCount), func(t *testing.T) {


### PR DESCRIPTION
## What?

Fixes a crash that happens when `Kill()` is called immediately after `Run()`, before the program has finished starting up.

## Why? 

Fixes #1689 