### PR TITLE
perf: render only when the view changes

### DIFF
--- a/renderer_scheduler_test.go
+++ b/renderer_scheduler_test.go
@@ -101,6 +101,10 @@ func TestRendererWakesForQueuedTerminalOutput(t *testing.T) {
 	t.Cleanup(func() { program.stopRenderer(true) })
 
 	program.execute("terminal query")
-	program.render(program.initialModel)
 	waitForSchedulerFlush(t, renderer)
+	program.mu.Lock()
+	defer program.mu.Unlock()
+	if program.outputBuf.Len() != 0 {
+		t.Fatalf("queued terminal output was not flushed: %q", program.outputBuf.String())
+	}
 }

--- a/renderer_scheduler_test.go
+++ b/renderer_scheduler_test.go
@@ -1,0 +1,106 @@
+package tea
+
+import (
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type schedulerTestModel struct {
+	content string
+}
+
+func (schedulerTestModel) Init() Cmd { return nil }
+
+func (m schedulerTestModel) Update(Msg) (Model, Cmd) { return m, nil }
+
+func (m schedulerTestModel) View() View { return NewView(m.content) }
+
+type schedulerTestRenderer struct {
+	nilRenderer
+	flushes atomic.Int64
+	flushed chan struct{}
+}
+
+func newSchedulerTestRenderer() *schedulerTestRenderer {
+	return &schedulerTestRenderer{flushed: make(chan struct{}, 16)}
+}
+
+func (r *schedulerTestRenderer) flush(bool) error {
+	r.flushes.Add(1)
+	select {
+	case r.flushed <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func waitForSchedulerFlush(t *testing.T, r *schedulerTestRenderer) {
+	t.Helper()
+	select {
+	case <-r.flushed:
+	case <-time.After(time.Second):
+		t.Fatal("renderer did not flush")
+	}
+}
+
+func TestRendererSleepsUntilViewChanges(t *testing.T) {
+	const fps = 120
+	frameInterval := time.Second / fps
+	renderer := newSchedulerTestRenderer()
+	program := NewProgram(schedulerTestModel{content: "initial"}, WithFPS(fps), WithOutput(io.Discard))
+	program.renderer = renderer
+	program.startRenderer()
+	t.Cleanup(func() { program.stopRenderer(true) })
+
+	program.render(program.initialModel)
+	waitForSchedulerFlush(t, renderer)
+	baseline := renderer.flushes.Load()
+
+	time.Sleep(5 * frameInterval)
+	if got := renderer.flushes.Load(); got != baseline {
+		t.Fatalf("idle renderer flushed %d additional times", got-baseline)
+	}
+
+	program.render(schedulerTestModel{content: "changed"})
+	waitForSchedulerFlush(t, renderer)
+	if got := renderer.flushes.Load(); got != baseline+1 {
+		t.Fatalf("view change produced %d flushes, want 1", got-baseline)
+	}
+}
+
+func TestRendererCoalescesBurstWithinFrameInterval(t *testing.T) {
+	const fps = 20
+	frameInterval := time.Second / fps
+	renderer := newSchedulerTestRenderer()
+	program := NewProgram(schedulerTestModel{content: "initial"}, WithFPS(fps), WithOutput(io.Discard))
+	program.renderer = renderer
+	program.startRenderer()
+	t.Cleanup(func() { program.stopRenderer(true) })
+
+	program.render(program.initialModel)
+	waitForSchedulerFlush(t, renderer)
+	baseline := renderer.flushes.Load()
+
+	for index := range 20 {
+		program.render(schedulerTestModel{content: string(rune('a' + index))})
+	}
+	waitForSchedulerFlush(t, renderer)
+	time.Sleep(2 * frameInterval)
+	if got := renderer.flushes.Load(); got != baseline+1 {
+		t.Fatalf("burst produced %d flushes, want 1", got-baseline)
+	}
+}
+
+func TestRendererWakesForQueuedTerminalOutput(t *testing.T) {
+	renderer := newSchedulerTestRenderer()
+	program := NewProgram(schedulerTestModel{content: "initial"}, WithFPS(60), WithOutput(io.Discard))
+	program.renderer = renderer
+	program.startRenderer()
+	t.Cleanup(func() { program.stopRenderer(true) })
+
+	program.execute("terminal query")
+	program.render(program.initialModel)
+	waitForSchedulerFlush(t, renderer)
+}

--- a/tea.go
+++ b/tea.go
@@ -1228,6 +1228,7 @@ func (p *Program) execute(seq string) {
 	p.mu.Lock()
 	_, _ = p.outputBuf.WriteString(seq)
 	p.mu.Unlock()
+	p.wakeRenderer()
 }
 
 func (p *Program) wakeRenderer() {

--- a/tea.go
+++ b/tea.go
@@ -539,8 +539,10 @@ type Program struct {
 	// modes keeps track of terminal modes that have been enabled or disabled.
 	ignoreSignals uint32
 
-	// ticker is the ticker that will be used to write to the renderer.
-	ticker *time.Ticker
+	// renderWake notifies the renderer that a view or terminal sequence is
+	// ready. The channel deliberately coalesces wakeups: one pending wake is
+	// enough to render the latest state.
+	renderWake chan struct{}
 
 	// once is used to stop the renderer.
 	once sync.Once
@@ -605,6 +607,7 @@ func NewProgram(model Model, opts ...ProgramOption) *Program {
 		initialModel: model,
 		msgs:         make(chan Msg),
 		errs:         make(chan error, 1),
+		renderWake:   make(chan struct{}, 1),
 		rendererDone: make(chan struct{}),
 	}
 
@@ -894,6 +897,7 @@ func (p *Program) eventLoop(model Model, cmds chan Cmd) (Model, error) {
 func (p *Program) render(model Model) {
 	if p.renderer != nil {
 		p.renderer.render(model.View()) // send view to renderer
+		p.wakeRenderer()
 	}
 }
 
@@ -1226,6 +1230,13 @@ func (p *Program) execute(seq string) {
 	p.mu.Unlock()
 }
 
+func (p *Program) wakeRenderer() {
+	select {
+	case p.renderWake <- struct{}{}:
+	default:
+	}
+}
+
 // flush flushes the output buffer to the program output.
 func (p *Program) flush() error {
 	p.mu.Lock()
@@ -1363,6 +1374,7 @@ func (p *Program) RestoreTerminal() error {
 	}
 
 	p.startRenderer()
+	p.wakeRenderer()
 
 	// If the output is a terminal, it may have been resized while another
 	// process was at the foreground, in which case we may not have received
@@ -1401,13 +1413,6 @@ func (p *Program) Printf(template string, args ...any) {
 // startRenderer starts the renderer.
 func (p *Program) startRenderer() {
 	framerate := time.Second / time.Duration(p.fps)
-	if p.ticker == nil {
-		p.ticker = time.NewTicker(framerate)
-	} else {
-		// If the ticker already exists, it has been stopped and we need to
-		// reset it.
-		p.ticker.Reset(framerate)
-	}
 
 	// Since the renderer can be restarted after a stop, we need to reset
 	// the done channel and its corresponding sync.Once.
@@ -1416,15 +1421,57 @@ func (p *Program) startRenderer() {
 	// Start the renderer.
 	p.renderer.start()
 	go func() {
+		var (
+			lastFlush time.Time
+			pending   bool
+			timer     *time.Timer
+			timerC    <-chan time.Time
+		)
+		stopTimer := func() {
+			if timer != nil && !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
+		flush := func() {
+			_ = p.flush()
+			_ = p.renderer.flush(false)
+			lastFlush = time.Now()
+			pending = false
+		}
+
 		for {
 			select {
 			case <-p.rendererDone:
-				p.ticker.Stop()
+				stopTimer()
 				return
 
-			case <-p.ticker.C:
-				_ = p.flush()
-				_ = p.renderer.flush(false)
+			case <-p.renderWake:
+				pending = true
+				if timerC != nil {
+					continue
+				}
+				if lastFlush.IsZero() {
+					timer = time.NewTimer(framerate)
+					timerC = timer.C
+					continue
+				}
+				delay := time.Until(lastFlush.Add(framerate))
+				if delay <= 0 {
+					flush()
+					continue
+				}
+				timer = time.NewTimer(delay)
+				timerC = timer.C
+
+			case <-timerC:
+				timer = nil
+				timerC = nil
+				if pending {
+					flush()
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
## What changed

- Wake the renderer when a new view is queued instead of polling it continuously.
- Coalesce bursts and retain `WithFPS` as the maximum active render rate.
- Wake the renderer after terminal restoration so resumed programs repaint normally.
- Add regression coverage for idle sleep, view-change wakeups, burst coalescing, and queued terminal output.

## Why

The current renderer starts a fixed-rate ticker for the full lifetime of every program. Even when the model schedules no commands and its view never changes, the process wakes and compares the frame at the configured FPS.

This keeps the same initial-frame ordering and active frame-rate ceiling, but lets the renderer block after the screen becomes unchanged. The next view change wakes it immediately; updates arriving inside one frame interval are rendered together.

## Reproduction and result

Measured with a static Bubble Tea v2.0.9 model whose `View` never changes and whose `Init` and `Update` schedule no commands. Both binaries ran in the same 80x24 real PTY, settled for 3 seconds, and were sampled for 10 seconds.

| Renderer | Idle CPU | Startup |
| --- | ---: | ---: |
| v2.0.9 fixed ticker | 0.790% | 50 ms |
| Demand-driven scheduler | 0.000% | 41 ms |

In an animation-enabled interactive run, both versions emitted 139 active output events. Mean active gaps were 15.75 ms before and 15.68 ms after, so the change did not reduce active rendering cadence.

## Validation

- `go test ./... -count=1`
- `go vet ./...`
- `go test -race ./... -count=1`
- Repeated focused scheduler and renderer race tests
- Real-PTY idle and active rendering checks
