### PR TITLE
add GOOS=js (wasm) build support

### DIFF
--- a/signals_js.go
+++ b/signals_js.go
@@ -1,0 +1,10 @@
+//go:build js
+// +build js
+
+package tea
+
+// listenForResize does nothing on js/wasm: there is no SIGWINCH. The host
+// environment can drive terminal size through WindowSizeMsg instead.
+func (p *Program) listenForResize(done chan struct{}) {
+	close(done)
+}

--- a/tty_js.go
+++ b/tty_js.go
@@ -1,0 +1,14 @@
+//go:build js
+// +build js
+
+package tea
+
+func (p *Program) initInput() (err error) {
+	// No termios to place in raw mode on js/wasm; whatever reader the caller
+	// supplied via WithInput is used as-is.
+	return nil
+}
+
+const suspendSupported = false
+
+func suspendProcess() {}


### PR DESCRIPTION
Provides the tty and signal platform layer for the js build tag so bubbletea compiles for browser (wasm) targets: `initInput` is a no-op (no termios to place in raw mode — the reader supplied via `WithInput` is used as-is), suspend is unsupported, and `listenForResize` completes immediately since there is no SIGWINCH — hosts drive terminal size through `WindowSizeMsg`.

With this, a `Program` runs in wasm over explicit I/O — for example wired to an xterm.js terminal in the page. All existing deps already build for js; the native test suite passes and native targets are unchanged. Motivation: embedding Go CLI apps (skycoin/skywire) that use bubbletea into a browser build.


Reopened from `0magnet/bubbletea` after consolidating a duplicate fork; supersedes #1789. Same commit, identical diff.
